### PR TITLE
Bug in the writing out of import directives

### DIFF
--- a/src/ast/writing/ast_mapping.ts
+++ b/src/ast/writing/ast_mapping.ts
@@ -1131,21 +1131,32 @@ class ContractDefinitionWriter extends DocumentedNodeWriter<ContractDefinition> 
 }
 
 class ImportDirectiveWriter extends ASTNodeWriter {
-    writeInner(node: ImportDirective): SrcDesc {
+    writeInner(node: ImportDirective, writer: ASTWriter): SrcDesc {
         if (node.unitAlias) {
             return [`import "${node.file}" as ${node.unitAlias};`];
         }
 
         if (node.vSymbolAliases.length) {
-            const entries: string[] = [];
+            const entries: SrcDesc[] = [];
 
-            for (const [origin, alias] of node.vSymbolAliases) {
-                const symbol = origin instanceof ImportDirective ? origin.unitAlias : origin.name;
+            for (let i = 0; i < node.vSymbolAliases.length; i++) {
+                const rawSymAlias = node.symbolAliases[i];
+                const [origin, alias] = node.vSymbolAliases[i];
 
-                entries.push(alias !== undefined ? symbol + " as " + alias : symbol);
+                if (rawSymAlias.foreign instanceof Identifier) {
+                    const desc = writer.desc(rawSymAlias.foreign);
+                    if (alias) {
+                        desc.push(` as ${alias}`);
+                    }
+                    entries.push(desc);
+                } else {
+                    const symbol =
+                        origin instanceof ImportDirective ? origin.unitAlias : origin.name;
+                    entries.push([alias !== undefined ? symbol + " as " + alias : symbol]);
+                }
             }
 
-            return [`import { ${entries.join(", ")} } from "${node.file}";`];
+            return [`import { `, ...flatJoin(entries, ", "), `} from "${node.file}";`];
         }
 
         return [`import "${node.file}";`];

--- a/src/ast/writing/ast_mapping.ts
+++ b/src/ast/writing/ast_mapping.ts
@@ -1156,7 +1156,7 @@ class ImportDirectiveWriter extends ASTNodeWriter {
                 }
             }
 
-            return [`import { `, ...flatJoin(entries, ", "), `} from "${node.file}";`];
+            return [`import { `, ...flatJoin(entries, ", "), ` } from "${node.file}";`];
         }
 
         return [`import "${node.file}";`];

--- a/test/samples/solidity/meta/complex_imports/c.sourced.sol
+++ b/test/samples/solidity/meta/complex_imports/c.sourced.sol
@@ -17,13 +17,13 @@ contract SomeContract {}
 // /test/samples/solidity/meta/complex_imports/b.sol
 // ------------------------------------------------------------
 import "./a.sol" as Util;
-import { SOME_CONST, SomeStruct, SomeEnum, someFn, SomeContract} from "./a.sol";
-import { SOME_CONST as OTHER_CONST, SomeStruct as OtherStruct, SomeEnum as OtherEnum, someFn as otherFn, SomeContract as OtherContract} from "./a.sol";
+import { SOME_CONST, SomeStruct, SomeEnum, someFn, SomeContract } from "./a.sol";
+import { SOME_CONST as OTHER_CONST, SomeStruct as OtherStruct, SomeEnum as OtherEnum, someFn as otherFn, SomeContract as OtherContract } from "./a.sol";
 // ------------------------------------------------------------
 // /test/samples/solidity/meta/complex_imports/c.sol
 // ------------------------------------------------------------
 pragma solidity ^0.7.4;
 
-import { Util as OtherUtil} from "./b.sol";
-import { OTHER_CONST, OtherStruct, OtherEnum, otherFn, OtherContract} from "./b.sol";
-import { OTHER_CONST as ANOTHER_CONST, OtherStruct as AnotherStruct, OtherEnum as AnotherEnum, otherFn as anotherFn, OtherContract as AnotherContract} from "./b.sol";
+import { Util as OtherUtil } from "./b.sol";
+import { OTHER_CONST, OtherStruct, OtherEnum, otherFn, OtherContract } from "./b.sol";
+import { OTHER_CONST as ANOTHER_CONST, OtherStruct as AnotherStruct, OtherEnum as AnotherEnum, otherFn as anotherFn, OtherContract as AnotherContract } from "./b.sol";

--- a/test/samples/solidity/meta/complex_imports/c.sourced.sol
+++ b/test/samples/solidity/meta/complex_imports/c.sourced.sol
@@ -17,13 +17,13 @@ contract SomeContract {}
 // /test/samples/solidity/meta/complex_imports/b.sol
 // ------------------------------------------------------------
 import "./a.sol" as Util;
-import { SOME_CONST, SomeStruct, SomeEnum, someFn, SomeContract } from "./a.sol";
-import { SOME_CONST as OTHER_CONST, SomeStruct as OtherStruct, SomeEnum as OtherEnum, someFn as otherFn, SomeContract as OtherContract } from "./a.sol";
+import { SOME_CONST, SomeStruct, SomeEnum, someFn, SomeContract} from "./a.sol";
+import { SOME_CONST as OTHER_CONST, SomeStruct as OtherStruct, SomeEnum as OtherEnum, someFn as otherFn, SomeContract as OtherContract} from "./a.sol";
 // ------------------------------------------------------------
 // /test/samples/solidity/meta/complex_imports/c.sol
 // ------------------------------------------------------------
 pragma solidity ^0.7.4;
 
-import { Util as OtherUtil } from "./b.sol";
-import { SOME_CONST, SomeStruct, SomeEnum, someFn, SomeContract } from "./b.sol";
-import { SOME_CONST as ANOTHER_CONST, SomeStruct as AnotherStruct, SomeEnum as AnotherEnum, someFn as anotherFn, SomeContract as AnotherContract } from "./b.sol";
+import { Util as OtherUtil} from "./b.sol";
+import { OTHER_CONST, OtherStruct, OtherEnum, otherFn, OtherContract} from "./b.sol";
+import { OTHER_CONST as ANOTHER_CONST, OtherStruct as AnotherStruct, OtherEnum as AnotherEnum, otherFn as anotherFn, OtherContract as AnotherContract} from "./b.sol";


### PR DESCRIPTION
Small bugs in writing out import directives:

   - when writing out `x as y` directives, we were incorrectly writing
     out the original definition instead of the name given
   - when the `foreign` field was an Identifier, we were forgetting to
     add it to the source map