### PR TITLE
Sanitize referenced declarations for builtin references

### DIFF
--- a/src/ast/postprocessing/builtin_referenced_declaration_normalizer.ts
+++ b/src/ast/postprocessing/builtin_referenced_declaration_normalizer.ts
@@ -1,0 +1,32 @@
+import { ASTNode } from "../ast_node";
+import { ASTContext, ASTNodePostprocessor } from "../ast_reader";
+import { Identifier } from "../implementation/expression/identifier";
+import { MemberAccess } from "../implementation/expression/member_access";
+import { IdentifierPath } from "../implementation/meta/identifier_path";
+import { UserDefinedTypeName } from "../implementation/type/user_defined_type_name";
+
+type SupportedNode = Identifier | MemberAccess | IdentifierPath | UserDefinedTypeName;
+
+export class BuiltinReferencedDeclarationNormalizer implements ASTNodePostprocessor {
+    process(node: ASTNode, context: ASTContext): void {
+        if (!this.isSupportedNode(node)) {
+            throw new Error(`Supplied node "${node.constructor.name}" is not supported`);
+        }
+
+        if (
+            node.referencedDeclaration >= 0 &&
+            context.locate(node.referencedDeclaration) === undefined
+        ) {
+            node.referencedDeclaration = -1;
+        }
+    }
+
+    private isSupportedNode(node: ASTNode): node is SupportedNode {
+        return (
+            node instanceof Identifier ||
+            node instanceof MemberAccess ||
+            node instanceof IdentifierPath ||
+            node instanceof UserDefinedTypeName
+        );
+    }
+}

--- a/src/ast/postprocessing/index.ts
+++ b/src/ast/postprocessing/index.ts
@@ -1,2 +1,3 @@
 export * from "./mapping";
+export * from "./builtin_referenced_declaration_normalizer";
 export * from "./structured_documentation_reconstruction";

--- a/src/ast/postprocessing/mapping.ts
+++ b/src/ast/postprocessing/mapping.ts
@@ -5,9 +5,15 @@ import { EventDefinition } from "../implementation/declaration/event_definition"
 import { FunctionDefinition } from "../implementation/declaration/function_definition";
 import { ModifierDefinition } from "../implementation/declaration/modifier_definition";
 import { VariableDeclaration } from "../implementation/declaration/variable_declaration";
+import { Identifier } from "../implementation/expression/identifier";
+import { MemberAccess } from "../implementation/expression/member_access";
+import { IdentifierPath } from "../implementation/meta/identifier_path";
+import { UserDefinedTypeName } from "../implementation/type/user_defined_type_name";
+import { BuiltinReferencedDeclarationNormalizer } from "./builtin_referenced_declaration_normalizer";
 import { StructuredDocumentationReconstructingPostprocessor } from "./structured_documentation_reconstruction";
 
 const reconstructor = new StructuredDocumentationReconstructingPostprocessor();
+const refNormalizer = new BuiltinReferencedDeclarationNormalizer();
 
 export const DefaultPostprocessorMapping = new Map<
     ASTNodeConstructor<ASTNode>,
@@ -17,5 +23,10 @@ export const DefaultPostprocessorMapping = new Map<
     [EventDefinition, [reconstructor]],
     [FunctionDefinition, [reconstructor]],
     [ModifierDefinition, [reconstructor]],
-    [VariableDeclaration, [reconstructor]]
+    [VariableDeclaration, [reconstructor]],
+
+    [Identifier, [refNormalizer]],
+    [MemberAccess, [refNormalizer]],
+    [IdentifierPath, [refNormalizer]],
+    [UserDefinedTypeName, [refNormalizer]]
 ]);


### PR DESCRIPTION
## Preface
The compiler sometimes provides invalid positive ids for some builtin references. For example in `abi.encode()` the identifier `abi` gets an id that +1 higher than the highest id in the current context.

This becomes a problem if we try to make a new node in the current AST context. Then all of a sudden the `abi` identifier stops being a builtin and now refers to something real.

One way to deal with this, is to do another pass after finalizing (or during finalizing), in which to set all invalid `referencedDeclaration`s to `-1`.

## Changes
- Introduced `BuiltinReferencedDeclarationNormalizer` to tweak `referencedDeclaration` property values, that refer to an inexisting ids. They would have `-1` as a value.
- Added it to postprocessor pass for `Identifier`, `MemberAccess`, `IdentifierPath` and `UserDefinedTypeName` nodes.

## Concerns
This is a bit destructive, though… If compiler will ever do some changes, we would have to adjust logic to only do such cleanup for certain compiler versions. But that concern is not yet have any real use case. 

Regards.