### PR TITLE
Export type AST from root and the entry point to parse type strings with explicit context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./ast";
 export * from "./compile";
 export * from "./misc";
+export * from "./types";

--- a/src/types/typeStrings/typeString_parser_header.ts
+++ b/src/types/typeStrings/typeString_parser_header.ts
@@ -1,6 +1,7 @@
 // Need the ts-nocheck to suppress the noUnusedLocals errors in the generated parser
 // @ts-nocheck
 import {
+    ASTNode,
     ContractDefinition,
     DataLocation,
     EnumDefinition,
@@ -73,11 +74,33 @@ function getFunctionAttributes(
     return [visiblity, mutability];
 }
 
+/**
+ * Return the `TypeNode` corresponding to `arg`, where `arg` is a node with a type string (`Expression` or `VariableDeclaration`).
+ * The function uses a parser to parse the type string, while resolving and user-defined type refernces in the context of `arg`.
+ * 
+ * @param arg - either a type string, or a node with a type string (`Expression` or `VariableDeclaration`)
+ * @param version - compiler version to be used. Useful as resolution rules changed betwee 0.4.x and 0.5.x
+ * @returns 
+ */
 export function getNodeType(node: Expression | VariableDeclaration, version: string): TypeNode {
     return parse(node.typeString, { ctx: node, version }) as TypeNode;
 }
 
-function makeUserDefinedType<T extends ASNode>(
+/**
+ * Return the `TypeNode` corresponding to `arg`, where `arg` is either a raw type string, or a node with a type string (`Expression` or `VariableDeclaration`).
+ * The function uses a parser to parse the type string, while resolving and user-defined type refernces in the context of `ctx`.
+ * 
+ * @param arg - either a type string, or a node with a type string (`Expression` or `VariableDeclaration`)
+ * @param version - compiler version to be used. Useful as resolution rules changed betwee 0.4.x and 0.5.x
+ * @param ctx - `ASTNode` representing the context in which a type string is to be parsed
+ * @returns 
+ */
+export function getNodeTypeInCtx(arg: Expression | VariableDeclaration | string, version: string, ctx: ASTNode): TypeNode {
+    const typeString = typeof arg === 'string' ? arg : arg.typeString;
+    return parse( typeString, { ctx, version }) as TypeNode;
+}
+
+function makeUserDefinedType<T extends ASTNode>(
     name: string,
     constructor: ASTNodeConstructor<T>,
     version: string,

--- a/src/types/typeStrings/typeString_parser_header.ts
+++ b/src/types/typeStrings/typeString_parser_header.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import {
     ASTNode,
+    ASTNodeConstructor,
     ContractDefinition,
     DataLocation,
     EnumDefinition,
@@ -34,30 +35,40 @@ import {
 } from "../ast";
 
 function getFunctionAttributes(
-    rawDecorators: string[]
+    decorators: string[]
 ): [FunctionVisibility, FunctionStateMutability] {
     let visiblity: FunctionVisibility | undefined;
     let mutability: FunctionStateMutability | undefined;
 
-    for (const decorator of rawDecorators) {
-        if (["external", "internal"].includes(decorator)) {
+    const visiblities = new Set<string>([
+        FunctionVisibility.Internal,
+        FunctionVisibility.External
+    ]);
+
+    const mutabilities = new Set<string>([
+        FunctionStateMutability.Pure,
+        FunctionStateMutability.View,
+        FunctionStateMutability.NonPayable,
+        FunctionStateMutability.Payable
+    ]);
+
+    for (const decorator of decorators) {
+        if (visiblities.has(decorator)) {
             if (visiblity !== undefined) {
                 throw new Error(
                     `Multiple visiblity decorators specified: ${decorator} conflicts with ${visiblity}`
                 );
             }
 
-            visiblity = decorator;
-        }
-
-        if (["pure", "view", "nonpayable", "payable"].includes(decorator)) {
+            visiblity = decorator as FunctionVisibility;
+        } else if (mutabilities.has(decorator)) {
             if (mutability !== undefined) {
                 throw new Error(
                     `Multiple mutability decorators specified: ${decorator} conflicts with ${mutability}`
                 );
             }
 
-            mutability = decorator;
+            mutability = decorator as FunctionStateMutability;
         }
     }
 
@@ -75,29 +86,34 @@ function getFunctionAttributes(
 }
 
 /**
- * Return the `TypeNode` corresponding to `arg`, where `arg` is a node with a type string (`Expression` or `VariableDeclaration`).
- * The function uses a parser to parse the type string, while resolving and user-defined type refernces in the context of `arg`.
+ * Return the `TypeNode` corresponding to `node`, where `node` is an AST node
+ * with a type string (`Expression` or `VariableDeclaration`).
+ *
+ * The function uses a parser to process the type string,
+ * while resolving and user-defined type references in the context of `node`.
  * 
- * @param arg - either a type string, or a node with a type string (`Expression` or `VariableDeclaration`)
- * @param version - compiler version to be used. Useful as resolution rules changed betwee 0.4.x and 0.5.x
- * @returns 
+ * @param arg - an AST node with a type string (`Expression` or `VariableDeclaration`)
+ * @param version - compiler version to be used. Useful as resolution rules changed between 0.4.x and 0.5.x.
  */
 export function getNodeType(node: Expression | VariableDeclaration, version: string): TypeNode {
     return parse(node.typeString, { ctx: node, version }) as TypeNode;
 }
 
 /**
- * Return the `TypeNode` corresponding to `arg`, where `arg` is either a raw type string, or a node with a type string (`Expression` or `VariableDeclaration`).
- * The function uses a parser to parse the type string, while resolving and user-defined type refernces in the context of `ctx`.
+ * Return the `TypeNode` corresponding to `arg`, where `arg` is either a raw type string,
+ * or an AST node with a type string (`Expression` or `VariableDeclaration`).
+ *
+ * The function uses a parser to process the type string,
+ * while resolving and user-defined type references in the context of `ctx`.
  * 
  * @param arg - either a type string, or a node with a type string (`Expression` or `VariableDeclaration`)
- * @param version - compiler version to be used. Useful as resolution rules changed betwee 0.4.x and 0.5.x
+ * @param version - compiler version to be used. Useful as resolution rules changed between 0.4.x and 0.5.x.
  * @param ctx - `ASTNode` representing the context in which a type string is to be parsed
- * @returns 
  */
 export function getNodeTypeInCtx(arg: Expression | VariableDeclaration | string, version: string, ctx: ASTNode): TypeNode {
-    const typeString = typeof arg === 'string' ? arg : arg.typeString;
-    return parse( typeString, { ctx, version }) as TypeNode;
+    const typeString = typeof arg === "string" ? arg : arg.typeString;
+
+    return parse(typeString, { ctx, version }) as TypeNode;
 }
 
 function makeUserDefinedType<T extends ASTNode>(


### PR DESCRIPTION
2 nits from 5.0.0 release:
1. new type definitions are not exported at the root level
2. wanted another entry point for parsing type strings with explicit context