### PR TITLE
Modify compile* endpoints to support selecting compilation output

### DIFF
--- a/src/ast/constants.ts
+++ b/src/ast/constants.ts
@@ -89,6 +89,32 @@ export enum TimeUnit {
     Years = "years"
 }
 
+export enum CompilationOutput {
+    AST = "ast",
+    ABI = "abi",
+    DEVDOC = "devdoc",
+    USERDOC = "userdoc",
+    METADATA = "metadata",
+    IR = "ir",
+    IR_OPTIMIZED = "irOptimized",
+    STORAGE_LAYOUT = "storageLayout",
+    EVM = "evm",
+    EVM_ASSEMBLY = "evm.assembly",
+    EVM_LEGACY_ASSEMBLY = "evm.legacyAssembly",
+    EVM_BYTECODE = "evm.bytecode",
+    EVM_BYTECODE_OBJECT = "evm.bytecode.object",
+    EVM_BYTECODE_OPCODES = "evm.bytecode.opcodes",
+    EVM_BYTECODE_SOURCEMAP = "evm.bytecode.sourceMap",
+    EVM_BYTECODE_LINKREFERENCES = "evm.bytecode.linkReferences",
+    EVM_BYTECODE_GENERATEDSOURCES = "evm.bytecode.generatedSources",
+    EVM_DEPLOYEDBYTECODE_IMMUTABLEREFERENCES = "evm.deployedBytecode.immutableReferences",
+    EVM_METHODIDENTIFIERS = "evm.methodIdentifiers",
+    EVM_GASESTIMATES = "evm.gasEstimates",
+    EWASM_WAST = "ewasm.wast",
+    EWASM_WASM = "ewasm.wasm",
+    ALL = "*"
+}
+
 export const PossibleDataLocations = new Set<string>(Object.values(DataLocation));
 
 export const PossibleFunctionVisibilities = new Set<string>(Object.values(FunctionVisibility));
@@ -114,3 +140,5 @@ export const PossibleLiteralKinds = new Set<string>(Object.values(LiteralKind));
 export const PossibleEtherUnits = new Set<string>(Object.values(EtherUnit));
 
 export const PossibleTimeUnits = new Set<string>(Object.values(TimeUnit));
+
+export const PossibleCompilationOutputs = new Set<string>(Object.values(CompilationOutput));

--- a/src/ast/constants.ts
+++ b/src/ast/constants.ts
@@ -89,32 +89,6 @@ export enum TimeUnit {
     Years = "years"
 }
 
-export enum CompilationOutput {
-    AST = "ast",
-    ABI = "abi",
-    DEVDOC = "devdoc",
-    USERDOC = "userdoc",
-    METADATA = "metadata",
-    IR = "ir",
-    IR_OPTIMIZED = "irOptimized",
-    STORAGE_LAYOUT = "storageLayout",
-    EVM = "evm",
-    EVM_ASSEMBLY = "evm.assembly",
-    EVM_LEGACY_ASSEMBLY = "evm.legacyAssembly",
-    EVM_BYTECODE = "evm.bytecode",
-    EVM_BYTECODE_OBJECT = "evm.bytecode.object",
-    EVM_BYTECODE_OPCODES = "evm.bytecode.opcodes",
-    EVM_BYTECODE_SOURCEMAP = "evm.bytecode.sourceMap",
-    EVM_BYTECODE_LINKREFERENCES = "evm.bytecode.linkReferences",
-    EVM_BYTECODE_GENERATEDSOURCES = "evm.bytecode.generatedSources",
-    EVM_DEPLOYEDBYTECODE_IMMUTABLEREFERENCES = "evm.deployedBytecode.immutableReferences",
-    EVM_METHODIDENTIFIERS = "evm.methodIdentifiers",
-    EVM_GASESTIMATES = "evm.gasEstimates",
-    EWASM_WAST = "ewasm.wast",
-    EWASM_WASM = "ewasm.wasm",
-    ALL = "*"
-}
-
 export const PossibleDataLocations = new Set<string>(Object.values(DataLocation));
 
 export const PossibleFunctionVisibilities = new Set<string>(Object.values(FunctionVisibility));
@@ -140,5 +114,3 @@ export const PossibleLiteralKinds = new Set<string>(Object.values(LiteralKind));
 export const PossibleEtherUnits = new Set<string>(Object.values(EtherUnit));
 
 export const PossibleTimeUnits = new Set<string>(Object.values(TimeUnit));
-
-export const PossibleCompilationOutputs = new Set<string>(Object.values(CompilationOutput));

--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -8,6 +8,7 @@ import {
     ASTNodeFormatter,
     ASTReader,
     ASTWriter,
+    CompilationOutput,
     CompileFailedError,
     compileJson,
     compileJsonData,
@@ -26,7 +27,6 @@ import {
     VariableDeclaration,
     XPath
 } from "..";
-import { CompilationOutput } from "../ast";
 
 const modes = ["auto", "sol", "json"];
 

--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -26,6 +26,7 @@ import {
     VariableDeclaration,
     XPath
 } from "..";
+import { CompilationOutput } from "../ast";
 
 const modes = ["auto", "sol", "json"];
 
@@ -136,6 +137,7 @@ OPTIONS:
 
     let fileName = args._[0];
     let result: CompileResult;
+    const compilationOutput: CompilationOutput[] = [CompilationOutput.ALL];
 
     try {
         if (stdin) {
@@ -156,6 +158,7 @@ OPTIONS:
                           JSON.parse(content),
                           compilerVersion,
                           pathRemapping,
+                          compilationOutput,
                           compilerSettings
                       )
                     : compileSourceString(
@@ -163,6 +166,7 @@ OPTIONS:
                           content,
                           compilerVersion,
                           pathRemapping,
+                          compilationOutput,
                           compilerSettings
                       );
         } else {
@@ -172,12 +176,19 @@ OPTIONS:
                 const iFileName = fileName.toLowerCase();
 
                 if (iFileName.endsWith(".sol")) {
-                    result = compileSol(fileName, compilerVersion, pathRemapping, compilerSettings);
+                    result = compileSol(
+                        fileName,
+                        compilerVersion,
+                        pathRemapping,
+                        compilationOutput,
+                        compilerSettings
+                    );
                 } else if (iFileName.endsWith(".json")) {
                     result = compileJson(
                         fileName,
                         compilerVersion,
                         pathRemapping,
+                        compilationOutput,
                         compilerSettings
                     );
                 } else {
@@ -186,8 +197,20 @@ OPTIONS:
             } else {
                 result =
                     mode === "json"
-                        ? compileJson(fileName, compilerVersion, pathRemapping, compilerSettings)
-                        : compileSol(fileName, compilerVersion, pathRemapping, compilerSettings);
+                        ? compileJson(
+                              fileName,
+                              compilerVersion,
+                              pathRemapping,
+                              compilationOutput,
+                              compilerSettings
+                          )
+                        : compileSol(
+                              fileName,
+                              compilerVersion,
+                              pathRemapping,
+                              compilationOutput,
+                              compilerSettings
+                          );
             }
         }
     } catch (e) {

--- a/src/compile/constants.ts
+++ b/src/compile/constants.ts
@@ -82,3 +82,33 @@ export const CompilerVersions = [
 ];
 
 export const LatestCompilerVersion = CompilerVersions[CompilerVersions.length - 1];
+
+/**
+ * Corresponds to the string constants used in "outputSelection" as described in
+ * https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
+ */
+export enum CompilationOutput {
+    AST = "ast",
+    ABI = "abi",
+    DEVDOC = "devdoc",
+    USERDOC = "userdoc",
+    METADATA = "metadata",
+    IR = "ir",
+    IR_OPTIMIZED = "irOptimized",
+    STORAGE_LAYOUT = "storageLayout",
+    EVM = "evm",
+    EVM_ASSEMBLY = "evm.assembly",
+    EVM_LEGACY_ASSEMBLY = "evm.legacyAssembly",
+    EVM_BYTECODE = "evm.bytecode",
+    EVM_BYTECODE_OBJECT = "evm.bytecode.object",
+    EVM_BYTECODE_OPCODES = "evm.bytecode.opcodes",
+    EVM_BYTECODE_SOURCEMAP = "evm.bytecode.sourceMap",
+    EVM_BYTECODE_LINKREFERENCES = "evm.bytecode.linkReferences",
+    EVM_BYTECODE_GENERATEDSOURCES = "evm.bytecode.generatedSources",
+    EVM_DEPLOYEDBYTECODE_IMMUTABLEREFERENCES = "evm.deployedBytecode.immutableReferences",
+    EVM_METHODIDENTIFIERS = "evm.methodIdentifiers",
+    EVM_GASESTIMATES = "evm.gasEstimates",
+    EWASM_WAST = "ewasm.wast",
+    EWASM_WASM = "ewasm.wasm",
+    ALL = "*"
+}

--- a/src/compile/utils.ts
+++ b/src/compile/utils.ts
@@ -1,13 +1,13 @@
 import fse from "fs-extra";
 import path from "path";
 import { lt, satisfies } from "semver";
-import { CompilationOutput } from "../ast";
 import {
     CompilerVersionSelectionStrategy,
     LatestVersionInEachSeriesStrategy,
     RangeVersionStrategy,
     VersionDetectionStrategy
 } from "./compiler_selection";
+import { CompilationOutput } from "./constants";
 import {
     FileSystemResolver,
     ImportResolver,
@@ -56,25 +56,19 @@ export function getCompilerForVersion(version: string): any {
     );
 }
 
-type PartialSolcInput = {
+interface PartialSolcInput {
     language: "Solidity";
     settings: { remappings: string[]; outputSelection: any; [otherKeys: string]: any };
     [otherKeys: string]: any;
-};
+}
 
-type Solc04Input = {
-    language: "Solidity";
+interface Solc04Input extends PartialSolcInput {
     sources: { [fileName: string]: string };
-    settings: { remappings: string[]; outputSelection: any; [otherKeys: string]: any };
-    [otherKeys: string]: any;
-};
+}
 
-type Solc05Input = {
-    language: "Solidity";
+interface Solc05Input extends PartialSolcInput {
     sources: { [fileName: string]: { content: string } };
-    settings: { remappings: string[]; outputSelection: any; [otherKeys: string]: any };
-    [otherKeys: string]: any;
-};
+}
 
 function mergeCompilerSettings<T extends Solc04Input | Solc05Input>(input: T, settings: any): T {
     if (settings !== undefined) {
@@ -128,20 +122,17 @@ function createCompilerInput(
         }
     };
 
-    let inp: Solc04Input | Solc05Input;
-
     if (lt(version, "0.5.0")) {
         partialInp.sources = {
             [fileName]: content
         };
-
-        inp = partialInp as Solc04Input;
     } else {
         partialInp.sources = {
             [fileName]: { content }
         };
-        inp = partialInp as Solc05Input;
     }
+
+    const inp = partialInp as Solc04Input | Solc05Input;
 
     return mergeCompilerSettings(inp, compilerSettings);
 }


### PR DESCRIPTION
This PR adds the capability to specify what specific output we want when compiling, by adding an extra optional `compilationOutput` argument to the API entrypoints `compile`, `compileSol`, `compileJSON`, `compileSourceString` and `compileJsonData`. `compilationOutput` is an array of values from the enum `CompilationOutput`, which correspond to the possible options to be specified in the `outputSelection` field of the standard input json (see [here](https://docs.soliditylang.org/en/v0.8.0/using-the-compiler.html#input-description) for more details.