### PR TITLE
[WIP] Support for generating TypeName of an arbitrary ASTNode

### DIFF
--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -1,0 +1,342 @@
+import { gte, lt } from "semver";
+import { ASTNode } from "./ast_node";
+import { StateVariableVisibility } from "./constants";
+import { EnumDefinition, StructDefinition } from "./implementation/declaration";
+import { ContractDefinition } from "./implementation/declaration/contract_definition";
+import { EventDefinition } from "./implementation/declaration/event_definition";
+import { FunctionDefinition } from "./implementation/declaration/function_definition";
+import { ModifierDefinition } from "./implementation/declaration/modifier_definition";
+import { VariableDeclaration } from "./implementation/declaration/variable_declaration";
+import { ImportDirective, SourceUnit } from "./implementation/meta";
+import {
+    Block,
+    ForStatement,
+    TryCatchClause,
+    UncheckedBlock,
+    VariableDeclarationStatement
+} from "./implementation/statement";
+
+/**
+ * Type describing the possible ASTNodes to which a given Identifier/IdentifierPath may resolve to.
+ */
+export type AnyResolvable =
+    | VariableDeclaration
+    | FunctionDefinition
+    | ModifierDefinition
+    | EventDefinition
+    | StructDefinition
+    | EnumDefinition
+    | ContractDefinition
+    | SourceUnit;
+
+/**
+ * Type describing all the ASTNodes that are scopes that can define new names
+ */
+export type ScopeNode =
+    | SourceUnit
+    | ContractDefinition
+    | FunctionDefinition
+    | ModifierDefinition
+    | VariableDeclarationStatement
+    | Block
+    | TryCatchClause
+    | UncheckedBlock;
+
+function pp(n: ASTNode | undefined): string {
+    return n !== undefined ? `${n.constructor.name}#${n.id}` : "undefined";
+}
+
+/**
+ * Given an ASTNode `node` and a compiler version `version` determine if `node` is a
+ * scope node. Note that `Block` and `UncheckedBlock` are only scopes in 0.4.x
+ */
+function isScope(node: ASTNode, version: string): node is ScopeNode {
+    if (lt(version, "0.5.0") && (node instanceof Block || node instanceof UncheckedBlock)) {
+        return true;
+    }
+
+    return (
+        node instanceof SourceUnit ||
+        node instanceof ContractDefinition ||
+        node instanceof FunctionDefinition ||
+        node instanceof ModifierDefinition ||
+        node instanceof VariableDeclarationStatement ||
+        node instanceof TryCatchClause
+    );
+}
+
+/**
+ * Given any `ASTNode` `node` and a compiler verison `version` return the `ScopeNode` containing `node`, or undefined
+ * if `node` is a top-level scope. (i.e. a `SourceUnit`)
+ */
+function getContainingScope(node: ASTNode, version: string): ScopeNode | undefined {
+    if (node instanceof SourceUnit) {
+        return undefined;
+    }
+
+    let pt = node.parent;
+
+    while (
+        pt !== undefined &&
+        !(
+            pt instanceof SourceUnit ||
+            pt instanceof ContractDefinition ||
+            pt instanceof FunctionDefinition ||
+            pt instanceof ModifierDefinition ||
+            pt instanceof Block ||
+            pt instanceof UncheckedBlock ||
+            pt instanceof ForStatement ||
+            pt instanceof TryCatchClause
+        )
+    ) {
+        node = pt;
+        pt = pt.parent;
+    }
+
+    if (pt === undefined) {
+        return undefined;
+    }
+
+    if (pt instanceof ForStatement) {
+        if (
+            node !== pt.vInitializationExpression &&
+            pt.vInitializationExpression instanceof VariableDeclarationStatement
+        ) {
+            return pt.vInitializationExpression;
+        }
+
+        return getContainingScope(pt, version);
+    }
+
+    if (pt instanceof Block || pt instanceof UncheckedBlock) {
+        if (gte(version, "0.5.0")) {
+            const ptChildren = pt.children;
+            for (let i = ptChildren.indexOf(node) - 1; i >= 0; i--) {
+                const sibling = ptChildren[i];
+                if (sibling instanceof VariableDeclarationStatement) {
+                    return sibling;
+                }
+            }
+
+            // Note that in >=0.5.0 Block/UncheckedBlock IS NOT a scope. VariableDeclarationStatement IS.
+            return getContainingScope(pt, version);
+        }
+    }
+
+    return pt;
+}
+
+/**
+ * Lookup the definition corresponding to `name` in the `ScopeNode` `node`. If no match is found return an empty set.
+ * Otherwise return the set of all definitions matching by name in this scope. This function may return multuple results only in the following cases:
+ * 1. Multiple FunctionDefinitions (and potentially VariableDeclarations corresponding to public state variables) with the same name and DIFFERENT SIGNATURES
+ * 2. Multiple EventDefinitions with the same name and different signatures.
+ */
+function lookupInScope(name: string, scope: ScopeNode): Set<AnyResolvable> {
+    const res: Set<AnyResolvable> = new Set();
+
+    if (scope instanceof SourceUnit) {
+        // Note order of checking SourceUnit children doesn't matter
+        // since any conflict would result in a compilation error.
+        for (const child of scope.children) {
+            if (
+                (child instanceof VariableDeclaration ||
+                    child instanceof FunctionDefinition ||
+                    child instanceof ContractDefinition ||
+                    child instanceof StructDefinition ||
+                    child instanceof EnumDefinition) &&
+                child.name === name
+            ) {
+                res.add(child);
+            }
+
+            if (child instanceof ImportDirective) {
+                if (child.unitAlias === name) {
+                    // `import "..." as <name>`
+                    res.add(child.vSourceUnit);
+                } else if (child.vSymbolAliases.length === 0) {
+                    // import "..."
+                    // @todo maybe its better to go through child.vSourceUnit.vExportedSymbols here?
+                    for (const def of lookupInScope(name, child.vSourceUnit)) {
+                        res.add(def);
+                    }
+                } else {
+                    // `import {<name>} from "..."` or `import {a as <name>} from "..."`
+                    for (const [foreignDef, alias] of child.vSymbolAliases) {
+                        let symImportName: string;
+                        const originalDef =
+                            foreignDef instanceof ImportDirective
+                                ? foreignDef.vSourceUnit
+                                : foreignDef;
+
+                        if (alias !== undefined) {
+                            symImportName = alias;
+                        } else {
+                            if (foreignDef instanceof ImportDirective) {
+                                symImportName = foreignDef.unitAlias;
+                                if (symImportName === "") {
+                                    throw new Error(
+                                        `Unexpected ImportDirective foreign def with non-unit alias ${pp(
+                                            foreignDef
+                                        )}`
+                                    );
+                                }
+                            } else {
+                                symImportName = foreignDef.name;
+                            }
+                        }
+
+                        if (alias === name) {
+                            res.add(originalDef);
+                        }
+                    }
+                }
+            }
+        }
+    } else if (scope instanceof ContractDefinition) {
+        const overridenSigHashes = new Set<string>();
+        for (const base of scope.vLinearizedBaseContracts) {
+            for (const child of base.children) {
+                if (
+                    (child instanceof VariableDeclaration ||
+                        child instanceof FunctionDefinition ||
+                        child instanceof ModifierDefinition ||
+                        child instanceof EventDefinition ||
+                        child instanceof StructDefinition ||
+                        child instanceof EnumDefinition) &&
+                    child.name === name
+                ) {
+                    let sigHash: string | undefined;
+                    if (child instanceof FunctionDefinition) {
+                        sigHash = child.canonicalSignatureHash;
+                    } else if (
+                        child instanceof VariableDeclaration &&
+                        child.visibility === StateVariableVisibility.Public
+                    ) {
+                        sigHash = child.getterCanonicalSignatureHash;
+                    }
+
+                    if (sigHash !== undefined) {
+                        if (overridenSigHashes.has(sigHash)) {
+                            continue;
+                        }
+
+                        overridenSigHashes.add(sigHash);
+                    }
+
+                    res.add(child);
+                }
+            }
+        }
+    } else if (scope instanceof FunctionDefinition) {
+        for (const paramList of [scope.vParameters, scope.vReturnParameters]) {
+            for (const parameter of paramList.vParameters) {
+                if (parameter.name === name) {
+                    res.add(parameter);
+                }
+            }
+        }
+    } else if (scope instanceof ModifierDefinition) {
+        for (const parameter of scope.vParameters.vParameters) {
+            if (parameter.name === name) {
+                res.add(parameter);
+            }
+        }
+    } else if (scope instanceof VariableDeclarationStatement) {
+        for (const decl of scope.vDeclarations) {
+            if (decl.name === name) {
+                res.add(decl);
+            }
+        }
+    } else if (scope instanceof Block || scope instanceof UncheckedBlock) {
+        for (const node of scope.children) {
+            if (!(node instanceof VariableDeclarationStatement)) {
+                continue;
+            }
+
+            for (const decl of node.vDeclarations) {
+                if (decl.name === name) {
+                    res.add(decl);
+                }
+            }
+        }
+    } else if (scope instanceof TryCatchClause) {
+        if (scope.vParameters) {
+            for (const decl of scope.vParameters.vParameters) {
+                if (decl.name === name) {
+                    res.add(decl);
+                }
+            }
+        }
+    } else {
+        throw new Error(`Unknown scope node ${pp(scope)}`);
+    }
+
+    return res;
+}
+
+/**
+ * Resolve the name `name` in the scope containing `ctx`, assuming compiler
+ * version `version`. If `inclusive` is true, then if `ctx` itself is a scope,
+ * lookup inside of it as well. (e.g. if ctx is the `ContractDefinition`
+ * corresponding to `contract { uint x; }`, calling `resolveAny("x", node,
+ * "0.5.0", true)` would return the state var X, and `resolveAny("x", node,
+ * "0.5.0", false)` would return undefined.).
+ *
+ * We return a set, since in the case where `name` resolves to a callable
+ * (function/public state var) or event, there could be multiple
+ * functions/events with the same name but different arguments. In all other
+ * cases the returned set should have either 0 or 1 elements.
+ */
+export function resolveAny(
+    name: string,
+    ctx: ASTNode,
+    version: string,
+    inclusive = false
+): Set<AnyResolvable> {
+    let scope: ScopeNode | undefined;
+
+    if (inclusive && isScope(ctx, version)) {
+        scope = ctx;
+    } else {
+        scope = getContainingScope(ctx, version);
+    }
+
+    while (scope !== undefined) {
+        const inScopeRes = lookupInScope(name, scope);
+        if (inScopeRes.size > 0) {
+            // Sanity check for the case where multiple values are returned.
+            // @todo re-write - this check is ugly
+            if (inScopeRes.size > 1) {
+                let isEvents: boolean | undefined;
+                for (const def of inScopeRes) {
+                    if (isEvents === undefined) {
+                        isEvents = def instanceof EventDefinition;
+                    }
+
+                    if (isEvents) {
+                        if (!(def instanceof EventDefinition)) {
+                            throw new Error(`Expected all overriden event definitions`);
+                        }
+                    } else {
+                        if (
+                            !(
+                                (def instanceof VariableDeclaration &&
+                                    def.stateVariable &&
+                                    def.visibility === StateVariableVisibility.Public) ||
+                                def instanceof FunctionDefinition
+                            )
+                        ) {
+                            throw new Error(`Expected all function/public vars`);
+                        }
+                    }
+                }
+            }
+            return inScopeRes;
+        }
+
+        scope = getContainingScope(scope, version);
+    }
+
+    return new Set();
+}

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -11,6 +11,7 @@ export * from "./constants";
 export * from "./postprocessing";
 export * from "./writing";
 export * from "./dispatch";
+export * from "./definitions";
 export * from "./utils";
 export * from "./xpath";
 export * from "./sanity";

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,1 +1,2 @@
 export * from "./location";
+export * from "./utils";

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -1,4 +1,4 @@
-export function forAll<T>(arr: T[] | Set<T>, cb: (arg0: T) => boolean): boolean {
+export function forAll<T>(arr: Iterable<T> | Set<T>, cb: (arg0: T) => boolean): boolean {
     for (const el of arr) {
         if (!cb(el)) {
             return false;

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -1,0 +1,9 @@
+export function forAll<T>(arr: T[] | Set<T>, cb: (arg0: T) => boolean): boolean {
+    for (const el of arr) {
+        if (!cb(el)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/test/samples/solidity/resolving/block_04.sol
+++ b/test/samples/solidity/resolving/block_04.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.0;
+contract Foo {
+    struct foo {
+        uint x;
+    }
+    
+    function main() internal {
+        foo memory m = foo(bar);
+        
+        uint bar = m.x;
+    }
+}

--- a/test/samples/solidity/resolving/block_05.sol
+++ b/test/samples/solidity/resolving/block_05.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+contract Foo {
+    struct foo {
+        uint x;
+    }
+    
+    function main() internal {
+        foo memory m;
+        
+        uint foo = m.x;
+        
+        m.x = 1;
+        
+        foo = 2;
+    }
+}

--- a/test/samples/solidity/resolving/boo.sol
+++ b/test/samples/solidity/resolving/boo.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.0;
+
+struct foo {
+    uint x;
+}

--- a/test/samples/solidity/resolving/foo.sol
+++ b/test/samples/solidity/resolving/foo.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.8.0;
+
+import "./boo.sol";
+import {foo as roo} from "./boo.sol";
+
+function moo(uint a) returns (uint) {
+    
+}

--- a/test/samples/solidity/resolving/id_paths.sol
+++ b/test/samples/solidity/resolving/id_paths.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.8.0;
+
+import "./id_paths_lib.sol" as L;
+import {Lib as Lib1} from "./id_paths_lib.sol";
+
+contract Base {
+    uint y = 2;
+    function foo(uint x) internal virtual returns (uint) {
+        return x + 1;
+    }
+    
+    struct S {
+        uint t;
+    }
+    
+    enum E {
+        A
+    }
+    
+    event E1();
+}
+
+contract Child is Base {
+    uint z = 1;
+    function foo(uint x) internal virtual override returns (uint) {
+        return Base.foo(x) + 1;
+    }
+    
+    
+    function main() public {
+        assert(foo(Child.z + Child.z) == 5);
+        emit Base.E1();
+    }
+}
+
+contract Unrelated {
+    function main() public {
+        Base.S memory s;
+        Base.E e;
+        
+        uint t = L.const;
+        
+        L.foo(t);
+        
+        L.SG memory s1;
+        L.EG e1;
+        
+        t = L.Lib.foo(t);
+
+        t = Lib1.foo(t);
+
+        L.Boo t1;
+    }
+}

--- a/test/samples/solidity/resolving/id_paths_lib.sol
+++ b/test/samples/solidity/resolving/id_paths_lib.sol
@@ -1,0 +1,21 @@
+import "./id_paths_lib2.sol";
+
+function foo(uint x) returns (uint) {
+    return x+1;
+}
+
+struct SG {
+    int8 a;
+}
+
+enum EG {
+    B
+}
+
+uint constant const = 1;
+
+library Lib {
+    function foo(uint t) internal returns (uint) {
+        return t + 2;
+    }
+}

--- a/test/samples/solidity/resolving/id_paths_lib2.sol
+++ b/test/samples/solidity/resolving/id_paths_lib2.sol
@@ -1,0 +1,3 @@
+contract Boo {
+	uint x;
+}

--- a/test/samples/solidity/resolving/imports_and_source_unit_function_overloading.sol
+++ b/test/samples/solidity/resolving/imports_and_source_unit_function_overloading.sol
@@ -1,0 +1,22 @@
+import "./foo.sol";
+import "./foo.sol" as boo;
+import {moo as goo} from "./foo.sol";
+
+function moo(address a) {
+    uint t = moo(1);
+}
+
+function goo() {
+    
+}
+
+function main() {
+    moo(1);
+    moo(address(0x0));
+    goo();
+    goo(1);
+
+    roo memory t;
+    foo memory t1;
+}
+

--- a/test/samples/solidity/resolving/inheritance_and_shadowing.sol
+++ b/test/samples/solidity/resolving/inheritance_and_shadowing.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.0;
+
+contract Base {
+    struct foo {
+        uint X;
+    }
+    //function foo() internal {}
+}
+
+uint constant foo = 1;
+
+contract Child is Base {
+    function main() public {
+        //uint x = foo;
+    }
+}

--- a/test/samples/solidity/resolving/resolving_08.sol
+++ b/test/samples/solidity/resolving/resolving_08.sol
@@ -1,0 +1,66 @@
+pragma solidity ^0.8.0;
+
+uint constant x1 = 1;
+
+contract Foo {
+    uint x1 = x1 + 1;
+    uint x2;
+    uint x3;
+    uint x4;
+    uint x5;
+    
+    uint tmp = x1+x2+x3+x4+x5;
+    
+    function foo(uint x1, uint x2) public moo(x1) returns (uint x5) {
+        uint x2 = x2+1;
+        uint t = x5;
+        for(uint x2 = x2; x2 < x3; x2++) {
+            uint x3 = 1+x3;
+        }
+        
+        if (x1<2) 
+            if (x2>2)
+                if (x3>3)
+                    x4 = 3;
+                else
+                    {
+                        uint x4 = x4;
+                    }
+                    
+        try this.foo(1,2) returns (uint x5) {
+            return x5;
+        } catch Error(string memory reason) {
+            revert(reason);
+        } catch Panic(uint code) {
+            if (code == 0x01) {
+                revert("Assertion failed");
+            } else if (code == 0x11) {
+                revert("Underflow/overflow");
+            }
+        } catch {
+            revert("Internal error");
+        }
+        
+        for (x2 = 0; x2<1; x2++) {
+            x5 = x2;
+        }
+    }
+    
+    function varDecls() public  {
+        (uint x1, uint x2) = (1, 2);
+        
+        {
+            uint x1 = x1 + 2;
+            if (x1 < 0){
+                uint x1  =x1 + 3;
+            } else {
+                uint x1 = x1 + 4;
+            }
+        }
+    }
+    
+    modifier moo(uint x1) {
+        x2 += x1;
+        _;
+    }
+}

--- a/test/samples/solidity/resolving/shadowing_overloading_and_overriding.sol
+++ b/test/samples/solidity/resolving/shadowing_overloading_and_overriding.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.8.0;
+function foo(uint x, uint y, uint z) {
+}
+
+
+function bar(uint x, uint y, uint z) {
+}
+
+function boo(uint x) {
+    
+}
+
+struct v {
+    uint x;
+    uint y;
+}
+
+abstract contract Base {
+    function foo() public virtual {}
+    function foo(uint x) public virtual {}
+    function v() external virtual  returns (uint) ;
+    function v(uint x) external virtual  returns (uint) {
+        return x;
+    }
+    modifier M() { _; }
+    
+    event E();
+    event E(uint x);
+}
+
+contract Child is Base {
+    uint public override v;
+    //event E(); can't override events
+    function foo() public override {}
+    function boo(uint t) public {}
+    
+    function main() M public {
+        foo();
+        foo(1);
+        //foo(1,2,3); // - higher-scope foo is not resolved
+        bar(1,2,3);
+        
+        emit E();
+        emit E(1);
+        
+        // boo() is not visible
+        boo(1);
+    }
+}
+

--- a/test/samples/solidity/resolving/simple_shadowing.sol
+++ b/test/samples/solidity/resolving/simple_shadowing.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.8.0;
+uint constant foo = 1;
+
+struct gfoo {
+    uint x;
+}
+
+enum gbar {
+    A
+}
+
+function gf1() { }
+
+contract Foo {
+    struct foo {
+        uint x;
+    }
+    
+    enum bar {
+        A
+    }
+    
+    event boo();
+    
+    function f1(uint x) internal {}
+    
+    uint gfoo;
+    uint gbar;
+    uint gf1;
+    function main(uint foo, uint bar, uint boo, uint f1) public {
+        
+        // Arguments shadowing defintions from the contract level
+        
+        //foo memory m; - can't access struct of same name
+        
+        //bar b; - can't access enum of same name
+        
+        //emit boo(); - can't access event of same name
+        
+        //f1(); - can't access function of same name
+        
+        // State vars shadowing definitions from the unit level
+        
+        //gfoo memory m; - can't access struct from global context shadowed by state var
+        
+        // gbar e; can't access enum from global context shadowed by state var
+        
+        // gf1(); - can't access free function from global context shadowed by state var
+    }
+}

--- a/test/unit/misc/definitions.spec.ts
+++ b/test/unit/misc/definitions.spec.ts
@@ -1,0 +1,350 @@
+import expect from "expect";
+import {
+    ASTKind,
+    ASTNode,
+    ASTReader,
+    CompilerVersions04,
+    CompilerVersions05,
+    CompilerVersions06,
+    CompilerVersions07,
+    CompilerVersions08,
+    compileSol,
+    detectCompileErrors,
+    ExternalReferenceType,
+    FunctionCall,
+    Identifier,
+    ImportDirective,
+    resolveAny,
+    UserDefinedTypeName
+} from "../../../src";
+
+const samples: Array<[string, string, ASTKind]> = [
+    [
+        "./test/samples/solidity/compile_04.sol",
+        CompilerVersions04[CompilerVersions04.length - 1],
+        ASTKind.Legacy
+    ],
+    [
+        "./test/samples/solidity/compile_05.sol",
+        CompilerVersions05[CompilerVersions05.length - 1],
+        ASTKind.Modern
+    ],
+    [
+        "./test/samples/solidity/latest_06.sol",
+        CompilerVersions06[CompilerVersions06.length - 1],
+        ASTKind.Modern
+    ],
+    [
+        "./test/samples/solidity/latest_07.sol",
+        CompilerVersions07[CompilerVersions07.length - 1],
+        ASTKind.Modern
+    ],
+    [
+        "./test/samples/solidity/latest_08.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern
+    ],
+    [
+        "./test/samples/solidity/resolving_08.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern
+    ],
+    [
+        "./test/samples/solidity/resolving/resolving_08.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern
+    ]
+];
+
+describe("resolveAny() correctly resolves all Identifiers/UserDefinedTypeNames/FunctionCalls", () => {
+    for (const [sample, compilerVersion, kind] of samples) {
+        it(`All definitions in ${sample} resolve correctly`, () => {
+            const result = compileSol(sample, "auto", []);
+
+            expect(result.compilerVersion).toEqual(compilerVersion);
+            const errors = detectCompileErrors(result.data);
+
+            expect(errors).toHaveLength(0);
+
+            const data = result.data;
+
+            const reader = new ASTReader();
+            const sourceUnits = reader.read(data, kind);
+
+            for (const unit of sourceUnits) {
+                for (const node of unit.getChildrenBySelector(
+                    (child) =>
+                        child instanceof Identifier ||
+                        child instanceof UserDefinedTypeName ||
+                        child instanceof FunctionCall
+                )) {
+                    const namedNode = node as Identifier | UserDefinedTypeName | FunctionCall;
+                    const def = namedNode.vReferencedDeclaration;
+                    let name: string;
+                    let ctx: ASTNode;
+
+                    if (namedNode instanceof FunctionCall) {
+                        if (
+                            namedNode.vFunctionCallType !== ExternalReferenceType.UserDefined ||
+                            namedNode.vFunctionName === ""
+                        ) {
+                            continue;
+                        }
+
+                        name = namedNode.vFunctionName;
+                        ctx = namedNode.vReferencedDeclaration as ASTNode;
+                    } else {
+                        if (namedNode.name === undefined) {
+                            continue;
+                        }
+
+                        name = namedNode.name;
+                        ctx = namedNode;
+                    }
+
+                    if (def === undefined || name === undefined) {
+                        continue;
+                    }
+
+                    let expectedID: number;
+                    // When the reference is an ImportDirective we resolve to the referenced SourceUnit
+                    if (def instanceof ImportDirective) {
+                        expect(def.unitAlias).not.toEqual("");
+                        expectedID = def.vSourceUnit.id;
+                    } else {
+                        expectedID = def.id;
+                    }
+
+                    const resolved = [...resolveAny(name, ctx, compilerVersion)];
+                    expect(resolved.length).toEqual(1);
+                    expect((resolved[0] as ASTNode).id).toEqual(expectedID);
+                }
+            }
+        });
+    }
+});
+
+const unitSamples: Array<
+    [string, string, ASTKind, Array<[number, Array<[string, number[], string]>]>]
+> = [
+    [
+        "./test/samples/solidity/resolving/simple_shadowing.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern,
+        [
+            [
+                43, // Body of main()
+                [
+                    ["foo", [34], "foo is the param of main, not the contract struct"],
+                    ["bar", [36], "bar is the param of main, not the contract enum"],
+                    ["boo", [38], "boo is the param of main, not the contract event"],
+                    ["f1", [40], "f1 is the param of main, not the contract function"],
+                    ["gfoo", [28], "gfoo is the contract state var, not the global struct def"],
+                    ["gbar", [30], "gbar is the contract state var, not the global enum def"],
+                    ["gf1", [32], "gf1 is the contract state var, not the free function"]
+                ]
+            ]
+        ]
+    ],
+    [
+        "./test/samples/solidity/resolving/inheritance_and_shadowing.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern,
+        [
+            [
+                13, // Body of main()
+                [["foo", [4], "foo is inherited struct definition, not the global constant"]]
+            ]
+        ]
+    ],
+    [
+        "./test/samples/solidity/resolving/block_05.sol",
+        CompilerVersions05[CompilerVersions05.length - 1],
+        ASTKind.Modern,
+        [
+            [
+                8, // Variable declaration for m
+                [["foo", [4], "foo in the begining of main refers to the struct"]]
+            ],
+            [
+                11, // Variable declaration for foo
+                [["foo", [4], "foo at the variable declaration for foo still refers to the struct"]]
+            ],
+            [
+                20, // Assignment after variable declaration for foo
+                [
+                    [
+                        "foo",
+                        [11],
+                        "foo after the variable declaration for foo refers to the vardeclstmt"
+                    ]
+                ]
+            ]
+        ]
+    ],
+    [
+        "./test/samples/solidity/resolving/block_04.sol",
+        CompilerVersions04[CompilerVersions04.length - 1],
+        ASTKind.Legacy,
+        [
+            [
+                12, // Variable declaration statement for m
+                [
+                    [
+                        "bar",
+                        [14],
+                        "Later variable declaration statement for bar is visible in earlier statement in same block for m"
+                    ]
+                ]
+            ],
+            [
+                17, // Variable declaration statement for bar
+                [
+                    [
+                        "m",
+                        [8],
+                        "Variable declaration statement for m is visible in alter statement in same block for bar"
+                    ]
+                ]
+            ]
+        ]
+    ],
+    [
+        "./test/samples/solidity/resolving/imports_and_source_unit_function_overloading.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern,
+        [
+            [
+                62, // Function declaration for moo in "foo.sol"
+                [
+                    ["foo", [68], 'foo in "foo.sol" refers to struct def imported from "boo.sol"'],
+                    [
+                        "roo",
+                        [68],
+                        'roo in "foo.sol" refers to struct def imported via alias from "boo.sol"'
+                    ]
+                ]
+            ],
+            [
+                15, // Body of function declaration for moo in "imports_and_source_unit_function_overloading.sol"
+                [
+                    [
+                        "moo",
+                        [16, 63],
+                        'moo in the body of "moo()" refers to both overloaded functions'
+                    ]
+                ]
+            ],
+            [
+                41, // Body of main in "imports_and_source_unit_function_overloading.sol"
+                [
+                    [
+                        "moo",
+                        [16, 63],
+                        'moo in the body of "main()" refers to both overloaded functions'
+                    ],
+                    [
+                        "goo",
+                        [20, 63],
+                        'moo in the body of "main()" refers to both overloaded functions'
+                    ],
+                    [
+                        "roo",
+                        [68],
+                        'roo in the body of "main()" refers to the struct def in "boo.sol"'
+                    ],
+                    [
+                        "foo",
+                        [68],
+                        'foo in the body of "main()" refers to the struct def in "boo.sol"'
+                    ]
+                ]
+            ]
+        ]
+    ],
+    [
+        "./test/samples/solidity/resolving/shadowing_overloading_and_overriding.sol",
+        CompilerVersions08[CompilerVersions08.length - 1],
+        ASTKind.Modern,
+        [
+            [
+                27, // body of the free function boo
+                [
+                    ["foo", [11], "foo at the global scope corresponds to the free function"],
+                    ["boo", [27], "foo at the global scope corresponds to the free function"],
+                    ["bar", [21], "foo at the global scope corresponds to the free function"],
+                    ["v", [32], "foo at the global scope corresponds to the global struct def"]
+                ]
+            ],
+
+            [
+                61, // Modifier definition inside Base
+                [
+                    [
+                        "foo",
+                        [36, 42],
+                        "foo in Base correspodns to the 2 overloaded function definitions"
+                    ],
+                    [
+                        "v",
+                        [47, 57],
+                        "v in Base corresponds to the 2 overloaded function definitions"
+                    ],
+                    ["E", [63, 67], "E in Base corrseponds to the 2 overloaded event definitions"]
+                ]
+            ],
+            [
+                114, // main function definition in Child
+                [
+                    [
+                        "foo",
+                        [78, 42],
+                        "foo in Child corresponds to the 1 overriden and 1 inherited overloaded function definitions"
+                    ],
+                    [
+                        "v",
+                        [73, 57],
+                        "v in Child corresponds to the overriding public state var and the inherited overloaded function def"
+                    ],
+                    ["bar", [21], "bar in Child corresponds to the free fun"],
+                    ["boo", [84], "boo in Child corresponds to the shadowing contract function"],
+                    [
+                        "E",
+                        [63, 67],
+                        "E in Child corrseponds to the 2 overloaded event definitions. (events can't be overriden)"
+                    ]
+                ]
+            ]
+        ]
+    ]
+];
+
+describe("resolveAny() unit tests", () => {
+    for (const [sample, compilerVersion, kind, sampleTests] of unitSamples) {
+        describe(`In sample ${sample}`, () => {
+            const result = compileSol(sample, "auto", []);
+
+            expect(result.compilerVersion).toEqual(compilerVersion);
+            const errors = detectCompileErrors(result.data);
+
+            expect(errors).toHaveLength(0);
+
+            const data = result.data;
+
+            const reader = new ASTReader();
+            reader.read(data, kind);
+
+            for (const [ctxId, unitTests] of sampleTests) {
+                const ctxNode = reader.context.locate(ctxId);
+                for (const [name, expectedIds, testName] of unitTests) {
+                    it(testName, () => {
+                        const resolvedNodes = resolveAny(name, ctxNode, compilerVersion);
+                        expect(new Set(expectedIds)).toEqual(
+                            new Set([...resolvedNodes].map((node) => node.id))
+                        );
+                    });
+                }
+            }
+        });
+    }
+});


### PR DESCRIPTION
WIP: Do not merge yet.

This PR aims to add the capability to generate a `TypeName` node for any `Expression` `ASTNode`. This is primarily done by parsing the `typeString` property associated with each node, but requires first writing a handy new function `resolveAny` that can resolve any definition (variable, function, contract, struct, enum, etc..) in the context of any ASTNode. This is useful for building `UserDefinedTypeName` nodes that need to refer to an exact definition. It will be also useful to remove some duplicated hacky code from scribble. Plan:

- [ ] Add `resolveAny()` function that can resolve any definition by name in the context of an ASTNode with associated tests
- [ ] Add new `InternalTypeName` abstract class, with a subtree of classes describing some internal types that cannot be declared, but can appear as types of intermediate expressions:
```
                                   ______`InternalTypeName`______
                                 /             |                  \
               `LiteralTypeName`   |      `TupleTypeName`          `TypeTypeName`
                                               |
                                    `BuiltinTypeName`
```
- [ ] migrate the typeString parser from scribble and add the `getExprType()` function leveraging the typestring parser.
- [ ] add associated tests for `getExprType()`