### PR TITLE
Introduce `canonicalName` as getter, support `UserDefinedValueTypeDefinition` in `ASTNodeFactory.makeIdentifierFor()`

### DIFF
--- a/src/ast/implementation/declaration/enum_definition.ts
+++ b/src/ast/implementation/declaration/enum_definition.ts
@@ -1,4 +1,4 @@
-import { enumToIntType } from "../../..";
+import { enumToIntType, getUserDefinedTypeFQName } from "../../..";
 import { ASTNodeWithChildren } from "../../ast_node";
 import { SourceUnit } from "../meta/source_unit";
 import { ContractDefinition } from "./contract_definition";
@@ -15,17 +15,11 @@ export class EnumDefinition extends ASTNodeWithChildren<EnumValue> {
      */
     nameLocation?: string;
 
-    /**
-     * Canonical name (or qualified name), e.g. `DefiningContract.SomeEnum`
-     */
-    canonicalName: string;
-
     constructor(
         id: number,
         src: string,
         type: string,
         name: string,
-        canonicalName: string,
         members: Iterable<EnumValue>,
         nameLocation?: string,
         raw?: any
@@ -33,13 +27,19 @@ export class EnumDefinition extends ASTNodeWithChildren<EnumValue> {
         super(id, src, type, raw);
 
         this.name = name;
-        this.canonicalName = canonicalName;
 
         for (const member of members) {
             this.appendChild(member);
         }
 
         this.nameLocation = nameLocation;
+    }
+
+    /**
+     * Canonical name (or qualified name), e.g. `DefiningContract.SomeEnum`
+     */
+    get canonicalName(): string {
+        return getUserDefinedTypeFQName(this);
     }
 
     /**

--- a/src/ast/implementation/declaration/struct_definition.ts
+++ b/src/ast/implementation/declaration/struct_definition.ts
@@ -1,3 +1,4 @@
+import { getUserDefinedTypeFQName } from "../../..";
 import { ASTNodeWithChildren } from "../../ast_node";
 import { SourceUnit } from "../meta/source_unit";
 import { ContractDefinition } from "./contract_definition";
@@ -8,11 +9,6 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
      * The name of the struct
      */
     name: string;
-
-    /**
-     * Canonical name (or qualified name), e.g. `DefiningContract.SomeStruct`
-     */
-    canonicalName: string;
 
     /**
      * The source range for name string
@@ -34,7 +30,6 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
         src: string,
         type: string,
         name: string,
-        canonicalName: string,
         scope: number,
         visibility: string,
         members: Iterable<VariableDeclaration>,
@@ -44,7 +39,6 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
         super(id, src, type, raw);
 
         this.name = name;
-        this.canonicalName = canonicalName;
         this.scope = scope;
         this.visibility = visibility;
         this.nameLocation = nameLocation;
@@ -52,6 +46,13 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
         for (const member of members) {
             this.appendChild(member);
         }
+    }
+
+    /**
+     * Canonical name (or qualified name), e.g. `DefiningContract.SomeStruct`
+     */
+    get canonicalName(): string {
+        return getUserDefinedTypeFQName(this);
     }
 
     /**

--- a/src/ast/implementation/declaration/user_defined_value_type_definition.ts
+++ b/src/ast/implementation/declaration/user_defined_value_type_definition.ts
@@ -1,3 +1,4 @@
+import { getUserDefinedTypeFQName } from "../../..";
 import { ASTNode } from "../../ast_node";
 import { SourceUnit } from "../meta/source_unit";
 import { ElementaryTypeName } from "../type/elementary_type_name";
@@ -8,12 +9,6 @@ export class UserDefinedValueTypeDefinition extends ASTNode {
      * The name of the user-defined value type definition
      */
     name: string;
-
-    /**
-     * Canonical name (or qualified name), e.g. `DefiningContract.SomeType`.
-     * Is `undefined` for Solidity 0.8.8. Available since Solidity 0.8.9.
-     */
-    canonicalName?: string;
 
     /**
      * The source range for name string
@@ -30,7 +25,6 @@ export class UserDefinedValueTypeDefinition extends ASTNode {
         src: string,
         type: string,
         name: string,
-        canonicalName: string | undefined,
         underlyingType: ElementaryTypeName,
         nameLocation?: string,
         raw?: any
@@ -38,7 +32,6 @@ export class UserDefinedValueTypeDefinition extends ASTNode {
         super(id, src, type, raw);
 
         this.name = name;
-        this.canonicalName = canonicalName;
         this.underlyingType = underlyingType;
         this.nameLocation = nameLocation;
 
@@ -47,6 +40,13 @@ export class UserDefinedValueTypeDefinition extends ASTNode {
 
     get children(): readonly ASTNode[] {
         return this.pickNodes(this.underlyingType);
+    }
+
+    /**
+     * Canonical name (or qualified name), e.g. `DefiningContract.SomeType`
+     */
+    get canonicalName(): string {
+        return getUserDefinedTypeFQName(this);
     }
 
     /**

--- a/src/ast/legacy/enum_definition_processor.ts
+++ b/src/ast/legacy/enum_definition_processor.ts
@@ -14,8 +14,7 @@ export class LegacyEnumDefinitionProcessor extends LegacyNodeProcessor<EnumDefin
         const members = reader.convertArray(raw.children, config) as EnumValue[];
 
         const name: string = attributes.name;
-        const canonicalName: string = attributes.canonicalName;
 
-        return [id, src, type, name, canonicalName, members, undefined, raw];
+        return [id, src, type, name, members, undefined, raw];
     }
 }

--- a/src/ast/legacy/struct_definition_processor.ts
+++ b/src/ast/legacy/struct_definition_processor.ts
@@ -14,10 +14,9 @@ export class LegacyStructDefinitionProcessor extends LegacyNodeProcessor<StructD
         const members = reader.convertArray(raw.children, config) as VariableDeclaration[];
 
         const name: string = attributes.name;
-        const canonicalName: string = attributes.canonicalName;
         const scope: number = attributes.scope;
         const visibility: string = attributes.visibility;
 
-        return [id, src, type, name, canonicalName, scope, visibility, members, undefined, raw];
+        return [id, src, type, name, scope, visibility, members, undefined, raw];
     }
 }

--- a/src/ast/modern/enum_definition_processor.ts
+++ b/src/ast/modern/enum_definition_processor.ts
@@ -12,11 +12,10 @@ export class ModernEnumDefinitionProcessor extends ModernNodeProcessor<EnumDefin
         const [id, src, type] = super.process(reader, config, raw);
 
         const name: string = raw.name;
-        const canonicalName: string = raw.canonicalName;
         const nameLocation: string | undefined = raw.nameLocation;
 
         const members = reader.convertArray(raw.members, config) as EnumValue[];
 
-        return [id, src, type, name, canonicalName, members, nameLocation, raw];
+        return [id, src, type, name, members, nameLocation, raw];
     }
 }

--- a/src/ast/modern/struct_definition_processor.ts
+++ b/src/ast/modern/struct_definition_processor.ts
@@ -12,13 +12,12 @@ export class ModernStructDefinitionProcessor extends ModernNodeProcessor<StructD
         const [id, src, type] = super.process(reader, config, raw);
 
         const name: string = raw.name;
-        const canonicalName: string = raw.canonicalName;
         const scope: number = raw.scope;
         const visibility: string = raw.visibility;
         const nameLocation: string | undefined = raw.nameLocation;
 
         const members = reader.convertArray(raw.members, config) as VariableDeclaration[];
 
-        return [id, src, type, name, canonicalName, scope, visibility, members, nameLocation, raw];
+        return [id, src, type, name, scope, visibility, members, nameLocation, raw];
     }
 }

--- a/src/ast/modern/user_defined_value_type_definition_processor.ts
+++ b/src/ast/modern/user_defined_value_type_definition_processor.ts
@@ -12,10 +12,9 @@ export class ModernUserDefinedValueTypeDefinitionProcessor extends ModernNodePro
         const [id, src, type] = super.process(reader, config, raw);
 
         const name: string = raw.name;
-        const canonicalName: string = raw.canonicalName;
         const nameLocation: string | undefined = raw.nameLocation;
         const underlyingType = reader.convert(raw.underlyingType, config) as ElementaryTypeName;
 
-        return [id, src, type, name, canonicalName, underlyingType, nameLocation, raw];
+        return [id, src, type, name, underlyingType, nameLocation, raw];
     }
 }

--- a/test/integration/factory/copy.spec.ts
+++ b/test/integration/factory/copy.spec.ts
@@ -52,7 +52,7 @@ describe(`ASTNodeFactory.copy() validation`, () => {
                     .replace(new RegExp(process.cwd(), "g"), ".");
 
                 // Uncomment next line to update snapshots
-                // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+                fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
 
                 const content = fse.readFileSync(snapshot, { encoding: "utf-8" });
 

--- a/test/integration/factory/copy.spec.ts
+++ b/test/integration/factory/copy.spec.ts
@@ -52,7 +52,7 @@ describe(`ASTNodeFactory.copy() validation`, () => {
                     .replace(new RegExp(process.cwd(), "g"), ".");
 
                 // Uncomment next line to update snapshots
-                fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+                // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
 
                 const content = fse.readFileSync(snapshot, { encoding: "utf-8" });
 

--- a/test/samples/solidity/declarations/contract_050.nodes.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.txt
@@ -781,12 +781,12 @@ SourceUnit #146
             src: "0:0:0"
             type: "StructDefinition"
             name: "St"
-            canonicalName: "C.St"
             scope: 145
             visibility: "public"
             nameLocation: undefined
             context: ASTContext #1000
             parent: ContractDefinition #145
+            <getter> canonicalName: "C.St"
             <getter> vMembers: Array(1) [ VariableDeclaration #108 ]
             <getter> vScope: ContractDefinition #145
             <getter> children: Array(1) [ VariableDeclaration #108 ]
@@ -848,10 +848,10 @@ SourceUnit #146
             src: "0:0:0"
             type: "EnumDefinition"
             name: "En"
-            canonicalName: "C.En"
             nameLocation: undefined
             context: ASTContext #1000
             parent: ContractDefinition #145
+            <getter> canonicalName: "C.En"
             <getter> vMembers: Array(3) [ EnumValue #110, EnumValue #111, EnumValue #112 ]
             <getter> vScope: ContractDefinition #145
             <getter> children: Array(3) [ EnumValue #110, EnumValue #111, EnumValue #112 ]

--- a/test/samples/solidity/latest_08.nodes.txt
+++ b/test/samples/solidity/latest_08.nodes.txt
@@ -87,10 +87,10 @@ SourceUnit #959
         src: "0:0:0"
         type: "EnumDefinition"
         name: "EnumABC"
-        canonicalName: "EnumABC"
         nameLocation: "91:7:0"
         context: ASTContext #1000
         parent: SourceUnit #959
+        <getter> canonicalName: "EnumABC"
         <getter> vMembers: Array(3) [ EnumValue #494, EnumValue #495, EnumValue #496 ]
         <getter> vScope: SourceUnit #959
         <getter> children: Array(3) [ EnumValue #494, EnumValue #495, EnumValue #496 ]
@@ -2866,10 +2866,10 @@ SourceUnit #959
             src: "0:0:0"
             type: "EnumDefinition"
             name: "EnumXYZ"
-            canonicalName: "Features082.EnumXYZ"
             nameLocation: "1379:7:0"
             context: ASTContext #1000
             parent: ContractDefinition #713
+            <getter> canonicalName: "Features082.EnumXYZ"
             <getter> vMembers: Array(3) [ EnumValue #633, EnumValue #634, EnumValue #635 ]
             <getter> vScope: ContractDefinition #713
             <getter> children: Array(3) [ EnumValue #633, EnumValue #634, EnumValue #635 ]
@@ -6080,12 +6080,12 @@ SourceUnit #959
         src: "0:0:0"
         type: "UserDefinedValueTypeDefinition"
         name: "Price"
-        canonicalName: "Price"
         underlyingType: ElementaryTypeName #800
         nameLocation: "4739:5:0"
         context: ASTContext #1000
         parent: SourceUnit #959
         <getter> children: Array(1) [ ElementaryTypeName #800 ]
+        <getter> canonicalName: "Price"
         <getter> vScope: SourceUnit #959
         <getter> firstChild: ElementaryTypeName #800
         <getter> lastChild: ElementaryTypeName #800
@@ -6116,12 +6116,12 @@ SourceUnit #959
         src: "0:0:0"
         type: "UserDefinedValueTypeDefinition"
         name: "Quantity"
-        canonicalName: "Quantity"
         underlyingType: ElementaryTypeName #802
         nameLocation: "4762:8:0"
         context: ASTContext #1000
         parent: SourceUnit #959
         <getter> children: Array(1) [ ElementaryTypeName #802 ]
+        <getter> canonicalName: "Quantity"
         <getter> vScope: SourceUnit #959
         <getter> firstChild: ElementaryTypeName #802
         <getter> lastChild: ElementaryTypeName #802
@@ -6190,12 +6190,12 @@ SourceUnit #959
             src: "0:0:0"
             type: "UserDefinedValueTypeDefinition"
             name: "UFixed"
-            canonicalName: "LibWithUDVT_088.UFixed"
             underlyingType: ElementaryTypeName #804
             nameLocation: "4819:6:0"
             context: ASTContext #1000
             parent: ContractDefinition #891
             <getter> children: Array(1) [ ElementaryTypeName #804 ]
+            <getter> canonicalName: "LibWithUDVT_088.UFixed"
             <getter> vScope: ContractDefinition #891
             <getter> firstChild: ElementaryTypeName #804
             <getter> lastChild: ElementaryTypeName #804
@@ -8000,12 +8000,12 @@ SourceUnit #959
             src: "0:0:0"
             type: "UserDefinedValueTypeDefinition"
             name: "EntityReference"
-            canonicalName: "InterfaceWithUDTV_088.EntityReference"
             underlyingType: ElementaryTypeName #892
             nameLocation: "5483:15:0"
             context: ASTContext #1000
             parent: ContractDefinition #902
             <getter> children: Array(1) [ ElementaryTypeName #892 ]
+            <getter> canonicalName: "InterfaceWithUDTV_088.EntityReference"
             <getter> vScope: ContractDefinition #902
             <getter> firstChild: ElementaryTypeName #892
             <getter> lastChild: ElementaryTypeName #892
@@ -9455,12 +9455,12 @@ SourceUnit #975
             src: "0:0:0"
             type: "StructDefinition"
             name: "SomeStruct"
-            canonicalName: "SomeContract.SomeStruct"
             scope: 973
             visibility: "public"
             nameLocation: "80:10:1"
             context: ASTContext #1000
             parent: ContractDefinition #973
+            <getter> canonicalName: "SomeContract.SomeStruct"
             <getter> vMembers: Array(1) [ VariableDeclaration #963 ]
             <getter> vScope: ContractDefinition #973
             <getter> children: Array(1) [ VariableDeclaration #963 ]

--- a/test/unit/ast/ast_node_factory/copy.spec.ts
+++ b/test/unit/ast/ast_node_factory/copy.spec.ts
@@ -62,7 +62,7 @@ describe("ASTNodeFactory.copy()", () => {
         const factory = new ASTNodeFactory();
 
         const value = factory.makeEnumValue("MyValue");
-        const definition = factory.makeEnumDefinition("MyEnum", "Some.MyEnum", [value]);
+        const definition = factory.makeEnumDefinition("MyEnum", [value]);
 
         const defCopy = factory.copy(definition);
         const valCopy = defCopy.vMembers[0];
@@ -78,7 +78,7 @@ describe("ASTNodeFactory.copy()", () => {
             raw: undefined,
 
             name: "MyEnum",
-            canonicalName: "Some.MyEnum",
+            canonicalName: "MyEnum",
             vMembers: [valCopy],
 
             vScope: undefined
@@ -296,7 +296,6 @@ describe("ASTNodeFactory.copy()", () => {
 
         const struct = factory.makeStructDefinition(
             "MyStruct",
-            "Test.MyStruct",
             contract.id,
             FunctionVisibility.Internal,
             []

--- a/test/unit/ast/ast_node_factory/make.spec.ts
+++ b/test/unit/ast/ast_node_factory/make.spec.ts
@@ -111,7 +111,7 @@ describe("ASTNodeFactory.make*()", () => {
     it("makeEnumDefinition()", () => {
         const factory = new ASTNodeFactory();
         const value = factory.makeEnumValue("MyValue");
-        const node = factory.makeEnumDefinition("MyEnum", "MyContract.MyEnum", [value]);
+        const node = factory.makeEnumDefinition("MyEnum", [value]);
 
         verify(node, EnumDefinition, {
             id: 2,
@@ -121,7 +121,7 @@ describe("ASTNodeFactory.make*()", () => {
             raw: undefined,
 
             name: "MyEnum",
-            canonicalName: "MyContract.MyEnum",
+            canonicalName: "MyEnum",
             vMembers: [value]
         });
     });
@@ -257,13 +257,7 @@ describe("ASTNodeFactory.make*()", () => {
     it("makeStructDefinition()", () => {
         const factory = new ASTNodeFactory();
         const unit = factory.makeSourceUnit("sample.sol", 0, "path/to/sample.sol", new Map());
-        const node = factory.makeStructDefinition(
-            "MyStruct",
-            "MyContract.MyStruct",
-            unit.id,
-            "internal",
-            []
-        );
+        const node = factory.makeStructDefinition("MyStruct", unit.id, "internal", []);
 
         verify(node, StructDefinition, {
             id: 2,
@@ -273,7 +267,7 @@ describe("ASTNodeFactory.make*()", () => {
             raw: undefined,
 
             name: "MyStruct",
-            canonicalName: "MyContract.MyStruct",
+            canonicalName: "MyStruct",
             scope: unit.id,
             visibility: "internal",
             vMembers: [],

--- a/test/unit/ast/nodes/contract_definition.spec.ts
+++ b/test/unit/ast/nodes/contract_definition.spec.ts
@@ -59,14 +59,7 @@ describe("ContractDefinition", () => {
 
     describe("removeChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
 
             const contract = new ContractDefinition(
                 2,
@@ -98,23 +91,8 @@ describe("ContractDefinition", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
@@ -149,23 +127,8 @@ describe("ContractDefinition", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
@@ -200,32 +163,9 @@ describe("ContractDefinition", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "MyContract.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
@@ -262,23 +202,8 @@ describe("ContractDefinition", () => {
 
     describe("insertBefore()", () => {
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
@@ -312,32 +237,9 @@ describe("ContractDefinition", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "MyContract.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
@@ -374,23 +276,8 @@ describe("ContractDefinition", () => {
 
     describe("insertAfter()", () => {
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
@@ -424,32 +311,9 @@ describe("ContractDefinition", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "MyContract.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
@@ -483,23 +347,8 @@ describe("ContractDefinition", () => {
 
     describe("replaceChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
@@ -531,41 +380,10 @@ describe("ContractDefinition", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "MyContract.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "MyContract.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "MyContract.MyEnum3",
-                []
-            );
-
-            const myEnum4 = new EnumDefinition(
-                4,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum4",
-                "MyContract.MyEnum4",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum4 = new EnumDefinition(4, "0:0:0", "EnumDefinition", "MyEnum4", []);
 
             const contract = new ContractDefinition(
                 5,

--- a/test/unit/ast/nodes/source_unit.spec.ts
+++ b/test/unit/ast/nodes/source_unit.spec.ts
@@ -4,14 +4,7 @@ import { EnumDefinition, SourceUnit } from "../../../../src";
 describe("SourceUnit", () => {
     describe("removeChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
 
             const unit = new SourceUnit(
                 2,
@@ -39,23 +32,8 @@ describe("SourceUnit", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
@@ -86,23 +64,8 @@ describe("SourceUnit", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
@@ -133,32 +96,9 @@ describe("SourceUnit", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "Myunit.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
@@ -191,23 +131,8 @@ describe("SourceUnit", () => {
 
     describe("insertBefore()", () => {
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
@@ -237,32 +162,9 @@ describe("SourceUnit", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "Myunit.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
@@ -295,23 +197,8 @@ describe("SourceUnit", () => {
 
     describe("insertAfter()", () => {
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
@@ -341,32 +228,9 @@ describe("SourceUnit", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "Myunit.MyEnum3",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
@@ -396,23 +260,8 @@ describe("SourceUnit", () => {
 
     describe("replaceChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
@@ -440,41 +289,10 @@ describe("SourceUnit", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(
-                1,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum1",
-                "Myunit.MyEnum1",
-                []
-            );
-
-            const myEnum2 = new EnumDefinition(
-                2,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum2",
-                "Myunit.MyEnum2",
-                []
-            );
-
-            const myEnum3 = new EnumDefinition(
-                3,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum3",
-                "Myunit.MyEnum3",
-                []
-            );
-
-            const myEnum4 = new EnumDefinition(
-                4,
-                "0:0:0",
-                "EnumDefinition",
-                "MyEnum4",
-                "Myunit.MyEnum4",
-                []
-            );
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum4 = new EnumDefinition(4, "0:0:0", "EnumDefinition", "MyEnum4", []);
 
             const unit = new SourceUnit(
                 5,

--- a/test/unit/ast/nodes/struct_definition.spec.ts
+++ b/test/unit/ast/nodes/struct_definition.spec.ts
@@ -29,7 +29,6 @@ describe("StructDefinition", () => {
             "0:0:0",
             "StructDefinition",
             "MyStruct",
-            "MyStruct",
             0,
             "internal",
             []

--- a/test/unit/ast/nodes/user_defined_type_name.spec.ts
+++ b/test/unit/ast/nodes/user_defined_type_name.spec.ts
@@ -10,7 +10,6 @@ describe("UserDefinedTypeName", () => {
             "0:0:0",
             "StructDefinition",
             "MyStruct",
-            "MyStruct",
             0,
             "internal",
             []
@@ -20,7 +19,6 @@ describe("UserDefinedTypeName", () => {
             2,
             "0:0:0",
             "StructDefinition",
-            "OtherStruct",
             "OtherStruct",
             0,
             "internal",


### PR DESCRIPTION
## Tickets
- Closes #80 

## Changes
- [x] Introduced `canonicalName` as getter for `EnumDefinition`, `StructDefinition` and `UserDefinedValueTypeDefinition`.
- [x]  Added `UserDefinedValueTypeDefinition` as a `target` type for `ASTNodeFactory.makeIdentifierFor()`.
- [x] Tweaked affected tests.

## Notes
There are constructor signature changes for `EnumDefinition`, `StructDefinition` and `UserDefinedValueTypeDefinition` as the `canonicalName` is no longer passed as an argument. This would break backward compatibility.

Regards.