### PR TITLE
Fixes for ASTNodeFactory and TupleExpression

### DIFF
--- a/src/ast/implementation/expression/tuple_expression.ts
+++ b/src/ast/implementation/expression/tuple_expression.ts
@@ -40,7 +40,7 @@ export class TupleExpression extends Expression {
      *
      * The `null` value is used to represent empty spots.
      */
-    get components(): Array<number | null> {
+    get components(): ReadonlyArray<number | null> {
         const result: Array<number | null> = [];
 
         for (const component of this.vOriginalComponents) {
@@ -53,7 +53,7 @@ export class TupleExpression extends Expression {
     /**
      * An array of non-`null` components
      */
-    get vComponents(): Expression[] {
+    get vComponents(): readonly Expression[] {
         const result: Expression[] = [];
 
         for (const component of this.vOriginalComponents) {


### PR DESCRIPTION
## Changes
- [x] Fixed cloning of `TupleExpression` was using wrong property value (`components` was used instead of `vOriginalComponents`).
- [x] Tweaked `vComponents` and `components` accessors to return `readonly` arrays in `TupleExpression`.
- [x] Tweaked `ASTNodeFactory.makeIdentifierFor()` to support `ImportDirective`s with non-empty `unitAlias`.

Regards.