### PR TITLE
Option to include source code to compiler artifact

### DIFF
--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -28,7 +28,16 @@ import {
 } from "..";
 
 const cli = {
-    boolean: ["version", "help", "solidity-versions", "stdin", "raw", "tree", "source"],
+    boolean: [
+        "version",
+        "help",
+        "solidity-versions",
+        "stdin",
+        "raw",
+        "with-sources",
+        "tree",
+        "source"
+    ],
     number: ["depth"],
     string: ["mode", "compiler-version", "path-remapping", "xpath"],
     default: {
@@ -79,6 +88,8 @@ OPTIONS:
                             Default value: auto
     --path-remapping        Path remapping input for Solc.
     --raw                   Print raw Solc compilation output.
+    --with-sources          When used with "raw", adds "source" property with 
+                            source files content to the compiler artifact.
     --tree                  Print short tree of parent-child relations in AST.
     --source                Print source code, assembled from Solc-generated AST.
     --xpath                 XPath selector to perform for each source unit.
@@ -174,6 +185,20 @@ OPTIONS:
     const { data, files } = result;
 
     if (args.raw) {
+        if (args["with-sources"] && files.size > 0) {
+            if (!data.sources) {
+                data.sources = {};
+            }
+
+            for (const [key, value] of files) {
+                if (!data.sources[key]) {
+                    data.sources[key] = {};
+                }
+
+                data.sources[key].source = value;
+            }
+        }
+
         const output = JSON.stringify(data, undefined, 4);
 
         console.log(output);

--- a/test/integration/sol-ast-compile/common.ts
+++ b/test/integration/sol-ast-compile/common.ts
@@ -25,6 +25,7 @@ export const options = [
     "compiler-version",
     "path-remapping",
     "raw",
+    "with-sources",
     "tree",
     "source",
     "xpath",

--- a/test/integration/sol-ast-compile/with-source.spec.ts
+++ b/test/integration/sol-ast-compile/with-source.spec.ts
@@ -1,0 +1,45 @@
+import expect from "expect";
+import fse from "fs-extra";
+import { SolAstCompileCommand, SolAstCompileExec } from "./common";
+
+const sample = "test/samples/solidity/meta/imports/A.sol";
+const args = [sample, "--raw", "--with-sources"];
+const command = SolAstCompileCommand(...args);
+
+describe(command, () => {
+    let exitCode: number | null;
+    let outData: string;
+    let errData: string;
+
+    before((done) => {
+        const result = SolAstCompileExec(...args);
+
+        outData = result.stdout;
+        errData = result.stderr;
+        exitCode = result.status;
+
+        done();
+    });
+
+    it("Exit code is valid", () => {
+        expect(exitCode).toEqual(0);
+    });
+
+    it("STDERR is empty", () => {
+        expect(errData).toEqual("");
+    });
+
+    it("STDOUT is correct", () => {
+        const data = JSON.parse(outData);
+
+        expect(data).toBeInstanceOf(Object);
+        expect(data.sources).toBeInstanceOf(Object);
+
+        const entries: Iterable<[string, any]> = Object.entries(data.sources);
+        const options = { encoding: "utf-8" };
+
+        for (const [key, entry] of entries) {
+            expect(entry.source).toEqual(fse.readFileSync(key, options));
+        }
+    });
+});


### PR DESCRIPTION
## Changes
- [x] Added CLI option `--with-sources` to include source files content to the compiler artifact.
- [x] Added an integration test for the feature.

## Notes
The option requires `--raw` to be specified. Usage:
```console
sol-ast-compile sample.sol --raw --with-sources
```

Regards.