### PR TITLE
bump to 6.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "solc-typed-ast",
-    "version": "6.1.2",
+    "version": "6.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "solc-typed-ast",
-    "version": "6.1.2",
+    "version": "6.1.3",
     "description": "A TypeScript library providing a normalized typed Solidity AST along with the utilities necessary to generate the AST (from Solc) and traverse/manipulate it.",
     "keywords": [],
     "files": [


### PR DESCRIPTION
This release adds the optional `compilationOutput` argument to all compile API endpoints