### PR TITLE
Fix canonical signature hashes (`selector`s) computation

### DIFF
--- a/src/ast/implementation/declaration/variable_declaration.ts
+++ b/src/ast/implementation/declaration/variable_declaration.ts
@@ -161,11 +161,11 @@ export class VariableDeclaration extends ASTNode {
             const declaration = type.vReferencedDeclaration;
 
             if (declaration instanceof StructDefinition) {
-                const signatures = declaration.vMembers.map(
-                    (member) => member.canonicalSignatureType
-                );
+                if (declaration.vScope instanceof ContractDefinition) {
+                    return declaration.vScope.name + "." + declaration.name;
+                }
 
-                return "(" + signatures.join(",") + ")";
+                return declaration.name;
             }
 
             if (declaration instanceof ContractDefinition) {

--- a/src/ast/implementation/declaration/variable_declaration.ts
+++ b/src/ast/implementation/declaration/variable_declaration.ts
@@ -1,3 +1,4 @@
+import { getUserDefinedTypeFQName } from "../../../types";
 import { ASTNode } from "../../ast_node";
 import { ContractKind, DataLocation, Mutability, StateVariableVisibility } from "../../constants";
 import { encodeSignature } from "../../utils";
@@ -169,17 +170,12 @@ export class VariableDeclaration extends ASTNode {
             const declaration = type.vReferencedDeclaration;
 
             if (site.kind === ContractKind.Library) {
-                if (declaration instanceof ContractDefinition) {
-                    return declaration.name;
-                }
-
                 if (
+                    declaration instanceof ContractDefinition ||
                     declaration instanceof StructDefinition ||
                     declaration instanceof EnumDefinition
                 ) {
-                    return declaration.vScope instanceof ContractDefinition
-                        ? declaration.vScope.name + "." + declaration.name
-                        : declaration.name;
+                    return getUserDefinedTypeFQName(declaration);
                 }
             } else {
                 if (declaration instanceof StructDefinition) {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -130,7 +130,7 @@ export function generalizeType(type: TypeNode): [TypeNode, DataLocation | undefi
     return [type, undefined];
 }
 
-function getUserDefinedTypeFQName(
+export function getUserDefinedTypeFQName(
     def: ContractDefinition | StructDefinition | EnumDefinition
 ): string {
     return def.vScope instanceof ContractDefinition ? `${def.vScope.name}.${def.name}` : def.name;

--- a/test/integration/factory/copy.spec.ts
+++ b/test/integration/factory/copy.spec.ts
@@ -51,6 +51,9 @@ describe(`ASTNodeFactory.copy() validation`, () => {
                     .join("\n")
                     .replace(new RegExp(process.cwd(), "g"), ".");
 
+                // Uncomment next line to update snapshots
+                // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+
                 const content = fse.readFileSync(snapshot, { encoding: "utf-8" });
 
                 expect(result).toEqual(content);

--- a/test/integration/sol-ast-compile/tree.spec.ts
+++ b/test/integration/sol-ast-compile/tree.spec.ts
@@ -7,7 +7,11 @@ const cases = [
         "test/samples/solidity/declarations/interface_060.sol",
         "test/samples/solidity/declarations/interface_060.tree.txt"
     ],
-    ["test/samples/solidity/interface_id.sol", "test/samples/solidity/interface_id.tree.txt"]
+    ["test/samples/solidity/interface_id.sol", "test/samples/solidity/interface_id.tree.txt"],
+    [
+        "test/samples/solidity/library_fun_overloads.sol",
+        "test/samples/solidity/library_fun_overloads.tree.txt"
+    ]
 ];
 
 for (const [sample, snapshot] of cases) {

--- a/test/integration/sol-ast-compile/tree.spec.ts
+++ b/test/integration/sol-ast-compile/tree.spec.ts
@@ -11,7 +11,8 @@ const cases = [
     [
         "test/samples/solidity/library_fun_overloads.sol",
         "test/samples/solidity/library_fun_overloads.tree.txt"
-    ]
+    ],
+    ["test/samples/solidity/fun_selectors.sol", "test/samples/solidity/fun_selectors.tree.txt"]
 ];
 
 for (const [sample, snapshot] of cases) {

--- a/test/samples/solidity/fun_selectors.sol
+++ b/test/samples/solidity/fun_selectors.sol
@@ -1,0 +1,92 @@
+contract D {
+    uint a;
+}
+
+struct T {
+    address y;
+}
+
+enum X {
+    A
+}
+
+library Foo {
+    enum Y {
+        A
+    }
+
+    struct S {
+        uint x;
+    }
+
+    function funD(D d) public {}
+    function funS(S memory s) public {}
+    function funT(T memory t) public {}
+    function funX(X x) public {}
+    function funY(Y y) public {}
+}
+
+interface Bar {
+    function funD(D d) external;
+    function funS(Foo.S calldata s) external;
+    function funT(T calldata s) external;
+    function funX(X x) external;
+    function funY(Foo.Y y) external;
+}
+
+contract Baz {
+    function funD(D d) external {}
+    function funS(Foo.S calldata s) external {}
+    function funT(T calldata s) external {}
+    function funX(X x) external {}
+    function funY(Foo.Y y) external {}
+
+    function main() public {
+        assert(Foo.funD.selector == bytes4(keccak256("funD(D)")));
+        assert(Foo.funD.selector == 0x46467911);
+
+        assert(Foo.funS.selector == bytes4(keccak256("funS(Foo.S)")));
+        assert(Foo.funS.selector == 0x2d9de9c3);
+
+        assert(Foo.funT.selector == bytes4(keccak256("funT(T)")));
+        assert(Foo.funT.selector == 0x8c551140);
+
+        assert(Foo.funX.selector == bytes4(keccak256("funX(X)")));
+        assert(Foo.funX.selector == 0x20c5a75c);
+
+        assert(Foo.funY.selector == bytes4(keccak256("funY(Foo.Y)")));
+        assert(Foo.funY.selector == 0xc79a4d37);
+
+        assert(Bar.funD.selector == bytes4(keccak256("funD(address)")));
+        assert(Bar.funD.selector == 0x4e209091);
+
+        assert(Bar.funS.selector == bytes4(keccak256("funS((uint256))")));
+        assert(Bar.funS.selector == 0xe373f962);
+
+        assert(Bar.funT.selector == bytes4(keccak256("funT((address))")));
+        assert(Bar.funT.selector == 0x3793b6f0);
+
+        assert(Bar.funX.selector == bytes4(keccak256("funX(uint8)")));
+        assert(Bar.funX.selector == 0x0a42a215);
+
+        assert(Bar.funY.selector == bytes4(keccak256("funY(uint8)")));
+        assert(Bar.funY.selector == 0x0a035664);
+        
+        assert(type(Bar).interfaceId == 0x9a812b72);
+
+        assert(Baz.funD.selector == bytes4(keccak256("funD(address)")));
+        assert(Baz.funD.selector == 0x4e209091);
+
+        assert(Baz.funS.selector == bytes4(keccak256("funS((uint256))")));
+        assert(Baz.funS.selector == 0xe373f962);
+
+        assert(Baz.funT.selector == bytes4(keccak256("funT((address))")));
+        assert(Baz.funT.selector == 0x3793b6f0);
+
+        assert(Baz.funX.selector == bytes4(keccak256("funX(uint8)")));
+        assert(Baz.funX.selector == 0x0a42a215);
+
+        assert(Baz.funY.selector == bytes4(keccak256("funY(uint8)")));
+        assert(Baz.funY.selector == 0x0a035664);
+    }
+}

--- a/test/samples/solidity/fun_selectors.tree.txt
+++ b/test/samples/solidity/fun_selectors.tree.txt
@@ -1,0 +1,446 @@
+SourceUnit #445 -> /test/samples/solidity/fun_selectors.sol
+|   ContractDefinition #3 -> contract D
+|   |   VariableDeclaration #2 -> uint256 internal a
+|   |   |   ElementaryTypeName #1
+|   StructDefinition #6
+|   |   VariableDeclaration #5 -> address y
+|   |   |   ElementaryTypeName #4
+|   EnumDefinition #8
+|   |   EnumValue #7
+|   ContractDefinition #49 -> library Foo
+|   |   EnumDefinition #10
+|   |   |   EnumValue #9
+|   |   StructDefinition #13
+|   |   |   VariableDeclaration #12 -> uint256 x
+|   |   |   |   ElementaryTypeName #11
+|   |   FunctionDefinition #20 -> funD(D) [selector: 46467911]
+|   |   |   ParameterList #17
+|   |   |   |   VariableDeclaration #16 -> contract D d
+|   |   |   |   |   UserDefinedTypeName #15
+|   |   |   |   |   |   IdentifierPath #14
+|   |   |   ParameterList #18
+|   |   |   Block #19
+|   |   FunctionDefinition #27 -> funS(Foo.S) [selector: 2d9de9c3]
+|   |   |   ParameterList #24
+|   |   |   |   VariableDeclaration #23 -> struct Foo.S s
+|   |   |   |   |   UserDefinedTypeName #22
+|   |   |   |   |   |   IdentifierPath #21
+|   |   |   ParameterList #25
+|   |   |   Block #26
+|   |   FunctionDefinition #34 -> funT(T) [selector: 8c551140]
+|   |   |   ParameterList #31
+|   |   |   |   VariableDeclaration #30 -> struct T t
+|   |   |   |   |   UserDefinedTypeName #29
+|   |   |   |   |   |   IdentifierPath #28
+|   |   |   ParameterList #32
+|   |   |   Block #33
+|   |   FunctionDefinition #41 -> funX(X) [selector: 20c5a75c]
+|   |   |   ParameterList #38
+|   |   |   |   VariableDeclaration #37 -> enum X x
+|   |   |   |   |   UserDefinedTypeName #36
+|   |   |   |   |   |   IdentifierPath #35
+|   |   |   ParameterList #39
+|   |   |   Block #40
+|   |   FunctionDefinition #48 -> funY(Foo.Y) [selector: c79a4d37]
+|   |   |   ParameterList #45
+|   |   |   |   VariableDeclaration #44 -> enum Foo.Y y
+|   |   |   |   |   UserDefinedTypeName #43
+|   |   |   |   |   |   IdentifierPath #42
+|   |   |   ParameterList #46
+|   |   |   Block #47
+|   ContractDefinition #80 -> interface Bar [id: 9a812b72]
+|   |   FunctionDefinition #55 -> funD(address) [selector: 4e209091]
+|   |   |   ParameterList #53
+|   |   |   |   VariableDeclaration #52 -> contract D d
+|   |   |   |   |   UserDefinedTypeName #51
+|   |   |   |   |   |   IdentifierPath #50
+|   |   |   ParameterList #54
+|   |   FunctionDefinition #61 -> funS((uint256)) [selector: e373f962]
+|   |   |   ParameterList #59
+|   |   |   |   VariableDeclaration #58 -> struct Foo.S s
+|   |   |   |   |   UserDefinedTypeName #57
+|   |   |   |   |   |   IdentifierPath #56
+|   |   |   ParameterList #60
+|   |   FunctionDefinition #67 -> funT((address)) [selector: 3793b6f0]
+|   |   |   ParameterList #65
+|   |   |   |   VariableDeclaration #64 -> struct T s
+|   |   |   |   |   UserDefinedTypeName #63
+|   |   |   |   |   |   IdentifierPath #62
+|   |   |   ParameterList #66
+|   |   FunctionDefinition #73 -> funX(uint8) [selector: 0a42a215]
+|   |   |   ParameterList #71
+|   |   |   |   VariableDeclaration #70 -> enum X x
+|   |   |   |   |   UserDefinedTypeName #69
+|   |   |   |   |   |   IdentifierPath #68
+|   |   |   ParameterList #72
+|   |   FunctionDefinition #79 -> funY(uint8) [selector: 0a035664]
+|   |   |   ParameterList #77
+|   |   |   |   VariableDeclaration #76 -> enum Foo.Y y
+|   |   |   |   |   UserDefinedTypeName #75
+|   |   |   |   |   |   IdentifierPath #74
+|   |   |   ParameterList #78
+|   ContractDefinition #444 -> contract Baz
+|   |   FunctionDefinition #87 -> funD(address) [selector: 4e209091]
+|   |   |   ParameterList #84
+|   |   |   |   VariableDeclaration #83 -> contract D d
+|   |   |   |   |   UserDefinedTypeName #82
+|   |   |   |   |   |   IdentifierPath #81
+|   |   |   ParameterList #85
+|   |   |   Block #86
+|   |   FunctionDefinition #94 -> funS((uint256)) [selector: e373f962]
+|   |   |   ParameterList #91
+|   |   |   |   VariableDeclaration #90 -> struct Foo.S s
+|   |   |   |   |   UserDefinedTypeName #89
+|   |   |   |   |   |   IdentifierPath #88
+|   |   |   ParameterList #92
+|   |   |   Block #93
+|   |   FunctionDefinition #101 -> funT((address)) [selector: 3793b6f0]
+|   |   |   ParameterList #98
+|   |   |   |   VariableDeclaration #97 -> struct T s
+|   |   |   |   |   UserDefinedTypeName #96
+|   |   |   |   |   |   IdentifierPath #95
+|   |   |   ParameterList #99
+|   |   |   Block #100
+|   |   FunctionDefinition #108 -> funX(uint8) [selector: 0a42a215]
+|   |   |   ParameterList #105
+|   |   |   |   VariableDeclaration #104 -> enum X x
+|   |   |   |   |   UserDefinedTypeName #103
+|   |   |   |   |   |   IdentifierPath #102
+|   |   |   ParameterList #106
+|   |   |   Block #107
+|   |   FunctionDefinition #115 -> funY(uint8) [selector: 0a035664]
+|   |   |   ParameterList #112
+|   |   |   |   VariableDeclaration #111 -> enum Foo.Y y
+|   |   |   |   |   UserDefinedTypeName #110
+|   |   |   |   |   |   IdentifierPath #109
+|   |   |   ParameterList #113
+|   |   |   Block #114
+|   |   FunctionDefinition #443 -> main() [selector: dffeadd0]
+|   |   |   ParameterList #116
+|   |   |   ParameterList #117
+|   |   |   Block #442
+|   |   |   |   ExpressionStatement #130
+|   |   |   |   |   FunctionCall #129
+|   |   |   |   |   |   Identifier #118
+|   |   |   |   |   |   BinaryOperation #128
+|   |   |   |   |   |   |   MemberAccess #121
+|   |   |   |   |   |   |   |   MemberAccess #120
+|   |   |   |   |   |   |   |   |   Identifier #119
+|   |   |   |   |   |   |   FunctionCall #127
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #123
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #122
+|   |   |   |   |   |   |   |   FunctionCall #126
+|   |   |   |   |   |   |   |   |   Identifier #124
+|   |   |   |   |   |   |   |   |   Literal #125
+|   |   |   |   ExpressionStatement #138
+|   |   |   |   |   FunctionCall #137
+|   |   |   |   |   |   Identifier #131
+|   |   |   |   |   |   BinaryOperation #136
+|   |   |   |   |   |   |   MemberAccess #134
+|   |   |   |   |   |   |   |   MemberAccess #133
+|   |   |   |   |   |   |   |   |   Identifier #132
+|   |   |   |   |   |   |   Literal #135
+|   |   |   |   ExpressionStatement #151
+|   |   |   |   |   FunctionCall #150
+|   |   |   |   |   |   Identifier #139
+|   |   |   |   |   |   BinaryOperation #149
+|   |   |   |   |   |   |   MemberAccess #142
+|   |   |   |   |   |   |   |   MemberAccess #141
+|   |   |   |   |   |   |   |   |   Identifier #140
+|   |   |   |   |   |   |   FunctionCall #148
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #144
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #143
+|   |   |   |   |   |   |   |   FunctionCall #147
+|   |   |   |   |   |   |   |   |   Identifier #145
+|   |   |   |   |   |   |   |   |   Literal #146
+|   |   |   |   ExpressionStatement #159
+|   |   |   |   |   FunctionCall #158
+|   |   |   |   |   |   Identifier #152
+|   |   |   |   |   |   BinaryOperation #157
+|   |   |   |   |   |   |   MemberAccess #155
+|   |   |   |   |   |   |   |   MemberAccess #154
+|   |   |   |   |   |   |   |   |   Identifier #153
+|   |   |   |   |   |   |   Literal #156
+|   |   |   |   ExpressionStatement #172
+|   |   |   |   |   FunctionCall #171
+|   |   |   |   |   |   Identifier #160
+|   |   |   |   |   |   BinaryOperation #170
+|   |   |   |   |   |   |   MemberAccess #163
+|   |   |   |   |   |   |   |   MemberAccess #162
+|   |   |   |   |   |   |   |   |   Identifier #161
+|   |   |   |   |   |   |   FunctionCall #169
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #165
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #164
+|   |   |   |   |   |   |   |   FunctionCall #168
+|   |   |   |   |   |   |   |   |   Identifier #166
+|   |   |   |   |   |   |   |   |   Literal #167
+|   |   |   |   ExpressionStatement #180
+|   |   |   |   |   FunctionCall #179
+|   |   |   |   |   |   Identifier #173
+|   |   |   |   |   |   BinaryOperation #178
+|   |   |   |   |   |   |   MemberAccess #176
+|   |   |   |   |   |   |   |   MemberAccess #175
+|   |   |   |   |   |   |   |   |   Identifier #174
+|   |   |   |   |   |   |   Literal #177
+|   |   |   |   ExpressionStatement #193
+|   |   |   |   |   FunctionCall #192
+|   |   |   |   |   |   Identifier #181
+|   |   |   |   |   |   BinaryOperation #191
+|   |   |   |   |   |   |   MemberAccess #184
+|   |   |   |   |   |   |   |   MemberAccess #183
+|   |   |   |   |   |   |   |   |   Identifier #182
+|   |   |   |   |   |   |   FunctionCall #190
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #186
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #185
+|   |   |   |   |   |   |   |   FunctionCall #189
+|   |   |   |   |   |   |   |   |   Identifier #187
+|   |   |   |   |   |   |   |   |   Literal #188
+|   |   |   |   ExpressionStatement #201
+|   |   |   |   |   FunctionCall #200
+|   |   |   |   |   |   Identifier #194
+|   |   |   |   |   |   BinaryOperation #199
+|   |   |   |   |   |   |   MemberAccess #197
+|   |   |   |   |   |   |   |   MemberAccess #196
+|   |   |   |   |   |   |   |   |   Identifier #195
+|   |   |   |   |   |   |   Literal #198
+|   |   |   |   ExpressionStatement #214
+|   |   |   |   |   FunctionCall #213
+|   |   |   |   |   |   Identifier #202
+|   |   |   |   |   |   BinaryOperation #212
+|   |   |   |   |   |   |   MemberAccess #205
+|   |   |   |   |   |   |   |   MemberAccess #204
+|   |   |   |   |   |   |   |   |   Identifier #203
+|   |   |   |   |   |   |   FunctionCall #211
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #207
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #206
+|   |   |   |   |   |   |   |   FunctionCall #210
+|   |   |   |   |   |   |   |   |   Identifier #208
+|   |   |   |   |   |   |   |   |   Literal #209
+|   |   |   |   ExpressionStatement #222
+|   |   |   |   |   FunctionCall #221
+|   |   |   |   |   |   Identifier #215
+|   |   |   |   |   |   BinaryOperation #220
+|   |   |   |   |   |   |   MemberAccess #218
+|   |   |   |   |   |   |   |   MemberAccess #217
+|   |   |   |   |   |   |   |   |   Identifier #216
+|   |   |   |   |   |   |   Literal #219
+|   |   |   |   ExpressionStatement #235
+|   |   |   |   |   FunctionCall #234
+|   |   |   |   |   |   Identifier #223
+|   |   |   |   |   |   BinaryOperation #233
+|   |   |   |   |   |   |   MemberAccess #226
+|   |   |   |   |   |   |   |   MemberAccess #225
+|   |   |   |   |   |   |   |   |   Identifier #224
+|   |   |   |   |   |   |   FunctionCall #232
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #228
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #227
+|   |   |   |   |   |   |   |   FunctionCall #231
+|   |   |   |   |   |   |   |   |   Identifier #229
+|   |   |   |   |   |   |   |   |   Literal #230
+|   |   |   |   ExpressionStatement #243
+|   |   |   |   |   FunctionCall #242
+|   |   |   |   |   |   Identifier #236
+|   |   |   |   |   |   BinaryOperation #241
+|   |   |   |   |   |   |   MemberAccess #239
+|   |   |   |   |   |   |   |   MemberAccess #238
+|   |   |   |   |   |   |   |   |   Identifier #237
+|   |   |   |   |   |   |   Literal #240
+|   |   |   |   ExpressionStatement #256
+|   |   |   |   |   FunctionCall #255
+|   |   |   |   |   |   Identifier #244
+|   |   |   |   |   |   BinaryOperation #254
+|   |   |   |   |   |   |   MemberAccess #247
+|   |   |   |   |   |   |   |   MemberAccess #246
+|   |   |   |   |   |   |   |   |   Identifier #245
+|   |   |   |   |   |   |   FunctionCall #253
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #249
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #248
+|   |   |   |   |   |   |   |   FunctionCall #252
+|   |   |   |   |   |   |   |   |   Identifier #250
+|   |   |   |   |   |   |   |   |   Literal #251
+|   |   |   |   ExpressionStatement #264
+|   |   |   |   |   FunctionCall #263
+|   |   |   |   |   |   Identifier #257
+|   |   |   |   |   |   BinaryOperation #262
+|   |   |   |   |   |   |   MemberAccess #260
+|   |   |   |   |   |   |   |   MemberAccess #259
+|   |   |   |   |   |   |   |   |   Identifier #258
+|   |   |   |   |   |   |   Literal #261
+|   |   |   |   ExpressionStatement #277
+|   |   |   |   |   FunctionCall #276
+|   |   |   |   |   |   Identifier #265
+|   |   |   |   |   |   BinaryOperation #275
+|   |   |   |   |   |   |   MemberAccess #268
+|   |   |   |   |   |   |   |   MemberAccess #267
+|   |   |   |   |   |   |   |   |   Identifier #266
+|   |   |   |   |   |   |   FunctionCall #274
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #270
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #269
+|   |   |   |   |   |   |   |   FunctionCall #273
+|   |   |   |   |   |   |   |   |   Identifier #271
+|   |   |   |   |   |   |   |   |   Literal #272
+|   |   |   |   ExpressionStatement #285
+|   |   |   |   |   FunctionCall #284
+|   |   |   |   |   |   Identifier #278
+|   |   |   |   |   |   BinaryOperation #283
+|   |   |   |   |   |   |   MemberAccess #281
+|   |   |   |   |   |   |   |   MemberAccess #280
+|   |   |   |   |   |   |   |   |   Identifier #279
+|   |   |   |   |   |   |   Literal #282
+|   |   |   |   ExpressionStatement #298
+|   |   |   |   |   FunctionCall #297
+|   |   |   |   |   |   Identifier #286
+|   |   |   |   |   |   BinaryOperation #296
+|   |   |   |   |   |   |   MemberAccess #289
+|   |   |   |   |   |   |   |   MemberAccess #288
+|   |   |   |   |   |   |   |   |   Identifier #287
+|   |   |   |   |   |   |   FunctionCall #295
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #291
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #290
+|   |   |   |   |   |   |   |   FunctionCall #294
+|   |   |   |   |   |   |   |   |   Identifier #292
+|   |   |   |   |   |   |   |   |   Literal #293
+|   |   |   |   ExpressionStatement #306
+|   |   |   |   |   FunctionCall #305
+|   |   |   |   |   |   Identifier #299
+|   |   |   |   |   |   BinaryOperation #304
+|   |   |   |   |   |   |   MemberAccess #302
+|   |   |   |   |   |   |   |   MemberAccess #301
+|   |   |   |   |   |   |   |   |   Identifier #300
+|   |   |   |   |   |   |   Literal #303
+|   |   |   |   ExpressionStatement #319
+|   |   |   |   |   FunctionCall #318
+|   |   |   |   |   |   Identifier #307
+|   |   |   |   |   |   BinaryOperation #317
+|   |   |   |   |   |   |   MemberAccess #310
+|   |   |   |   |   |   |   |   MemberAccess #309
+|   |   |   |   |   |   |   |   |   Identifier #308
+|   |   |   |   |   |   |   FunctionCall #316
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #312
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #311
+|   |   |   |   |   |   |   |   FunctionCall #315
+|   |   |   |   |   |   |   |   |   Identifier #313
+|   |   |   |   |   |   |   |   |   Literal #314
+|   |   |   |   ExpressionStatement #327
+|   |   |   |   |   FunctionCall #326
+|   |   |   |   |   |   Identifier #320
+|   |   |   |   |   |   BinaryOperation #325
+|   |   |   |   |   |   |   MemberAccess #323
+|   |   |   |   |   |   |   |   MemberAccess #322
+|   |   |   |   |   |   |   |   |   Identifier #321
+|   |   |   |   |   |   |   Literal #324
+|   |   |   |   ExpressionStatement #336
+|   |   |   |   |   FunctionCall #335
+|   |   |   |   |   |   Identifier #328
+|   |   |   |   |   |   BinaryOperation #334
+|   |   |   |   |   |   |   MemberAccess #332
+|   |   |   |   |   |   |   |   FunctionCall #331
+|   |   |   |   |   |   |   |   |   Identifier #329
+|   |   |   |   |   |   |   |   |   Identifier #330
+|   |   |   |   |   |   |   Literal #333
+|   |   |   |   ExpressionStatement #349
+|   |   |   |   |   FunctionCall #348
+|   |   |   |   |   |   Identifier #337
+|   |   |   |   |   |   BinaryOperation #347
+|   |   |   |   |   |   |   MemberAccess #340
+|   |   |   |   |   |   |   |   MemberAccess #339
+|   |   |   |   |   |   |   |   |   Identifier #338
+|   |   |   |   |   |   |   FunctionCall #346
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #342
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #341
+|   |   |   |   |   |   |   |   FunctionCall #345
+|   |   |   |   |   |   |   |   |   Identifier #343
+|   |   |   |   |   |   |   |   |   Literal #344
+|   |   |   |   ExpressionStatement #357
+|   |   |   |   |   FunctionCall #356
+|   |   |   |   |   |   Identifier #350
+|   |   |   |   |   |   BinaryOperation #355
+|   |   |   |   |   |   |   MemberAccess #353
+|   |   |   |   |   |   |   |   MemberAccess #352
+|   |   |   |   |   |   |   |   |   Identifier #351
+|   |   |   |   |   |   |   Literal #354
+|   |   |   |   ExpressionStatement #370
+|   |   |   |   |   FunctionCall #369
+|   |   |   |   |   |   Identifier #358
+|   |   |   |   |   |   BinaryOperation #368
+|   |   |   |   |   |   |   MemberAccess #361
+|   |   |   |   |   |   |   |   MemberAccess #360
+|   |   |   |   |   |   |   |   |   Identifier #359
+|   |   |   |   |   |   |   FunctionCall #367
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #363
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #362
+|   |   |   |   |   |   |   |   FunctionCall #366
+|   |   |   |   |   |   |   |   |   Identifier #364
+|   |   |   |   |   |   |   |   |   Literal #365
+|   |   |   |   ExpressionStatement #378
+|   |   |   |   |   FunctionCall #377
+|   |   |   |   |   |   Identifier #371
+|   |   |   |   |   |   BinaryOperation #376
+|   |   |   |   |   |   |   MemberAccess #374
+|   |   |   |   |   |   |   |   MemberAccess #373
+|   |   |   |   |   |   |   |   |   Identifier #372
+|   |   |   |   |   |   |   Literal #375
+|   |   |   |   ExpressionStatement #391
+|   |   |   |   |   FunctionCall #390
+|   |   |   |   |   |   Identifier #379
+|   |   |   |   |   |   BinaryOperation #389
+|   |   |   |   |   |   |   MemberAccess #382
+|   |   |   |   |   |   |   |   MemberAccess #381
+|   |   |   |   |   |   |   |   |   Identifier #380
+|   |   |   |   |   |   |   FunctionCall #388
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #384
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #383
+|   |   |   |   |   |   |   |   FunctionCall #387
+|   |   |   |   |   |   |   |   |   Identifier #385
+|   |   |   |   |   |   |   |   |   Literal #386
+|   |   |   |   ExpressionStatement #399
+|   |   |   |   |   FunctionCall #398
+|   |   |   |   |   |   Identifier #392
+|   |   |   |   |   |   BinaryOperation #397
+|   |   |   |   |   |   |   MemberAccess #395
+|   |   |   |   |   |   |   |   MemberAccess #394
+|   |   |   |   |   |   |   |   |   Identifier #393
+|   |   |   |   |   |   |   Literal #396
+|   |   |   |   ExpressionStatement #412
+|   |   |   |   |   FunctionCall #411
+|   |   |   |   |   |   Identifier #400
+|   |   |   |   |   |   BinaryOperation #410
+|   |   |   |   |   |   |   MemberAccess #403
+|   |   |   |   |   |   |   |   MemberAccess #402
+|   |   |   |   |   |   |   |   |   Identifier #401
+|   |   |   |   |   |   |   FunctionCall #409
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #405
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #404
+|   |   |   |   |   |   |   |   FunctionCall #408
+|   |   |   |   |   |   |   |   |   Identifier #406
+|   |   |   |   |   |   |   |   |   Literal #407
+|   |   |   |   ExpressionStatement #420
+|   |   |   |   |   FunctionCall #419
+|   |   |   |   |   |   Identifier #413
+|   |   |   |   |   |   BinaryOperation #418
+|   |   |   |   |   |   |   MemberAccess #416
+|   |   |   |   |   |   |   |   MemberAccess #415
+|   |   |   |   |   |   |   |   |   Identifier #414
+|   |   |   |   |   |   |   Literal #417
+|   |   |   |   ExpressionStatement #433
+|   |   |   |   |   FunctionCall #432
+|   |   |   |   |   |   Identifier #421
+|   |   |   |   |   |   BinaryOperation #431
+|   |   |   |   |   |   |   MemberAccess #424
+|   |   |   |   |   |   |   |   MemberAccess #423
+|   |   |   |   |   |   |   |   |   Identifier #422
+|   |   |   |   |   |   |   FunctionCall #430
+|   |   |   |   |   |   |   |   ElementaryTypeNameExpression #426
+|   |   |   |   |   |   |   |   |   ElementaryTypeName #425
+|   |   |   |   |   |   |   |   FunctionCall #429
+|   |   |   |   |   |   |   |   |   Identifier #427
+|   |   |   |   |   |   |   |   |   Literal #428
+|   |   |   |   ExpressionStatement #441
+|   |   |   |   |   FunctionCall #440
+|   |   |   |   |   |   Identifier #434
+|   |   |   |   |   |   BinaryOperation #439
+|   |   |   |   |   |   |   MemberAccess #437
+|   |   |   |   |   |   |   |   MemberAccess #436
+|   |   |   |   |   |   |   |   |   Identifier #435
+|   |   |   |   |   |   |   Literal #438
+

--- a/test/samples/solidity/latest_08.nodes.txt
+++ b/test/samples/solidity/latest_08.nodes.txt
@@ -876,7 +876,7 @@ SourceUnit #607
                         parent: VariableDeclarationStatement #361
                         <getter> children: Array(1) [ UserDefinedTypeName #354 ]
                         <getter> vScope: Block #362
-                        <getter> canonicalSignatureType: "(uint256)"
+                        <getter> canonicalSignatureType: "SomeContract.SomeStruct"
                         <getter> getterCanonicalSignature: "s()"
                         <getter> getterCanonicalSignatureHash: "86b714e2"
                         <getter> firstChild: UserDefinedTypeName #354

--- a/test/samples/solidity/latest_08.nodes.txt
+++ b/test/samples/solidity/latest_08.nodes.txt
@@ -876,7 +876,7 @@ SourceUnit #607
                         parent: VariableDeclarationStatement #361
                         <getter> children: Array(1) [ UserDefinedTypeName #354 ]
                         <getter> vScope: Block #362
-                        <getter> canonicalSignatureType: "SomeContract.SomeStruct"
+                        <getter> canonicalSignatureType: "(uint256)"
                         <getter> getterCanonicalSignature: "s()"
                         <getter> getterCanonicalSignatureHash: "86b714e2"
                         <getter> firstChild: UserDefinedTypeName #354

--- a/test/samples/solidity/library_fun_overloads.sol
+++ b/test/samples/solidity/library_fun_overloads.sol
@@ -1,0 +1,34 @@
+library Some {
+    struct Item {
+        uint id;
+    }
+
+    struct Abc {
+        Item item;
+    }
+
+    struct Def {
+        Item item;
+    }
+
+    function id(Abc memory data) pure public returns(uint) {
+        return data.item.id;
+    }
+
+    function id(Def memory data) pure public returns(uint) {
+        return data.item.id;
+    }
+}
+
+contract Test {
+    using Some for Some.Abc;
+    using Some for Some.Def;
+
+    function verify() pure public {
+        Some.Abc memory a = Some.Abc({ item: Some.Item(1) });
+        Some.Def memory b = Some.Def({ item: Some.Item(2) });
+
+        assert(a.id() == 1);
+        assert(b.id() == 2);
+    }
+}

--- a/test/samples/solidity/library_fun_overloads.tree.txt
+++ b/test/samples/solidity/library_fun_overloads.tree.txt
@@ -1,0 +1,91 @@
+SourceUnit #94 -> /test/samples/solidity/library_fun_overloads.sol
+|   ContractDefinition #38 -> library Some
+|   |   StructDefinition #3
+|   |   |   VariableDeclaration #2 -> uint256 id
+|   |   |   |   ElementaryTypeName #1
+|   |   StructDefinition #7
+|   |   |   VariableDeclaration #6 -> struct Some.Item item
+|   |   |   |   UserDefinedTypeName #5
+|   |   |   |   |   IdentifierPath #4
+|   |   StructDefinition #11
+|   |   |   VariableDeclaration #10 -> struct Some.Item item
+|   |   |   |   UserDefinedTypeName #9
+|   |   |   |   |   IdentifierPath #8
+|   |   FunctionDefinition #24 -> id(Some.Abc) [selector: 7c503cd6]
+|   |   |   ParameterList #15
+|   |   |   |   VariableDeclaration #14 -> struct Some.Abc data
+|   |   |   |   |   UserDefinedTypeName #13
+|   |   |   |   |   |   IdentifierPath #12
+|   |   |   ParameterList #18
+|   |   |   |   VariableDeclaration #17 -> uint256
+|   |   |   |   |   ElementaryTypeName #16
+|   |   |   Block #23
+|   |   |   |   Return #22
+|   |   |   |   |   MemberAccess #21
+|   |   |   |   |   |   MemberAccess #20
+|   |   |   |   |   |   |   Identifier #19
+|   |   FunctionDefinition #37 -> id(Some.Def) [selector: 9c9d982f]
+|   |   |   ParameterList #28
+|   |   |   |   VariableDeclaration #27 -> struct Some.Def data
+|   |   |   |   |   UserDefinedTypeName #26
+|   |   |   |   |   |   IdentifierPath #25
+|   |   |   ParameterList #31
+|   |   |   |   VariableDeclaration #30 -> uint256
+|   |   |   |   |   ElementaryTypeName #29
+|   |   |   Block #36
+|   |   |   |   Return #35
+|   |   |   |   |   MemberAccess #34
+|   |   |   |   |   |   MemberAccess #33
+|   |   |   |   |   |   |   Identifier #32
+|   ContractDefinition #93 -> contract Test
+|   |   UsingForDirective #42
+|   |   |   IdentifierPath #39
+|   |   |   UserDefinedTypeName #41
+|   |   |   |   IdentifierPath #40
+|   |   UsingForDirective #46
+|   |   |   IdentifierPath #43
+|   |   |   UserDefinedTypeName #45
+|   |   |   |   IdentifierPath #44
+|   |   FunctionDefinition #92 -> verify() [selector: fc735e99]
+|   |   |   ParameterList #47
+|   |   |   ParameterList #48
+|   |   |   Block #91
+|   |   |   |   VariableDeclarationStatement #61
+|   |   |   |   |   VariableDeclaration #53 -> struct Some.Abc a
+|   |   |   |   |   |   UserDefinedTypeName #52
+|   |   |   |   |   |   |   IdentifierPath #51
+|   |   |   |   |   FunctionCall #60
+|   |   |   |   |   |   MemberAccess #55
+|   |   |   |   |   |   |   Identifier #54
+|   |   |   |   |   |   FunctionCall #59
+|   |   |   |   |   |   |   MemberAccess #57
+|   |   |   |   |   |   |   |   Identifier #56
+|   |   |   |   |   |   |   Literal #58
+|   |   |   |   VariableDeclarationStatement #74
+|   |   |   |   |   VariableDeclaration #66 -> struct Some.Def b
+|   |   |   |   |   |   UserDefinedTypeName #65
+|   |   |   |   |   |   |   IdentifierPath #64
+|   |   |   |   |   FunctionCall #73
+|   |   |   |   |   |   MemberAccess #68
+|   |   |   |   |   |   |   Identifier #67
+|   |   |   |   |   |   FunctionCall #72
+|   |   |   |   |   |   |   MemberAccess #70
+|   |   |   |   |   |   |   |   Identifier #69
+|   |   |   |   |   |   |   Literal #71
+|   |   |   |   ExpressionStatement #82
+|   |   |   |   |   FunctionCall #81
+|   |   |   |   |   |   Identifier #75
+|   |   |   |   |   |   BinaryOperation #80
+|   |   |   |   |   |   |   FunctionCall #78
+|   |   |   |   |   |   |   |   MemberAccess #77
+|   |   |   |   |   |   |   |   |   Identifier #76
+|   |   |   |   |   |   |   Literal #79
+|   |   |   |   ExpressionStatement #90
+|   |   |   |   |   FunctionCall #89
+|   |   |   |   |   |   Identifier #83
+|   |   |   |   |   |   BinaryOperation #88
+|   |   |   |   |   |   |   FunctionCall #86
+|   |   |   |   |   |   |   |   MemberAccess #85
+|   |   |   |   |   |   |   |   |   Identifier #84
+|   |   |   |   |   |   |   Literal #87
+


### PR DESCRIPTION
## Tasks
Fixes #49.

## Changes
- [x] Fixed canonical signature hash computation. 
- [x] Fixed affected test samples. Added related test sample.

## Notes
This fix may look silly, however there is a reason to keep things "as simple as possible". It might be a bit surprising, that compiler catches and restricts possible signature clashes for a following case:
- **a.sol**
  ```solidity
  library A {
      struct S {
          uint value;
      }
  }
  ```
- **b.sol**
  ```solidity
  import { A as T } from './a.sol';

  library A {
      struct S {
          uint value;
      }

      function get(S memory s) pure public returns (uint) {
          return s.value;
      }

      function get(T.S memory s) pure public returns (uint) {
          return s.value;
      }
  }
  ```
Compiler produces following:
```text
TypeError: Function overload clash during conversion to external types for arguments.
 --> test.sol:12:5:
  | 12
  | function get(T.S memory s) pure public returns (uint) {
  | ^ (Relevant source part starts here and spans across multiple lines).
```
This proves that we should not encounter cases when symbol aliasing is causing additional complications.

Regards.