### PR TITLE
Add support for user-passed compiler settings

### DIFF
--- a/test/integration/sol-ast-compile/common.ts
+++ b/test/integration/sol-ast-compile/common.ts
@@ -24,6 +24,7 @@ export const options = [
     "mode",
     "compiler-version",
     "path-remapping",
+    "compiler-settings",
     "raw",
     "with-sources",
     "tree",

--- a/test/integration/sol-ast-compile/compiler-settings/invalid.spec.ts
+++ b/test/integration/sol-ast-compile/compiler-settings/invalid.spec.ts
@@ -1,0 +1,42 @@
+import expect from "expect";
+import { SolAstCompileCommand, SolAstCompileExec } from "../common";
+
+const sample = "test/samples/solidity/missing_pragma.sol";
+const badArgsSamples = [
+    [
+        [sample, "--compiler-settings", "{blahblah}"],
+        `Error: Invalid compiler settings '{blahblah}'. Compiler settings must be a valid JSON object.`
+    ]
+];
+
+for (const [args, expectedError] of badArgsSamples) {
+    const command = SolAstCompileCommand(...args);
+
+    describe(command, () => {
+        let exitCode: number | null;
+        let outData = "";
+        let errData = "";
+
+        before((done) => {
+            const result = SolAstCompileExec(...args);
+
+            outData = result.stdout;
+            errData = result.stderr;
+            exitCode = result.status;
+
+            done();
+        });
+
+        it("Exit code is valid", () => {
+            expect(exitCode).toEqual(1);
+        });
+
+        it("STDERR is correct", () => {
+            expect(errData).toContain(expectedError);
+        });
+
+        it("STDOUT is empty", () => {
+            expect(outData).toEqual("");
+        });
+    });
+}

--- a/test/integration/sol-ast-compile/compiler-settings/valid.spec.ts
+++ b/test/integration/sol-ast-compile/compiler-settings/valid.spec.ts
@@ -1,0 +1,65 @@
+import expect from "expect";
+import { SolAstCompileCommand, SolAstCompileExec } from "../common";
+
+const sample = "test/samples/solidity/missing_pragma.sol";
+
+const values = [
+    "SourceUnit #5",
+    'src: "0:38:0"',
+
+    "ContractDefinition #4",
+    'src: "0:37:0"',
+    'name: "Test"',
+
+    "VariableDeclaration #3",
+    'src: "20:14:0"',
+    'name: "some"',
+    'typeString: "uint8"',
+
+    "ElementaryTypeName #1",
+    'src: "20:5:0"',
+    'name: "uint8"',
+
+    "Literal #2",
+    'src: "33:1:0"',
+    'value: "1"'
+];
+
+const args = [
+    sample,
+    "--compiler-settings",
+    `{"optimizer": {"enabled": true, "runs": 1}}`,
+    "--compiler-version",
+    "0.6.0"
+];
+const command = SolAstCompileCommand(...args);
+
+describe(command, () => {
+    let exitCode: number | null;
+    let outData: string;
+    let errData: string;
+
+    before((done) => {
+        const result = SolAstCompileExec(...args);
+
+        outData = result.stdout;
+        errData = result.stderr;
+        exitCode = result.status;
+
+        done();
+    });
+
+    it("Exit code is valid", () => {
+        expect(exitCode).toEqual(0);
+    });
+
+    it("STDERR is empty", () => {
+        expect(errData).toEqual("");
+    });
+
+    it("STDOUT is correct", () => {
+        for (const value of values) {
+            expect(outData).toContain(value);
+        }
+    });
+});


### PR DESCRIPTION
This PR fixes #65 .

Namely it:

- adds a new optional argument `compilerSettings` to all compile API entry points (`compile`, `compileSol`, `compileJSON`, `compileSourceString` and `compileJSONData`) that should be a valid JSON object, and gets merged with the `setttings` field of the standard compiler input

- adds a new `--compiler-settings` command line option to the `sol-ast-compile` tool, that when present should contain a valid JSON that gets passed in as compiler settings