### PR TITLE
Version change from 4.0.0 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "solc-typed-ast",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "findup-sync": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "solc-typed-ast",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "description": "A TypeScript library providing a normalized typed Solidity AST along with the utilities necessary to generate the AST (from Solc) and traverse/manipulate it.",
     "keywords": [],
     "files": [


### PR DESCRIPTION
## Changes
- [X] Changed package version to `5.0.0` (this is due to multiple breaking changes in package API).

## Pending release references
- Migrate some features from Scribble (#29)
- A comprehensive list of known AST node types (#30)
- Support for Solidity 0.8.4 (#33)
- Parser and AST for arbitrary expression types (#34)

Regards.