### PR TITLE
Remove `type` argument from `ASTNode` constructor

### DIFF
--- a/src/ast/ast_node.ts
+++ b/src/ast/ast_node.ts
@@ -33,11 +33,6 @@ export class ASTNode {
     src: string;
 
     /**
-     * Type of the AST node
-     */
-    type: string;
-
-    /**
      * Raw original Solc AST node that was used to create current node.
      */
     raw?: any;
@@ -47,10 +42,9 @@ export class ASTNode {
      */
     parent?: ASTNode;
 
-    constructor(id: number, src: string, type: string, raw?: any) {
+    constructor(id: number, src: string, raw?: any) {
         this.id = id;
         this.src = src;
-        this.type = type;
         this.raw = raw;
     }
 
@@ -77,6 +71,13 @@ export class ASTNode {
         for (const node of this.children) {
             node.parent = this;
         }
+    }
+
+    /**
+     * Type of the AST node
+     */
+    get type(): string {
+        return this.constructor.name;
     }
 
     /**
@@ -424,7 +425,6 @@ export class ASTNodeWithChildren<T extends ASTNode> extends ASTNode {
 export type ASTNodeConstructor<T extends ASTNode> = new (
     id: number,
     src: string,
-    type: string,
     ...args: any[]
 ) => T;
 

--- a/src/ast/ast_node_factory.ts
+++ b/src/ast/ast_node_factory.ts
@@ -77,12 +77,7 @@ import { UserDefinedTypeName } from "./implementation/type/user_defined_type_nam
  */
 type Specific<Args extends any[]> = Args["length"] extends 0
     ? undefined
-    : ((...args: Args) => void) extends (
-          id: number,
-          src: string,
-          type: string,
-          ...rest: infer Rest
-      ) => void
+    : ((...args: Args) => void) extends (id: number, src: string, ...rest: infer Rest) => void
     ? Rest
     : [];
 
@@ -1091,7 +1086,7 @@ export class ASTNodeFactory {
         type: ASTNodeConstructor<T>,
         ...args: Specific<ConstructorParameters<typeof type>>
     ): T {
-        const node = new type(++this.lastId, "0:0:0", type.name, ...args);
+        const node = new type(++this.lastId, "0:0:0", ...args);
 
         this.context.register(node);
 

--- a/src/ast/ast_node_formatter.ts
+++ b/src/ast/ast_node_formatter.ts
@@ -15,10 +15,7 @@ export class ASTNodeFormatter {
     }
 
     private formatNodeValue(node: ASTNode): string {
-        const name = node.constructor.name;
-        const result = `${name} #${node.id}`;
-
-        return name === node.type ? result : `${result} = ${node.type}`;
+        return `${node.type} #${node.id}`;
     }
 
     private formatArrayValue(array: any[]): string {

--- a/src/ast/implementation/declaration/contract_definition.ts
+++ b/src/ast/implementation/declaration/contract_definition.ts
@@ -65,7 +65,6 @@ export class ContractDefinition extends ASTNodeWithChildren<ASTNode> {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         scope: number,
         kind: ContractKind,
@@ -78,7 +77,7 @@ export class ContractDefinition extends ASTNodeWithChildren<ASTNode> {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
         this.scope = scope;

--- a/src/ast/implementation/declaration/enum_definition.ts
+++ b/src/ast/implementation/declaration/enum_definition.ts
@@ -18,13 +18,12 @@ export class EnumDefinition extends ASTNodeWithChildren<EnumValue> {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         members: Iterable<EnumValue>,
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
 

--- a/src/ast/implementation/declaration/enum_value.ts
+++ b/src/ast/implementation/declaration/enum_value.ts
@@ -11,15 +11,8 @@ export class EnumValue extends ASTNode {
      */
     nameLocation?: string;
 
-    constructor(
-        id: number,
-        src: string,
-        type: string,
-        name: string,
-        nameLocation?: string,
-        raw?: any
-    ) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, name: string, nameLocation?: string, raw?: any) {
+        super(id, src, raw);
 
         this.name = name;
         this.nameLocation = nameLocation;

--- a/src/ast/implementation/declaration/error_definition.ts
+++ b/src/ast/implementation/declaration/error_definition.ts
@@ -33,14 +33,13 @@ export class ErrorDefinition extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         parameters: ParameterList,
         documentation?: string | StructuredDocumentation,
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
         this.documentation = documentation;

--- a/src/ast/implementation/declaration/event_definition.ts
+++ b/src/ast/implementation/declaration/event_definition.ts
@@ -38,7 +38,6 @@ export class EventDefinition extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         anonymous: boolean,
         name: string,
         parameters: ParameterList,
@@ -46,7 +45,7 @@ export class EventDefinition extends ASTNode {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.anonymous = anonymous;
         this.name = name;

--- a/src/ast/implementation/declaration/function_definition.ts
+++ b/src/ast/implementation/declaration/function_definition.ts
@@ -104,7 +104,6 @@ export class FunctionDefinition extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         scope: number,
         kind: FunctionKind,
         name: string,
@@ -121,7 +120,7 @@ export class FunctionDefinition extends ASTNode {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.implemented = body !== undefined;
         this.virtual = virtual;

--- a/src/ast/implementation/declaration/modifier_definition.ts
+++ b/src/ast/implementation/declaration/modifier_definition.ts
@@ -57,7 +57,6 @@ export class ModifierDefinition extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         virtual: boolean,
         visibility: string,
@@ -68,7 +67,7 @@ export class ModifierDefinition extends ASTNode {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
         this.virtual = virtual;

--- a/src/ast/implementation/declaration/struct_definition.ts
+++ b/src/ast/implementation/declaration/struct_definition.ts
@@ -28,7 +28,6 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         scope: number,
         visibility: string,
@@ -36,7 +35,7 @@ export class StructDefinition extends ASTNodeWithChildren<VariableDeclaration> {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
         this.scope = scope;

--- a/src/ast/implementation/declaration/user_defined_value_type_definition.ts
+++ b/src/ast/implementation/declaration/user_defined_value_type_definition.ts
@@ -23,13 +23,12 @@ export class UserDefinedValueTypeDefinition extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         name: string,
         underlyingType: ElementaryTypeName,
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.name = name;
         this.underlyingType = underlyingType;

--- a/src/ast/implementation/declaration/variable_declaration.ts
+++ b/src/ast/implementation/declaration/variable_declaration.ts
@@ -113,7 +113,6 @@ export class VariableDeclaration extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         constant: boolean,
         indexed: boolean,
         name: string,
@@ -130,7 +129,7 @@ export class VariableDeclaration extends ASTNode {
         nameLocation?: string,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.constant = constant;
         this.indexed = indexed;

--- a/src/ast/implementation/expression/assignment.ts
+++ b/src/ast/implementation/expression/assignment.ts
@@ -20,14 +20,13 @@ export class Assignment extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         operator: string,
         leftHandSide: Expression,
         rightHandSide: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.operator = operator;
 

--- a/src/ast/implementation/expression/binary_operation.ts
+++ b/src/ast/implementation/expression/binary_operation.ts
@@ -20,14 +20,13 @@ export class BinaryOperation extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         operator: string,
         leftExpression: Expression,
         rightExpression: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.operator = operator;
 

--- a/src/ast/implementation/expression/conditional.ts
+++ b/src/ast/implementation/expression/conditional.ts
@@ -24,14 +24,13 @@ export class Conditional extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         condition: Expression,
         trueExpression: Expression,
         falseExpression: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vCondition = condition;
         this.vTrueExpression = trueExpression;

--- a/src/ast/implementation/expression/elementary_type_name_expression.ts
+++ b/src/ast/implementation/expression/elementary_type_name_expression.ts
@@ -14,12 +14,11 @@ export class ElementaryTypeNameExpression extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         typeName: string | ElementaryTypeName,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.typeName = typeName;
 

--- a/src/ast/implementation/expression/expression.ts
+++ b/src/ast/implementation/expression/expression.ts
@@ -6,8 +6,8 @@ export class Expression extends ASTNode {
      */
     typeString: string;
 
-    constructor(id: number, src: string, type: string, typeString: string, raw?: any) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, typeString: string, raw?: any) {
+        super(id, src, raw);
 
         this.typeString = typeString;
     }
@@ -16,7 +16,6 @@ export class Expression extends ASTNode {
 export type ExpressionConstructor<T extends Expression> = new (
     id: number,
     src: string,
-    type: string,
     typeString: string,
     ...args: any[]
 ) => T;

--- a/src/ast/implementation/expression/function_call.ts
+++ b/src/ast/implementation/expression/function_call.ts
@@ -46,7 +46,6 @@ export class FunctionCall extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         kind: FunctionCallKind,
         expression: Expression,
@@ -54,7 +53,7 @@ export class FunctionCall extends Expression {
         fieldNames?: string[],
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.kind = kind;
         this.fieldNames = fieldNames;

--- a/src/ast/implementation/expression/function_call_options.ts
+++ b/src/ast/implementation/expression/function_call_options.ts
@@ -19,13 +19,12 @@ export class FunctionCallOptions extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         expression: Expression,
         options: Map<string, Expression>,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vExpression = expression;
         this.vOptionsMap = options;

--- a/src/ast/implementation/expression/identifier.ts
+++ b/src/ast/implementation/expression/identifier.ts
@@ -16,13 +16,12 @@ export class Identifier extends PrimaryExpression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         name: string,
         referencedDeclaration: number,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.name = name;
         this.referencedDeclaration = referencedDeclaration;

--- a/src/ast/implementation/expression/index_access.ts
+++ b/src/ast/implementation/expression/index_access.ts
@@ -18,13 +18,12 @@ export class IndexAccess extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         baseExpression: Expression,
         indexExpression?: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vBaseExpression = baseExpression;
         this.vIndexExpression = indexExpression;

--- a/src/ast/implementation/expression/index_range_access.ts
+++ b/src/ast/implementation/expression/index_range_access.ts
@@ -22,14 +22,13 @@ export class IndexRangeAccess extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         baseExpression: Expression,
         startExpression?: Expression,
         endExpression?: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vBaseExpression = baseExpression;
         this.vStartExpression = startExpression;

--- a/src/ast/implementation/expression/literal.ts
+++ b/src/ast/implementation/expression/literal.ts
@@ -31,7 +31,6 @@ export class Literal extends PrimaryExpression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         kind: LiteralKind,
         hexValue: string,
@@ -39,7 +38,7 @@ export class Literal extends PrimaryExpression {
         subdenomination?: TimeUnit | EtherUnit,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.kind = kind;
         this.hexValue = hexValue;

--- a/src/ast/implementation/expression/member_access.ts
+++ b/src/ast/implementation/expression/member_access.ts
@@ -20,14 +20,13 @@ export class MemberAccess extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         expression: Expression,
         memberName: string,
         referencedDeclaration: number,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vExpression = expression;
         this.memberName = memberName;

--- a/src/ast/implementation/expression/new_expression.ts
+++ b/src/ast/implementation/expression/new_expression.ts
@@ -8,15 +8,8 @@ export class NewExpression extends Expression {
      */
     vTypeName: TypeName;
 
-    constructor(
-        id: number,
-        src: string,
-        type: string,
-        typeString: string,
-        typeName: TypeName,
-        raw?: any
-    ) {
-        super(id, src, type, typeString, raw);
+    constructor(id: number, src: string, typeString: string, typeName: TypeName, raw?: any) {
+        super(id, src, typeString, raw);
 
         this.vTypeName = typeName;
 

--- a/src/ast/implementation/expression/tuple_expression.ts
+++ b/src/ast/implementation/expression/tuple_expression.ts
@@ -17,13 +17,12 @@ export class TupleExpression extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         isInlineArray: boolean,
         components: Array<Expression | null>,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.isInlineArray = isInlineArray;
         this.vOriginalComponents = components;

--- a/src/ast/implementation/expression/unary_operation.ts
+++ b/src/ast/implementation/expression/unary_operation.ts
@@ -24,14 +24,13 @@ export class UnaryOperation extends Expression {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         prefix: boolean,
         operator: string,
         subExpression: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.prefix = prefix;
         this.operator = operator;

--- a/src/ast/implementation/meta/identifier_path.ts
+++ b/src/ast/implementation/meta/identifier_path.ts
@@ -11,15 +11,8 @@ export class IdentifierPath extends ASTNode {
      */
     referencedDeclaration: number;
 
-    constructor(
-        id: number,
-        src: string,
-        type: string,
-        name: string,
-        referencedDeclaration: number,
-        raw?: any
-    ) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, name: string, referencedDeclaration: number, raw?: any) {
+        super(id, src, raw);
 
         this.name = name;
         this.referencedDeclaration = referencedDeclaration;

--- a/src/ast/implementation/meta/import_directive.ts
+++ b/src/ast/implementation/meta/import_directive.ts
@@ -46,7 +46,6 @@ export class ImportDirective extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         file: string,
         absolutePath: string,
         unitAlias: string,
@@ -55,7 +54,7 @@ export class ImportDirective extends ASTNode {
         sourceUnit: number,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.file = file;
         this.absolutePath = absolutePath;

--- a/src/ast/implementation/meta/inheritance_specifier.ts
+++ b/src/ast/implementation/meta/inheritance_specifier.ts
@@ -17,12 +17,11 @@ export class InheritanceSpecifier extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         baseType: UserDefinedTypeName | IdentifierPath,
         args: Expression[],
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.vBaseType = baseType;
         this.vArguments = args;

--- a/src/ast/implementation/meta/modifier_invocation.ts
+++ b/src/ast/implementation/meta/modifier_invocation.ts
@@ -29,13 +29,12 @@ export class ModifierInvocation extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         modifierName: Identifier | IdentifierPath,
         args: Expression[],
         kind?: ModifierInvocationKind,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.kind = kind;
 

--- a/src/ast/implementation/meta/override_specifier.ts
+++ b/src/ast/implementation/meta/override_specifier.ts
@@ -6,11 +6,10 @@ export class OverrideSpecifier extends ASTNodeWithChildren<UserDefinedTypeName |
     constructor(
         id: number,
         src: string,
-        type: string,
         overrides: Iterable<UserDefinedTypeName | IdentifierPath>,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         for (const override of overrides) {
             this.appendChild(override);

--- a/src/ast/implementation/meta/parameter_list.ts
+++ b/src/ast/implementation/meta/parameter_list.ts
@@ -2,14 +2,8 @@ import { ASTNodeWithChildren } from "../../ast_node";
 import { VariableDeclaration } from "../declaration/variable_declaration";
 
 export class ParameterList extends ASTNodeWithChildren<VariableDeclaration> {
-    constructor(
-        id: number,
-        src: string,
-        type: string,
-        parameters: Iterable<VariableDeclaration>,
-        raw?: any
-    ) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, parameters: Iterable<VariableDeclaration>, raw?: any) {
+        super(id, src, raw);
 
         for (const parameter of parameters) {
             this.appendChild(parameter);

--- a/src/ast/implementation/meta/pragma_directive.ts
+++ b/src/ast/implementation/meta/pragma_directive.ts
@@ -7,8 +7,8 @@ export class PragmaDirective extends ASTNode {
      */
     literals: string[];
 
-    constructor(id: number, src: string, type: string, literals: string[], raw?: any) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, literals: string[], raw?: any) {
+        super(id, src, raw);
 
         this.literals = literals;
     }

--- a/src/ast/implementation/meta/source_unit.ts
+++ b/src/ast/implementation/meta/source_unit.ts
@@ -43,7 +43,6 @@ export class SourceUnit extends ASTNodeWithChildren<ASTNode> {
     constructor(
         id: number,
         src: string,
-        type: string,
         sourceEntryKey: string,
         sourceListIndex: number,
         absolutePath: string,
@@ -51,7 +50,7 @@ export class SourceUnit extends ASTNodeWithChildren<ASTNode> {
         children?: Iterable<ASTNode>,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.sourceEntryKey = sourceEntryKey;
         this.sourceListIndex = sourceListIndex;

--- a/src/ast/implementation/meta/structured_documentation.ts
+++ b/src/ast/implementation/meta/structured_documentation.ts
@@ -6,8 +6,8 @@ export class StructuredDocumentation extends ASTNode {
      */
     text: string;
 
-    constructor(id: number, src: string, type: string, text: string, raw?: any) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, text: string, raw?: any) {
+        super(id, src, raw);
 
         this.text = text;
     }

--- a/src/ast/implementation/meta/using_for_directive.ts
+++ b/src/ast/implementation/meta/using_for_directive.ts
@@ -17,12 +17,11 @@ export class UsingForDirective extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         libraryName: UserDefinedTypeName | IdentifierPath,
         typeName?: TypeName,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.vLibraryName = libraryName;
         this.vTypeName = typeName;

--- a/src/ast/implementation/statement/block.ts
+++ b/src/ast/implementation/statement/block.ts
@@ -8,12 +8,11 @@ export class Block extends StatementWithChildren<Statement> {
     constructor(
         id: number,
         src: string,
-        type: string,
         statements: Iterable<Statement>,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         for (const statement of statements) {
             this.appendChild(statement);

--- a/src/ast/implementation/statement/do_while_statement.ts
+++ b/src/ast/implementation/statement/do_while_statement.ts
@@ -17,13 +17,12 @@ export class DoWhileStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         condition: Expression,
         body: Statement,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vCondition = condition;
         this.vBody = body;

--- a/src/ast/implementation/statement/emit_statement.ts
+++ b/src/ast/implementation/statement/emit_statement.ts
@@ -12,12 +12,11 @@ export class EmitStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         eventCall: FunctionCall,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vEventCall = eventCall;
 

--- a/src/ast/implementation/statement/expression_statement.ts
+++ b/src/ast/implementation/statement/expression_statement.ts
@@ -15,12 +15,11 @@ export class ExpressionStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         expression: Expression,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vExpression = expression;
 

--- a/src/ast/implementation/statement/for_statement.ts
+++ b/src/ast/implementation/statement/for_statement.ts
@@ -30,7 +30,6 @@ export class ForStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         body: Statement,
         initializationExpression?: VariableDeclarationStatement | ExpressionStatement,
         condition?: Expression,
@@ -38,7 +37,7 @@ export class ForStatement extends Statement {
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vInitializationExpression = initializationExpression;
         this.vCondition = condition;

--- a/src/ast/implementation/statement/if_statement.ts
+++ b/src/ast/implementation/statement/if_statement.ts
@@ -22,14 +22,13 @@ export class IfStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         condition: Expression,
         trueBody: Statement,
         falseBody?: Statement,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vCondition = condition;
         this.vTrueBody = trueBody;

--- a/src/ast/implementation/statement/inline_assembly.ts
+++ b/src/ast/implementation/statement/inline_assembly.ts
@@ -17,14 +17,13 @@ export class InlineAssembly extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         externalReferences: any[],
         operations?: string,
         yul?: YulNode,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.externalReferences = externalReferences;
         this.operations = operations;

--- a/src/ast/implementation/statement/return.ts
+++ b/src/ast/implementation/statement/return.ts
@@ -18,13 +18,12 @@ export class Return extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         functionReturnParameters: number,
         expression?: Expression,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.functionReturnParameters = functionReturnParameters;
 

--- a/src/ast/implementation/statement/revert_statement.ts
+++ b/src/ast/implementation/statement/revert_statement.ts
@@ -12,12 +12,11 @@ export class RevertStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         errorCall: FunctionCall,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.errorCall = errorCall;
 

--- a/src/ast/implementation/statement/statement.ts
+++ b/src/ast/implementation/statement/statement.ts
@@ -12,11 +12,10 @@ export class Statement extends ASTNode {
     constructor(
         id: number,
         src: string,
-        type: string,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.documentation = documentation;
     }
@@ -33,11 +32,10 @@ export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildre
     constructor(
         id: number,
         src: string,
-        type: string,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, raw);
+        super(id, src, raw);
 
         this.documentation = documentation;
     }

--- a/src/ast/implementation/statement/try_catch_clause.ts
+++ b/src/ast/implementation/statement/try_catch_clause.ts
@@ -23,14 +23,13 @@ export class TryCatchClause extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         errorName: string,
         block: Block,
         parameters?: ParameterList,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.errorName = errorName;
         this.vParameters = parameters;

--- a/src/ast/implementation/statement/try_statement.ts
+++ b/src/ast/implementation/statement/try_statement.ts
@@ -18,13 +18,12 @@ export class TryStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         externalCall: FunctionCall,
         clauses: TryCatchClause[],
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vExternalCall = externalCall;
         this.vClauses = clauses;

--- a/src/ast/implementation/statement/unchecked_block.ts
+++ b/src/ast/implementation/statement/unchecked_block.ts
@@ -9,12 +9,11 @@ export class UncheckedBlock extends StatementWithChildren<Statement> {
     constructor(
         id: number,
         src: string,
-        type: string,
         statements: Iterable<Statement>,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         for (const statement of statements) {
             this.appendChild(statement);

--- a/src/ast/implementation/statement/variable_declaration_statement.ts
+++ b/src/ast/implementation/statement/variable_declaration_statement.ts
@@ -25,14 +25,13 @@ export class VariableDeclarationStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         assignments: Array<number | null>,
         declarations: VariableDeclaration[],
         initialValue?: Expression,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.assignments = assignments;
         this.vDeclarations = declarations;

--- a/src/ast/implementation/statement/while_statement.ts
+++ b/src/ast/implementation/statement/while_statement.ts
@@ -17,13 +17,12 @@ export class WhileStatement extends Statement {
     constructor(
         id: number,
         src: string,
-        type: string,
         condition: Expression,
         body: Statement,
         documentation?: string | StructuredDocumentation,
         raw?: any
     ) {
-        super(id, src, type, documentation, raw);
+        super(id, src, documentation, raw);
 
         this.vCondition = condition;
         this.vBody = body;

--- a/src/ast/implementation/type/array_type_name.ts
+++ b/src/ast/implementation/type/array_type_name.ts
@@ -17,13 +17,12 @@ export class ArrayTypeName extends TypeName {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         baseType: TypeName,
         length?: Expression,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vBaseType = baseType;
         this.vLength = length;

--- a/src/ast/implementation/type/elementary_type_name.ts
+++ b/src/ast/implementation/type/elementary_type_name.ts
@@ -15,13 +15,12 @@ export class ElementaryTypeName extends TypeName {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         name: string,
         stateMutability: "nonpayable" | "payable" = "nonpayable",
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.name = name;
         this.stateMutability = stateMutability;

--- a/src/ast/implementation/type/function_type_name.ts
+++ b/src/ast/implementation/type/function_type_name.ts
@@ -28,7 +28,6 @@ export class FunctionTypeName extends TypeName {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         visibility: FunctionVisibility,
         stateMutability: FunctionStateMutability,
@@ -36,7 +35,7 @@ export class FunctionTypeName extends TypeName {
         returnParameterTypes: ParameterList,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.visibility = visibility;
         this.stateMutability = stateMutability;

--- a/src/ast/implementation/type/mapping.ts
+++ b/src/ast/implementation/type/mapping.ts
@@ -16,13 +16,12 @@ export class Mapping extends TypeName {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         keyType: TypeName,
         valueType: TypeName,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.vKeyType = keyType;
         this.vValueType = valueType;

--- a/src/ast/implementation/type/type_name.ts
+++ b/src/ast/implementation/type/type_name.ts
@@ -6,8 +6,8 @@ export class TypeName extends ASTNode {
      */
     typeString: string;
 
-    constructor(id: number, src: string, type: string, typeString: string, raw?: any) {
-        super(id, src, type, raw);
+    constructor(id: number, src: string, typeString: string, raw?: any) {
+        super(id, src, raw);
 
         this.typeString = typeString;
     }
@@ -16,7 +16,6 @@ export class TypeName extends ASTNode {
 export type TypeNameConstructor<T extends TypeName> = new (
     id: number,
     src: string,
-    type: string,
     typeString: string,
     ...args: any[]
 ) => T;

--- a/src/ast/implementation/type/user_defined_type_name.ts
+++ b/src/ast/implementation/type/user_defined_type_name.ts
@@ -21,14 +21,13 @@ export class UserDefinedTypeName extends TypeName {
     constructor(
         id: number,
         src: string,
-        type: string,
         typeString: string,
         name: string | undefined,
         referencedDeclaration: number,
         path?: IdentifierPath,
         raw?: any
     ) {
-        super(id, src, type, typeString, raw);
+        super(id, src, typeString, raw);
 
         this.name = name;
         this.referencedDeclaration = referencedDeclaration;

--- a/src/ast/legacy/array_type_name_processor.ts
+++ b/src/ast/legacy/array_type_name_processor.ts
@@ -10,13 +10,13 @@ export class LegacyArrayTypeNameProcessor extends LegacyTypeNameProcessor<ArrayT
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ArrayTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const [baseType, length] = reader.convertArray(raw.children, config) as [
             TypeName,
             Expression?
         ];
 
-        return [id, src, type, typeString, baseType, length, raw];
+        return [id, src, typeString, baseType, length, raw];
     }
 }

--- a/src/ast/legacy/assignment_processor.ts
+++ b/src/ast/legacy/assignment_processor.ts
@@ -9,7 +9,7 @@ export class LegacyAssignmentProcessor extends LegacyExpressionProcessor<Assignm
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Assignment> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const operator: string = raw.attributes.operator;
 
@@ -18,6 +18,6 @@ export class LegacyAssignmentProcessor extends LegacyExpressionProcessor<Assignm
             Expression
         ];
 
-        return [id, src, type, typeString, operator, leftHandSide, rightHandSide, raw];
+        return [id, src, typeString, operator, leftHandSide, rightHandSide, raw];
     }
 }

--- a/src/ast/legacy/binary_operation_processor.ts
+++ b/src/ast/legacy/binary_operation_processor.ts
@@ -9,7 +9,7 @@ export class LegacyBinaryOperationProcessor extends LegacyExpressionProcessor<Bi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof BinaryOperation> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const operator = raw.attributes.operator;
 
@@ -18,6 +18,6 @@ export class LegacyBinaryOperationProcessor extends LegacyExpressionProcessor<Bi
             Expression
         ];
 
-        return [id, src, type, typeString, operator, leftHandSide, rightHandSide, raw];
+        return [id, src, typeString, operator, leftHandSide, rightHandSide, raw];
     }
 }

--- a/src/ast/legacy/block_processor.ts
+++ b/src/ast/legacy/block_processor.ts
@@ -9,10 +9,10 @@ export class LegacyBlockProcessor extends LegacyNodeProcessor<Block> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Block> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const statements = reader.convertArray(raw.children, config) as Statement[];
 
-        return [id, src, type, statements, undefined, raw];
+        return [id, src, statements, undefined, raw];
     }
 }

--- a/src/ast/legacy/break_processor.ts
+++ b/src/ast/legacy/break_processor.ts
@@ -8,8 +8,8 @@ export class LegacyBreakProcessor extends LegacyNodeProcessor<Break> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Break> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
-        return [id, src, type, undefined, raw];
+        return [id, src, undefined, raw];
     }
 }

--- a/src/ast/legacy/conditional_processor.ts
+++ b/src/ast/legacy/conditional_processor.ts
@@ -9,13 +9,13 @@ export class LegacyConditionalProcessor extends LegacyExpressionProcessor<Condit
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Conditional> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const [condition, trueExpression, falseExpression] = reader.convertArray(
             raw.children,
             config
         ) as [Expression, Expression, Expression];
 
-        return [id, src, type, typeString, condition, trueExpression, falseExpression, raw];
+        return [id, src, typeString, condition, trueExpression, falseExpression, raw];
     }
 }

--- a/src/ast/legacy/continue_processor.ts
+++ b/src/ast/legacy/continue_processor.ts
@@ -8,8 +8,8 @@ export class LegacyContinueProcessor extends LegacyNodeProcessor<Continue> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Continue> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
-        return [id, src, type, undefined, raw];
+        return [id, src, undefined, raw];
     }
 }

--- a/src/ast/legacy/contract_definition_processor.ts
+++ b/src/ast/legacy/contract_definition_processor.ts
@@ -10,7 +10,7 @@ export class LegacyContractDefinitionProcessor extends LegacyNodeProcessor<Contr
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ContractDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -34,7 +34,6 @@ export class LegacyContractDefinitionProcessor extends LegacyNodeProcessor<Contr
         return [
             id,
             src,
-            type,
             name,
             scope,
             kind,

--- a/src/ast/legacy/do_while_statement_processor.ts
+++ b/src/ast/legacy/do_while_statement_processor.ts
@@ -10,13 +10,13 @@ export class LegacyDoWhileStatementProcessor extends LegacyNodeProcessor<DoWhile
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof DoWhileStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [condition, body] = reader.convertArray(raw.children, config) as [
             Expression,
             Statement
         ];
 
-        return [id, src, type, condition, body, undefined, raw];
+        return [id, src, condition, body, undefined, raw];
     }
 }

--- a/src/ast/legacy/elementary_type_name_expression_processor.ts
+++ b/src/ast/legacy/elementary_type_name_expression_processor.ts
@@ -9,13 +9,13 @@ export class LegacyElementaryTypeNameExpressionProcessor extends LegacyExpressio
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ElementaryTypeNameExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const children = raw.children ? reader.convertArray(raw.children, config) : undefined;
 
         const [typeName] = children
             ? (children as [ElementaryTypeName])
             : ([raw.attributes.value] as [string]);
 
-        return [id, src, type, typeString, typeName, raw];
+        return [id, src, typeString, typeName, raw];
     }
 }

--- a/src/ast/legacy/elementary_type_name_processor.ts
+++ b/src/ast/legacy/elementary_type_name_processor.ts
@@ -8,13 +8,13 @@ export class LegacyElementaryTypeNameProcessor extends LegacyTypeNameProcessor<E
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ElementaryTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const name: string = attributes.name;
         const stateMutability: "nonpayable" | "payable" =
             "stateMutability" in attributes ? attributes.stateMutability : "nonpayable";
 
-        return [id, src, type, typeString, name, stateMutability, raw];
+        return [id, src, typeString, name, stateMutability, raw];
     }
 }

--- a/src/ast/legacy/emit_statement_processor.ts
+++ b/src/ast/legacy/emit_statement_processor.ts
@@ -9,10 +9,10 @@ export class LegacyEmitStatementProcessor extends LegacyNodeProcessor<EmitStatem
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EmitStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [eventCall] = reader.convertArray(raw.children, config) as [FunctionCall];
 
-        return [id, src, type, eventCall, undefined, raw];
+        return [id, src, eventCall, undefined, raw];
     }
 }

--- a/src/ast/legacy/enum_definition_processor.ts
+++ b/src/ast/legacy/enum_definition_processor.ts
@@ -9,12 +9,12 @@ export class LegacyEnumDefinitionProcessor extends LegacyNodeProcessor<EnumDefin
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EnumDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const members = reader.convertArray(raw.children, config) as EnumValue[];
 
         const name: string = attributes.name;
 
-        return [id, src, type, name, members, undefined, raw];
+        return [id, src, name, members, undefined, raw];
     }
 }

--- a/src/ast/legacy/enum_value_processor.ts
+++ b/src/ast/legacy/enum_value_processor.ts
@@ -8,11 +8,11 @@ export class LegacyEnumValueProcessor extends LegacyNodeProcessor<EnumValue> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EnumValue> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const name: string = attributes.name;
 
-        return [id, src, type, name, undefined, raw];
+        return [id, src, name, undefined, raw];
     }
 }

--- a/src/ast/legacy/event_definition_processor.ts
+++ b/src/ast/legacy/event_definition_processor.ts
@@ -11,7 +11,7 @@ export class LegacyEventDefinitionProcessor extends LegacyNodeProcessor<EventDef
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EventDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -28,7 +28,7 @@ export class LegacyEventDefinitionProcessor extends LegacyNodeProcessor<EventDef
             documentation = attributes.documentation;
         }
 
-        return [id, src, type, anonymous, name, parameters, documentation, undefined, raw];
+        return [id, src, anonymous, name, parameters, documentation, undefined, raw];
     }
 
     private extract(children: ASTNode[]): [StructuredDocumentation | undefined, ParameterList] {

--- a/src/ast/legacy/expression_processor.ts
+++ b/src/ast/legacy/expression_processor.ts
@@ -8,11 +8,9 @@ export class LegacyExpressionProcessor<T extends Expression> extends LegacyNodeP
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<ExpressionConstructor<T>> {
-        const [id, src, type] = super.process(reader, config, raw);
-        const attributes = raw.attributes;
+        const [id, src] = super.process(reader, config, raw);
+        const typeString: string = raw.attributes.type;
 
-        const typeString: string = attributes.type;
-
-        return [id, src, type, typeString, raw];
+        return [id, src, typeString, raw];
     }
 }

--- a/src/ast/legacy/expression_statement_processor.ts
+++ b/src/ast/legacy/expression_statement_processor.ts
@@ -9,10 +9,10 @@ export class LegacyExpressionStatementProcessor extends LegacyNodeProcessor<Expr
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ExpressionStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [expression] = reader.convertArray(raw.children, config) as [Expression];
 
-        return [id, src, type, expression, undefined, raw];
+        return [id, src, expression, undefined, raw];
     }
 }

--- a/src/ast/legacy/for_statement_processor.ts
+++ b/src/ast/legacy/for_statement_processor.ts
@@ -12,7 +12,7 @@ export class LegacyForStatementProcessor extends LegacyNodeProcessor<ForStatemen
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ForStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes || {};
         const children = reader.convertArray(raw.children, config);
 
@@ -31,16 +31,6 @@ export class LegacyForStatementProcessor extends LegacyNodeProcessor<ForStatemen
 
         const body = children.shift() as Statement;
 
-        return [
-            id,
-            src,
-            type,
-            body,
-            initializationExpression,
-            condition,
-            loopExpression,
-            undefined,
-            raw
-        ];
+        return [id, src, body, initializationExpression, condition, loopExpression, undefined, raw];
     }
 }

--- a/src/ast/legacy/function_call_options_processor.ts
+++ b/src/ast/legacy/function_call_options_processor.ts
@@ -9,7 +9,7 @@ export class LegacyFunctionCallOptionsProcessor extends LegacyExpressionProcesso
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionCallOptions> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const names: string[] = raw.attributes.names;
         const [expression, ...values] = reader.convertArray(raw.children, config) as Expression[];
@@ -19,6 +19,6 @@ export class LegacyFunctionCallOptionsProcessor extends LegacyExpressionProcesso
             options.set(names[n], values[n]);
         }
 
-        return [id, src, type, typeString, expression, options, raw];
+        return [id, src, typeString, expression, options, raw];
     }
 }

--- a/src/ast/legacy/function_call_processor.ts
+++ b/src/ast/legacy/function_call_processor.ts
@@ -10,7 +10,7 @@ export class LegacyFunctionCallProcessor extends LegacyExpressionProcessor<Funct
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionCall> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const kind = this.detectKind(attributes);
@@ -18,7 +18,7 @@ export class LegacyFunctionCallProcessor extends LegacyExpressionProcessor<Funct
 
         const [expression, ...args] = reader.convertArray(raw.children, config) as Expression[];
 
-        return [id, src, type, typeString, kind, expression, args, fieldNames, raw];
+        return [id, src, typeString, kind, expression, args, fieldNames, raw];
     }
 
     private detectKind(attributes: any): FunctionCallKind {

--- a/src/ast/legacy/function_definition_processor.ts
+++ b/src/ast/legacy/function_definition_processor.ts
@@ -15,7 +15,7 @@ export class LegacyFunctionDefinitionProcessor extends LegacyNodeProcessor<Funct
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -47,7 +47,6 @@ export class LegacyFunctionDefinitionProcessor extends LegacyNodeProcessor<Funct
         return [
             id,
             src,
-            type,
             scope,
             kind,
             name,

--- a/src/ast/legacy/function_type_name_processor.ts
+++ b/src/ast/legacy/function_type_name_processor.ts
@@ -10,7 +10,7 @@ export class LegacyFunctionTypeNameProcessor extends LegacyTypeNameProcessor<Fun
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const visibility: FunctionVisibility = attributes.visibility;
@@ -24,7 +24,6 @@ export class LegacyFunctionTypeNameProcessor extends LegacyTypeNameProcessor<Fun
         return [
             id,
             src,
-            type,
             typeString,
             visibility,
             stateMutability,

--- a/src/ast/legacy/identifier_processor.ts
+++ b/src/ast/legacy/identifier_processor.ts
@@ -8,13 +8,13 @@ export class LegacyIdentifierProcessor extends LegacyExpressionProcessor<Identif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Identifier> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const attributes = raw.attributes;
 
         const name: string = attributes.value;
         const referencedDeclaration: number = attributes.referencedDeclaration;
 
-        return [id, src, type, typeString, name, referencedDeclaration, raw];
+        return [id, src, typeString, name, referencedDeclaration, raw];
     }
 }

--- a/src/ast/legacy/if_statement_processor.ts
+++ b/src/ast/legacy/if_statement_processor.ts
@@ -10,7 +10,7 @@ export class LegacyIfStatementProcessor extends LegacyNodeProcessor<IfStatement>
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IfStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [condition, trueBody, falseBody] = reader.convertArray(raw.children, config) as [
             Expression,
@@ -18,6 +18,6 @@ export class LegacyIfStatementProcessor extends LegacyNodeProcessor<IfStatement>
             Statement?
         ];
 
-        return [id, src, type, condition, trueBody, falseBody, undefined, raw];
+        return [id, src, condition, trueBody, falseBody, undefined, raw];
     }
 }

--- a/src/ast/legacy/import_directive_processor.ts
+++ b/src/ast/legacy/import_directive_processor.ts
@@ -11,7 +11,7 @@ export class LegacyImportDirectiveProcessor extends LegacyNodeProcessor<ImportDi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ImportDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const file: string = attributes.file;
@@ -27,17 +27,6 @@ export class LegacyImportDirectiveProcessor extends LegacyNodeProcessor<ImportDi
             }
         }
 
-        return [
-            id,
-            src,
-            type,
-            file,
-            absolutePath,
-            unitAlias,
-            symbolAliases,
-            scope,
-            sourceUnit,
-            raw
-        ];
+        return [id, src, file, absolutePath, unitAlias, symbolAliases, scope, sourceUnit, raw];
     }
 }

--- a/src/ast/legacy/index_access_processor.ts
+++ b/src/ast/legacy/index_access_processor.ts
@@ -9,13 +9,13 @@ export class LegacyIndexAccessProcessor extends LegacyExpressionProcessor<IndexA
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IndexAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const [baseExpression, indexExpression] = reader.convertArray(raw.children, config) as [
             Expression,
             Expression | undefined
         ];
 
-        return [id, src, type, typeString, baseExpression, indexExpression, raw];
+        return [id, src, typeString, baseExpression, indexExpression, raw];
     }
 }

--- a/src/ast/legacy/index_range_access_processor.ts
+++ b/src/ast/legacy/index_range_access_processor.ts
@@ -9,7 +9,7 @@ export class LegacyIndexRangeAccessProcessor extends LegacyExpressionProcessor<I
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IndexRangeAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config) as Expression[];
 
@@ -17,6 +17,6 @@ export class LegacyIndexRangeAccessProcessor extends LegacyExpressionProcessor<I
         const startExpression = attributes.startExpression === null ? undefined : children.shift();
         const endExpression = attributes.endExpression === null ? undefined : children.shift();
 
-        return [id, src, type, typeString, baseExpression, startExpression, endExpression, raw];
+        return [id, src, typeString, baseExpression, startExpression, endExpression, raw];
     }
 }

--- a/src/ast/legacy/inheritance_specifier_processor.ts
+++ b/src/ast/legacy/inheritance_specifier_processor.ts
@@ -10,13 +10,13 @@ export class LegacyInheritanceSpecifierProcessor extends LegacyNodeProcessor<Inh
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof InheritanceSpecifier> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [baseType, ...args] = reader.convertArray(raw.children, config) as [
             UserDefinedTypeName,
             ...Expression[]
         ];
 
-        return [id, src, type, baseType, args, raw];
+        return [id, src, baseType, args, raw];
     }
 }

--- a/src/ast/legacy/inline_assembly_processor.ts
+++ b/src/ast/legacy/inline_assembly_processor.ts
@@ -8,7 +8,7 @@ export class LegacyInlineAssemblyProcessor extends LegacyNodeProcessor<InlineAss
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof InlineAssembly> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const externalReferences: any[] = attributes.externalReferences;
@@ -20,6 +20,6 @@ export class LegacyInlineAssemblyProcessor extends LegacyNodeProcessor<InlineAss
          */
         const yul = undefined;
 
-        return [id, src, type, externalReferences, operations, yul, undefined, raw];
+        return [id, src, externalReferences, operations, yul, undefined, raw];
     }
 }

--- a/src/ast/legacy/literal_processor.ts
+++ b/src/ast/legacy/literal_processor.ts
@@ -9,7 +9,7 @@ export class LegacyLiteralProcessor extends LegacyExpressionProcessor<Literal> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Literal> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const attributes = raw.attributes;
 
@@ -20,6 +20,6 @@ export class LegacyLiteralProcessor extends LegacyExpressionProcessor<Literal> {
             ? attributes.subdenomination
             : undefined;
 
-        return [id, src, type, typeString, kind, hexValue, value, subdenomination, raw];
+        return [id, src, typeString, kind, hexValue, value, subdenomination, raw];
     }
 }

--- a/src/ast/legacy/mapping_processor.ts
+++ b/src/ast/legacy/mapping_processor.ts
@@ -9,13 +9,13 @@ export class LegacyMappingProcessor extends LegacyTypeNameProcessor<Mapping> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Mapping> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const [keyType, valueType] = reader.convertArray(raw.children, config) as [
             TypeName,
             TypeName
         ];
 
-        return [id, src, type, typeString, keyType, valueType, raw];
+        return [id, src, typeString, keyType, valueType, raw];
     }
 }

--- a/src/ast/legacy/member_access_processor.ts
+++ b/src/ast/legacy/member_access_processor.ts
@@ -9,7 +9,7 @@ export class LegacyMemberAccessProcessor extends LegacyExpressionProcessor<Membe
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof MemberAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const attributes = raw.attributes;
 
@@ -18,6 +18,6 @@ export class LegacyMemberAccessProcessor extends LegacyExpressionProcessor<Membe
 
         const [expression] = reader.convertArray(raw.children, config) as [Expression];
 
-        return [id, src, type, typeString, expression, memberName, referencedDeclaration, raw];
+        return [id, src, typeString, expression, memberName, referencedDeclaration, raw];
     }
 }

--- a/src/ast/legacy/modifier_definition_processor.ts
+++ b/src/ast/legacy/modifier_definition_processor.ts
@@ -13,7 +13,7 @@ export class LegacyModifierDefinitionProcessor extends LegacyNodeProcessor<Modif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ModifierDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -35,7 +35,6 @@ export class LegacyModifierDefinitionProcessor extends LegacyNodeProcessor<Modif
         return [
             id,
             src,
-            type,
             name,
             virtual,
             visibility,

--- a/src/ast/legacy/modifier_invocation_processor.ts
+++ b/src/ast/legacy/modifier_invocation_processor.ts
@@ -10,13 +10,13 @@ export class LegacyModifierInvocationProcessor extends LegacyNodeProcessor<Modif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ModifierInvocation> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [modifierName, ...args] = reader.convertArray(raw.children, config) as [
             Identifier,
             ...Expression[]
         ];
 
-        return [id, src, type, modifierName, args, undefined, raw];
+        return [id, src, modifierName, args, undefined, raw];
     }
 }

--- a/src/ast/legacy/new_expression_processor.ts
+++ b/src/ast/legacy/new_expression_processor.ts
@@ -9,10 +9,10 @@ export class LegacyNewExpressionProcessor extends LegacyExpressionProcessor<NewE
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof NewExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const [typeName] = reader.convertArray(raw.children, config) as [TypeName];
 
-        return [id, src, type, typeString, typeName, raw];
+        return [id, src, typeString, typeName, raw];
     }
 }

--- a/src/ast/legacy/node_processor.ts
+++ b/src/ast/legacy/node_processor.ts
@@ -7,6 +7,6 @@ export class LegacyNodeProcessor<T extends ASTNode> implements ASTNodeProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<ASTNodeConstructor<T>> {
-        return [raw.id, raw.src, raw.name, raw];
+        return [raw.id, raw.src, raw];
     }
 }

--- a/src/ast/legacy/override_specifier_processor.ts
+++ b/src/ast/legacy/override_specifier_processor.ts
@@ -9,11 +9,11 @@ export class LegacyOverrideSpecifierProcessor extends LegacyNodeProcessor<Overri
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof OverrideSpecifier> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const children = raw.children ? reader.convertArray(raw.children, config) : undefined;
 
         const overrides = children ? (children as UserDefinedTypeName[]) : [];
 
-        return [id, src, type, overrides, raw];
+        return [id, src, overrides, raw];
     }
 }

--- a/src/ast/legacy/parameter_list_processor.ts
+++ b/src/ast/legacy/parameter_list_processor.ts
@@ -9,10 +9,10 @@ export class LegacyParameterListProcessor extends LegacyNodeProcessor<ParameterL
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ParameterList> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const parameters = reader.convertArray(raw.children, config) as VariableDeclaration[];
 
-        return [id, src, type, parameters, raw];
+        return [id, src, parameters, raw];
     }
 }

--- a/src/ast/legacy/placeholder_statement_processor.ts
+++ b/src/ast/legacy/placeholder_statement_processor.ts
@@ -8,8 +8,8 @@ export class LegacyPlaceholderStatementProcessor extends LegacyNodeProcessor<Pla
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof PlaceholderStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
-        return [id, src, type, undefined, raw];
+        return [id, src, undefined, raw];
     }
 }

--- a/src/ast/legacy/pragma_directive_processor.ts
+++ b/src/ast/legacy/pragma_directive_processor.ts
@@ -8,10 +8,10 @@ export class LegacyPragmaDirectiveProcessor extends LegacyNodeProcessor<PragmaDi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof PragmaDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const literals: string[] = raw.attributes.literals;
 
-        return [id, src, type, literals, raw];
+        return [id, src, literals, raw];
     }
 }

--- a/src/ast/legacy/return_processor.ts
+++ b/src/ast/legacy/return_processor.ts
@@ -9,13 +9,13 @@ export class LegacyReturnProcessor extends LegacyNodeProcessor<Return> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Return> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const children = raw.children ? reader.convertArray(raw.children, config) : undefined;
 
         const functionReturnParameters: number = raw.attributes.functionReturnParameters;
 
         const [expression] = children ? (children as [Expression]) : [];
 
-        return [id, src, type, functionReturnParameters, expression, undefined, raw];
+        return [id, src, functionReturnParameters, expression, undefined, raw];
     }
 }

--- a/src/ast/legacy/source_unit_processor.ts
+++ b/src/ast/legacy/source_unit_processor.ts
@@ -8,7 +8,7 @@ export class LegacySourceUnitProcessor extends LegacyNodeProcessor<SourceUnit> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof SourceUnit> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -23,16 +23,6 @@ export class LegacySourceUnitProcessor extends LegacyNodeProcessor<SourceUnit> {
             symbols.set(name, exportedSymbols[name][0]);
         }
 
-        return [
-            id,
-            src,
-            type,
-            sourceEntryKey,
-            sourceListIndex,
-            absolutePath,
-            symbols,
-            children,
-            raw
-        ];
+        return [id, src, sourceEntryKey, sourceListIndex, absolutePath, symbols, children, raw];
     }
 }

--- a/src/ast/legacy/struct_definition_processor.ts
+++ b/src/ast/legacy/struct_definition_processor.ts
@@ -9,7 +9,7 @@ export class LegacyStructDefinitionProcessor extends LegacyNodeProcessor<StructD
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof StructDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const members = reader.convertArray(raw.children, config) as VariableDeclaration[];
 
@@ -17,6 +17,6 @@ export class LegacyStructDefinitionProcessor extends LegacyNodeProcessor<StructD
         const scope: number = attributes.scope;
         const visibility: string = attributes.visibility;
 
-        return [id, src, type, name, scope, visibility, members, undefined, raw];
+        return [id, src, name, scope, visibility, members, undefined, raw];
     }
 }

--- a/src/ast/legacy/structured_documentation_processor.ts
+++ b/src/ast/legacy/structured_documentation_processor.ts
@@ -8,10 +8,10 @@ export class LegacyStructuredDocumentationProcessor extends LegacyNodeProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof StructuredDocumentation> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const text: string = raw.attributes.text;
 
-        return [id, src, type, text, raw];
+        return [id, src, text, raw];
     }
 }

--- a/src/ast/legacy/throw_processor.ts
+++ b/src/ast/legacy/throw_processor.ts
@@ -8,8 +8,8 @@ export class LegacyThrowProcessor extends LegacyNodeProcessor<Throw> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Throw> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
-        return [id, src, type, undefined, raw];
+        return [id, src, undefined, raw];
     }
 }

--- a/src/ast/legacy/try_catch_clause_processor.ts
+++ b/src/ast/legacy/try_catch_clause_processor.ts
@@ -10,7 +10,7 @@ export class LegacyTryCatchClauseProcessor extends LegacyNodeProcessor<TryCatchC
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TryCatchClause> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const children = reader.convertArray(raw.children, config);
 
         const errorName: string = raw.attributes.errorName;
@@ -18,6 +18,6 @@ export class LegacyTryCatchClauseProcessor extends LegacyNodeProcessor<TryCatchC
         const block = children.pop() as Block;
         const parameters = children.length ? (children.pop() as ParameterList) : undefined;
 
-        return [id, src, type, errorName, block, parameters, undefined, raw];
+        return [id, src, errorName, block, parameters, undefined, raw];
     }
 }

--- a/src/ast/legacy/try_statement_processor.ts
+++ b/src/ast/legacy/try_statement_processor.ts
@@ -10,13 +10,13 @@ export class LegacyTryStatementProcessor extends LegacyNodeProcessor<TryStatemen
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TryStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [externalCall, ...clauses] = reader.convertArray(raw.children, config) as [
             FunctionCall,
             ...TryCatchClause[]
         ];
 
-        return [id, src, type, externalCall, clauses, undefined, raw];
+        return [id, src, externalCall, clauses, undefined, raw];
     }
 }

--- a/src/ast/legacy/tuple_expression_processor.ts
+++ b/src/ast/legacy/tuple_expression_processor.ts
@@ -11,7 +11,7 @@ export class LegacyTupleExpressionProcessor extends LegacyExpressionProcessor<Tu
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TupleExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = raw.children ? reader.convertArray(raw.children, config) : undefined;
 
@@ -21,7 +21,7 @@ export class LegacyTupleExpressionProcessor extends LegacyExpressionProcessor<Tu
             ? this.extractComponentsFromRaw(attributes.components, reader, config)
             : this.extractComponentsFromTypeString(typeString, children);
 
-        return [id, src, type, typeString, isInlineArray, components, raw];
+        return [id, src, typeString, isInlineArray, components, raw];
     }
 
     private extractComponentsFromRaw(

--- a/src/ast/legacy/type_name_processor.ts
+++ b/src/ast/legacy/type_name_processor.ts
@@ -8,10 +8,10 @@ export class LegacyTypeNameProcessor<T extends TypeName> extends LegacyNodeProce
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<TypeNameConstructor<T>> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const typeString: string = raw.attributes.type;
 
-        return [id, src, type, typeString, raw];
+        return [id, src, typeString, raw];
     }
 }

--- a/src/ast/legacy/unary_operation_processor.ts
+++ b/src/ast/legacy/unary_operation_processor.ts
@@ -9,7 +9,7 @@ export class LegacyUnaryOperationProcessor extends LegacyExpressionProcessor<Una
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UnaryOperation> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const prefix: boolean = attributes.prefix;
@@ -17,6 +17,6 @@ export class LegacyUnaryOperationProcessor extends LegacyExpressionProcessor<Una
 
         const [subExpression] = reader.convertArray(raw.children, config) as [Expression];
 
-        return [id, src, type, typeString, prefix, operator, subExpression, raw];
+        return [id, src, typeString, prefix, operator, subExpression, raw];
     }
 }

--- a/src/ast/legacy/user_defined_type_name_processor.ts
+++ b/src/ast/legacy/user_defined_type_name_processor.ts
@@ -8,12 +8,12 @@ export class LegacyUserDefinedTypeNameProcessor extends LegacyTypeNameProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UserDefinedTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
         const attributes = raw.attributes;
 
         const name: string = attributes.name;
         const referencedDeclaration: number = attributes.referencedDeclaration;
 
-        return [id, src, type, typeString, name, referencedDeclaration, undefined, raw];
+        return [id, src, typeString, name, referencedDeclaration, undefined, raw];
     }
 }

--- a/src/ast/legacy/using_for_directive_processor.ts
+++ b/src/ast/legacy/using_for_directive_processor.ts
@@ -10,13 +10,13 @@ export class LegacyUsingForDirectiveProcessor extends LegacyNodeProcessor<UsingF
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UsingForDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [libraryName, typeName] = reader.convertArray(raw.children, config) as [
             UserDefinedTypeName,
             TypeName?
         ];
 
-        return [id, src, type, libraryName, typeName, raw];
+        return [id, src, libraryName, typeName, raw];
     }
 }

--- a/src/ast/legacy/variable_declaration_processor.ts
+++ b/src/ast/legacy/variable_declaration_processor.ts
@@ -14,7 +14,7 @@ export class LegacyVariableDeclarationProcessor extends LegacyNodeProcessor<Vari
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof VariableDeclaration> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -40,7 +40,6 @@ export class LegacyVariableDeclarationProcessor extends LegacyNodeProcessor<Vari
         return [
             id,
             src,
-            type,
             constant,
             indexed,
             name,

--- a/src/ast/legacy/variable_declaration_statement_processor.ts
+++ b/src/ast/legacy/variable_declaration_statement_processor.ts
@@ -10,7 +10,7 @@ export class LegacyVariableDeclarationStatementProcessor extends LegacyNodeProce
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof VariableDeclarationStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
         const attributes = raw.attributes;
         const children = reader.convertArray(raw.children, config);
 
@@ -21,6 +21,6 @@ export class LegacyVariableDeclarationStatementProcessor extends LegacyNodeProce
 
         const declarations = children as VariableDeclaration[];
 
-        return [id, src, type, assignments, declarations, initialValue, undefined, raw];
+        return [id, src, assignments, declarations, initialValue, undefined, raw];
     }
 }

--- a/src/ast/legacy/while_statement_processor.ts
+++ b/src/ast/legacy/while_statement_processor.ts
@@ -10,13 +10,13 @@ export class LegacyWhileStatementProcessor extends LegacyNodeProcessor<WhileStat
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof WhileStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const [condition, body] = reader.convertArray(raw.children, config) as [
             Expression,
             Statement
         ];
 
-        return [id, src, type, condition, body, undefined, raw];
+        return [id, src, condition, body, undefined, raw];
     }
 }

--- a/src/ast/modern/array_type_name_processor.ts
+++ b/src/ast/modern/array_type_name_processor.ts
@@ -10,11 +10,11 @@ export class ModernArrayTypeNameProcessor extends ModernTypeNameProcessor<ArrayT
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ArrayTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const baseType = reader.convert(raw.baseType, config) as TypeName;
         const length = raw.length ? (reader.convert(raw.length, config) as Expression) : undefined;
 
-        return [id, src, type, typeString, baseType, length, raw];
+        return [id, src, typeString, baseType, length, raw];
     }
 }

--- a/src/ast/modern/assignment_processor.ts
+++ b/src/ast/modern/assignment_processor.ts
@@ -9,13 +9,13 @@ export class ModernAssignmentProcessor extends ModernExpressionProcessor<Assignm
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Assignment> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const operator: string = raw.operator;
 
         const leftHandSide = reader.convert(raw.leftHandSide, config) as Expression;
         const rightHandSide = reader.convert(raw.rightHandSide, config) as Expression;
 
-        return [id, src, type, typeString, operator, leftHandSide, rightHandSide, raw];
+        return [id, src, typeString, operator, leftHandSide, rightHandSide, raw];
     }
 }

--- a/src/ast/modern/binary_operation_processor.ts
+++ b/src/ast/modern/binary_operation_processor.ts
@@ -9,13 +9,13 @@ export class ModernBinaryOperationProcessor extends ModernExpressionProcessor<Bi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof BinaryOperation> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const operator: string = raw.operator;
 
         const leftExpression = reader.convert(raw.leftExpression, config) as Expression;
         const rightExpression = reader.convert(raw.rightExpression, config) as Expression;
 
-        return [id, src, type, typeString, operator, leftExpression, rightExpression, raw];
+        return [id, src, typeString, operator, leftExpression, rightExpression, raw];
     }
 }

--- a/src/ast/modern/block_processor.ts
+++ b/src/ast/modern/block_processor.ts
@@ -9,12 +9,12 @@ export class ModernBlockProcessor extends ModernNodeProcessor<Block> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Block> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const statements = reader.convertArray(raw.statements, config) as Statement[];
 
-        return [id, src, type, statements, documentation, raw];
+        return [id, src, statements, documentation, raw];
     }
 }

--- a/src/ast/modern/break_processor.ts
+++ b/src/ast/modern/break_processor.ts
@@ -8,10 +8,10 @@ export class ModernBreakProcessor extends ModernNodeProcessor<Break> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Break> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
-        return [id, src, type, documentation, raw];
+        return [id, src, documentation, raw];
     }
 }

--- a/src/ast/modern/conditional_processor.ts
+++ b/src/ast/modern/conditional_processor.ts
@@ -9,12 +9,12 @@ export class ModernConditionalProcessor extends ModernExpressionProcessor<Condit
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Conditional> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const condition = reader.convert(raw.condition, config) as Expression;
         const trueExpression = reader.convert(raw.trueExpression, config) as Expression;
         const falseExpression = reader.convert(raw.falseExpression, config) as Expression;
 
-        return [id, src, type, typeString, condition, trueExpression, falseExpression, raw];
+        return [id, src, typeString, condition, trueExpression, falseExpression, raw];
     }
 }

--- a/src/ast/modern/continue_processor.ts
+++ b/src/ast/modern/continue_processor.ts
@@ -8,10 +8,10 @@ export class ModernContinueProcessor extends ModernNodeProcessor<Continue> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Continue> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
-        return [id, src, type, documentation, raw];
+        return [id, src, documentation, raw];
     }
 }

--- a/src/ast/modern/contract_definition_processor.ts
+++ b/src/ast/modern/contract_definition_processor.ts
@@ -10,7 +10,7 @@ export class ModernContractDefinitionProcessor extends ModernNodeProcessor<Contr
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ContractDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const scope: number = raw.scope;
@@ -41,7 +41,6 @@ export class ModernContractDefinitionProcessor extends ModernNodeProcessor<Contr
         return [
             id,
             src,
-            type,
             name,
             scope,
             kind,

--- a/src/ast/modern/do_while_statement_processor.ts
+++ b/src/ast/modern/do_while_statement_processor.ts
@@ -10,13 +10,13 @@ export class ModernDoWhileStatementProcessor extends ModernNodeProcessor<DoWhile
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof DoWhileStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const condition = reader.convert(raw.condition, config) as Expression;
         const body = reader.convert(raw.body, config) as Statement;
 
-        return [id, src, type, condition, body, documentation, raw];
+        return [id, src, condition, body, documentation, raw];
     }
 }

--- a/src/ast/modern/elementary_type_name_expression_processor.ts
+++ b/src/ast/modern/elementary_type_name_expression_processor.ts
@@ -9,13 +9,13 @@ export class ModernElementaryTypeNameExpressionProcessor extends ModernExpressio
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ElementaryTypeNameExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const typeName =
             typeof raw.typeName === "string"
                 ? (raw.typeName as string)
                 : (reader.convert(raw.typeName, config) as ElementaryTypeName);
 
-        return [id, src, type, typeString, typeName, raw];
+        return [id, src, typeString, typeName, raw];
     }
 }

--- a/src/ast/modern/elementary_type_name_processor.ts
+++ b/src/ast/modern/elementary_type_name_processor.ts
@@ -8,12 +8,12 @@ export class ModernElementaryTypeNameProcessor extends ModernTypeNameProcessor<E
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ElementaryTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const stateMutability: "nonpayable" | "payable" =
             "stateMutability" in raw ? raw.stateMutability : "nonpayable";
 
-        return [id, src, type, typeString, name, stateMutability, raw];
+        return [id, src, typeString, name, stateMutability, raw];
     }
 }

--- a/src/ast/modern/emit_statement_processor.ts
+++ b/src/ast/modern/emit_statement_processor.ts
@@ -9,12 +9,12 @@ export class ModernEmitStatementProcessor extends ModernNodeProcessor<EmitStatem
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EmitStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const eventCall = reader.convert(raw.eventCall, config) as FunctionCall;
 
-        return [id, src, type, eventCall, documentation, raw];
+        return [id, src, eventCall, documentation, raw];
     }
 }

--- a/src/ast/modern/enum_definition_processor.ts
+++ b/src/ast/modern/enum_definition_processor.ts
@@ -9,13 +9,13 @@ export class ModernEnumDefinitionProcessor extends ModernNodeProcessor<EnumDefin
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EnumDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const nameLocation: string | undefined = raw.nameLocation;
 
         const members = reader.convertArray(raw.members, config) as EnumValue[];
 
-        return [id, src, type, name, members, nameLocation, raw];
+        return [id, src, name, members, nameLocation, raw];
     }
 }

--- a/src/ast/modern/enum_value_processor.ts
+++ b/src/ast/modern/enum_value_processor.ts
@@ -8,11 +8,11 @@ export class ModernEnumValueProcessor extends ModernNodeProcessor<EnumValue> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EnumValue> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const nameLocation: string | undefined = raw.nameLocation;
 
-        return [id, src, type, name, nameLocation, raw];
+        return [id, src, name, nameLocation, raw];
     }
 }

--- a/src/ast/modern/error_definition_processor.ts
+++ b/src/ast/modern/error_definition_processor.ts
@@ -10,7 +10,7 @@ export class ModernErrorDefinitionProcessor extends ModernNodeProcessor<ErrorDef
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ErrorDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const nameLocation: string | undefined = raw.nameLocation;
@@ -26,6 +26,6 @@ export class ModernErrorDefinitionProcessor extends ModernNodeProcessor<ErrorDef
 
         const parameters = reader.convert(raw.parameters, config) as ParameterList;
 
-        return [id, src, type, name, parameters, documentation, nameLocation, raw];
+        return [id, src, name, parameters, documentation, nameLocation, raw];
     }
 }

--- a/src/ast/modern/event_definition_processor.ts
+++ b/src/ast/modern/event_definition_processor.ts
@@ -10,7 +10,7 @@ export class ModernEventDefinitionProcessor extends ModernNodeProcessor<EventDef
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof EventDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const anonymous: boolean = raw.anonymous;
         const name: string = raw.name;
@@ -27,6 +27,6 @@ export class ModernEventDefinitionProcessor extends ModernNodeProcessor<EventDef
 
         const parameters = reader.convert(raw.parameters, config) as ParameterList;
 
-        return [id, src, type, anonymous, name, parameters, documentation, nameLocation, raw];
+        return [id, src, anonymous, name, parameters, documentation, nameLocation, raw];
     }
 }

--- a/src/ast/modern/expression_processor.ts
+++ b/src/ast/modern/expression_processor.ts
@@ -8,10 +8,10 @@ export class ModernExpressionProcessor<T extends Expression> extends ModernNodeP
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<ExpressionConstructor<T>> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const typeString: string = raw.typeDescriptions.typeString;
 
-        return [id, src, type, typeString, undefined, raw];
+        return [id, src, typeString, undefined, raw];
     }
 }

--- a/src/ast/modern/expression_statement_processor.ts
+++ b/src/ast/modern/expression_statement_processor.ts
@@ -9,12 +9,12 @@ export class ModernExpressionStatementProcessor extends ModernNodeProcessor<Expr
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ExpressionStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const expression = reader.convert(raw.expression, config) as Expression;
 
-        return [id, src, type, expression, documentation, raw];
+        return [id, src, expression, documentation, raw];
     }
 }

--- a/src/ast/modern/for_statement_processor.ts
+++ b/src/ast/modern/for_statement_processor.ts
@@ -12,7 +12,7 @@ export class ModernForStatementProcessor extends ModernNodeProcessor<ForStatemen
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ForStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
@@ -33,7 +33,6 @@ export class ModernForStatementProcessor extends ModernNodeProcessor<ForStatemen
         return [
             id,
             src,
-            type,
             body,
             initializationExpression,
             condition,

--- a/src/ast/modern/function_call_options_processor.ts
+++ b/src/ast/modern/function_call_options_processor.ts
@@ -9,7 +9,7 @@ export class ModernFunctionCallOptionsProcessor extends ModernExpressionProcesso
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionCallOptions> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const names: string[] = raw.names;
         const expression = reader.convert(raw.expression, config) as Expression;
@@ -20,6 +20,6 @@ export class ModernFunctionCallOptionsProcessor extends ModernExpressionProcesso
             options.set(names[n], values[n]);
         }
 
-        return [id, src, type, typeString, expression, options, raw];
+        return [id, src, typeString, expression, options, raw];
     }
 }

--- a/src/ast/modern/function_call_processor.ts
+++ b/src/ast/modern/function_call_processor.ts
@@ -10,7 +10,7 @@ export class ModernFunctionCallProcessor extends ModernExpressionProcessor<Funct
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionCall> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const kind: FunctionCallKind = raw.kind;
         const fieldNames: string[] | undefined = raw.names.length ? raw.names : undefined;
@@ -18,6 +18,6 @@ export class ModernFunctionCallProcessor extends ModernExpressionProcessor<Funct
         const expression = reader.convert(raw.expression, config) as Expression;
         const args = reader.convertArray(raw.arguments, config) as Expression[];
 
-        return [id, src, type, typeString, kind, expression, args, fieldNames, raw];
+        return [id, src, typeString, kind, expression, args, fieldNames, raw];
     }
 }

--- a/src/ast/modern/function_definition_processor.ts
+++ b/src/ast/modern/function_definition_processor.ts
@@ -14,7 +14,7 @@ export class ModernFunctionDefinitionProcessor extends ModernNodeProcessor<Funct
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const scope: number = raw.scope;
         const kind: FunctionKind = raw.kind;
@@ -46,7 +46,6 @@ export class ModernFunctionDefinitionProcessor extends ModernNodeProcessor<Funct
         return [
             id,
             src,
-            type,
             scope,
             kind,
             name,

--- a/src/ast/modern/function_type_name_processor.ts
+++ b/src/ast/modern/function_type_name_processor.ts
@@ -10,7 +10,7 @@ export class ModernFunctionTypeNameProcessor extends ModernTypeNameProcessor<Fun
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof FunctionTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const visibility: FunctionVisibility = raw.visibility;
         const stateMutability: FunctionStateMutability = raw.stateMutability;
@@ -24,7 +24,6 @@ export class ModernFunctionTypeNameProcessor extends ModernTypeNameProcessor<Fun
         return [
             id,
             src,
-            type,
             typeString,
             visibility,
             stateMutability,

--- a/src/ast/modern/identifier_path_processor.ts
+++ b/src/ast/modern/identifier_path_processor.ts
@@ -8,11 +8,11 @@ export class ModernIdentifierPathProcessor extends ModernNodeProcessor<Identifie
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IdentifierPath> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const referencedDeclaration: number = raw.referencedDeclaration;
 
-        return [id, src, type, name, referencedDeclaration, raw];
+        return [id, src, name, referencedDeclaration, raw];
     }
 }

--- a/src/ast/modern/identifier_processor.ts
+++ b/src/ast/modern/identifier_processor.ts
@@ -8,11 +8,11 @@ export class ModernIdentifierProcessor extends ModernExpressionProcessor<Identif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Identifier> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const referencedDeclaration: number = raw.referencedDeclaration;
 
-        return [id, src, type, typeString, name, referencedDeclaration, raw];
+        return [id, src, typeString, name, referencedDeclaration, raw];
     }
 }

--- a/src/ast/modern/if_statement_processor.ts
+++ b/src/ast/modern/if_statement_processor.ts
@@ -10,7 +10,7 @@ export class ModernIfStatementProcessor extends ModernNodeProcessor<IfStatement>
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IfStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
@@ -20,6 +20,6 @@ export class ModernIfStatementProcessor extends ModernNodeProcessor<IfStatement>
             ? (reader.convert(raw.falseBody, config) as Statement)
             : undefined;
 
-        return [id, src, type, condition, trueBody, falseBody, documentation, raw];
+        return [id, src, condition, trueBody, falseBody, documentation, raw];
     }
 }

--- a/src/ast/modern/import_directive_processor.ts
+++ b/src/ast/modern/import_directive_processor.ts
@@ -9,7 +9,7 @@ export class ModernImportDirectiveProcessor extends ModernNodeProcessor<ImportDi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ImportDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const file: string = raw.file;
         const absolutePath: string = raw.absolutePath;
@@ -24,17 +24,6 @@ export class ModernImportDirectiveProcessor extends ModernNodeProcessor<ImportDi
             }
         }
 
-        return [
-            id,
-            src,
-            type,
-            file,
-            absolutePath,
-            unitAlias,
-            symbolAliases,
-            scope,
-            sourceUnit,
-            raw
-        ];
+        return [id, src, file, absolutePath, unitAlias, symbolAliases, scope, sourceUnit, raw];
     }
 }

--- a/src/ast/modern/index_access_processor.ts
+++ b/src/ast/modern/index_access_processor.ts
@@ -9,13 +9,13 @@ export class ModernIndexAccessProcessor extends ModernExpressionProcessor<IndexA
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IndexAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const baseExpression = reader.convert(raw.baseExpression, config) as Expression;
         const indexExpression = raw.indexExpression
             ? (reader.convert(raw.indexExpression, config) as Expression)
             : undefined;
 
-        return [id, src, type, typeString, baseExpression, indexExpression];
+        return [id, src, typeString, baseExpression, indexExpression];
     }
 }

--- a/src/ast/modern/index_range_access_processor.ts
+++ b/src/ast/modern/index_range_access_processor.ts
@@ -9,7 +9,7 @@ export class ModernIndexRangeAccessProcessor extends ModernExpressionProcessor<I
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof IndexRangeAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const baseExpression = reader.convert(raw.baseExpression, config) as Expression;
 
@@ -21,6 +21,6 @@ export class ModernIndexRangeAccessProcessor extends ModernExpressionProcessor<I
             ? (reader.convert(raw.endExpression, config) as Expression)
             : undefined;
 
-        return [id, src, type, typeString, baseExpression, startExpression, endExpression, raw];
+        return [id, src, typeString, baseExpression, startExpression, endExpression, raw];
     }
 }

--- a/src/ast/modern/inheritance_specifier_processor.ts
+++ b/src/ast/modern/inheritance_specifier_processor.ts
@@ -10,13 +10,13 @@ export class ModernInheritanceSpecifierProcessor extends ModernNodeProcessor<Inh
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof InheritanceSpecifier> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const baseType = reader.convert(raw.baseName, config) as UserDefinedTypeName;
         const args = raw.arguments
             ? (reader.convertArray(raw.arguments, config) as Expression[])
             : [];
 
-        return [id, src, type, baseType, args, raw];
+        return [id, src, baseType, args, raw];
     }
 }

--- a/src/ast/modern/inline_assembly_processor.ts
+++ b/src/ast/modern/inline_assembly_processor.ts
@@ -8,13 +8,13 @@ export class ModernInlineAssemblyProcessor extends ModernNodeProcessor<InlineAss
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof InlineAssembly> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const externalReferences: any[] = raw.externalReferences;
         const documentation: string | undefined = raw.documentation;
         const operations: string | undefined = raw.operations;
         const yul: YulNode | undefined = raw.AST;
 
-        return [id, src, type, externalReferences, operations, yul, documentation, raw];
+        return [id, src, externalReferences, operations, yul, documentation, raw];
     }
 }

--- a/src/ast/modern/literal_processor.ts
+++ b/src/ast/modern/literal_processor.ts
@@ -9,7 +9,7 @@ export class ModernLiteralProcessor extends ModernExpressionProcessor<Literal> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Literal> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const kind: LiteralKind = raw.kind;
         const hexValue: string = raw.hexValue;
@@ -18,6 +18,6 @@ export class ModernLiteralProcessor extends ModernExpressionProcessor<Literal> {
             ? raw.subdenomination
             : undefined;
 
-        return [id, src, type, typeString, kind, hexValue, value, subdenomination, raw];
+        return [id, src, typeString, kind, hexValue, value, subdenomination, raw];
     }
 }

--- a/src/ast/modern/mapping_processor.ts
+++ b/src/ast/modern/mapping_processor.ts
@@ -9,11 +9,11 @@ export class ModernMappingProcessor extends ModernTypeNameProcessor<Mapping> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Mapping> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const keyType = reader.convert(raw.keyType, config) as TypeName;
         const valueType = reader.convert(raw.valueType, config) as TypeName;
 
-        return [id, src, type, typeString, keyType, valueType, raw];
+        return [id, src, typeString, keyType, valueType, raw];
     }
 }

--- a/src/ast/modern/member_access_processor.ts
+++ b/src/ast/modern/member_access_processor.ts
@@ -9,13 +9,13 @@ export class ModernMemberAccessProcessor extends ModernExpressionProcessor<Membe
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof MemberAccess> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const memberName: string = raw.memberName;
         const referencedDeclaration: number = raw.referencedDeclaration;
 
         const expression = reader.convert(raw.expression, config) as Expression;
 
-        return [id, src, type, typeString, expression, memberName, referencedDeclaration, raw];
+        return [id, src, typeString, expression, memberName, referencedDeclaration, raw];
     }
 }

--- a/src/ast/modern/modifier_definition_processor.ts
+++ b/src/ast/modern/modifier_definition_processor.ts
@@ -12,7 +12,7 @@ export class ModernModifierDefinitionProcessor extends ModernNodeProcessor<Modif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ModifierDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const visibility: string = raw.visibility;
@@ -39,7 +39,6 @@ export class ModernModifierDefinitionProcessor extends ModernNodeProcessor<Modif
         return [
             id,
             src,
-            type,
             name,
             virtual,
             visibility,

--- a/src/ast/modern/modifier_invocation_processor.ts
+++ b/src/ast/modern/modifier_invocation_processor.ts
@@ -11,7 +11,7 @@ export class ModernModifierInvocationProcessor extends ModernNodeProcessor<Modif
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ModifierInvocation> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const kind: ModifierInvocationKind | undefined = raw.kind;
 
@@ -20,6 +20,6 @@ export class ModernModifierInvocationProcessor extends ModernNodeProcessor<Modif
             ? (reader.convertArray(raw.arguments, config) as Expression[])
             : [];
 
-        return [id, src, type, modifierName, args, kind, raw];
+        return [id, src, modifierName, args, kind, raw];
     }
 }

--- a/src/ast/modern/new_expression_processor.ts
+++ b/src/ast/modern/new_expression_processor.ts
@@ -9,10 +9,10 @@ export class ModernNewExpressionProcessor extends ModernExpressionProcessor<NewE
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof NewExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const typeName = reader.convert(raw.typeName, config) as TypeName;
 
-        return [id, src, type, typeString, typeName, raw];
+        return [id, src, typeString, typeName, raw];
     }
 }

--- a/src/ast/modern/node_processor.ts
+++ b/src/ast/modern/node_processor.ts
@@ -7,6 +7,6 @@ export class ModernNodeProcessor<T extends ASTNode> implements ASTNodeProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<ASTNodeConstructor<T>> {
-        return [raw.id, raw.src, raw.nodeType, undefined, raw];
+        return [raw.id, raw.src, undefined, raw];
     }
 }

--- a/src/ast/modern/override_specifier_processor.ts
+++ b/src/ast/modern/override_specifier_processor.ts
@@ -9,10 +9,10 @@ export class ModernOverrideSpecifierProcessor extends ModernNodeProcessor<Overri
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof OverrideSpecifier> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const overrides = reader.convertArray(raw.overrides, config) as UserDefinedTypeName[];
 
-        return [id, src, type, overrides, raw];
+        return [id, src, overrides, raw];
     }
 }

--- a/src/ast/modern/parameter_list_processor.ts
+++ b/src/ast/modern/parameter_list_processor.ts
@@ -9,10 +9,10 @@ export class ModernParameterListProcessor extends ModernNodeProcessor<ParameterL
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof ParameterList> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const parameters = reader.convertArray(raw.parameters, config) as VariableDeclaration[];
 
-        return [id, src, type, parameters, raw];
+        return [id, src, parameters, raw];
     }
 }

--- a/src/ast/modern/placeholder_statement_processor.ts
+++ b/src/ast/modern/placeholder_statement_processor.ts
@@ -8,10 +8,10 @@ export class ModernPlaceholderStatementProcessor extends ModernNodeProcessor<Pla
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof PlaceholderStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
-        return [id, src, type, documentation, raw];
+        return [id, src, documentation, raw];
     }
 }

--- a/src/ast/modern/pragma_directive_processor.ts
+++ b/src/ast/modern/pragma_directive_processor.ts
@@ -8,10 +8,10 @@ export class ModernPragmaDirectiveProcessor extends ModernNodeProcessor<PragmaDi
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof PragmaDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const literals: string[] = raw.literals;
 
-        return [id, src, type, literals, raw];
+        return [id, src, literals, raw];
     }
 }

--- a/src/ast/modern/return_processor.ts
+++ b/src/ast/modern/return_processor.ts
@@ -9,7 +9,7 @@ export class ModernReturnProcessor extends ModernNodeProcessor<Return> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Return> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const functionReturnParameters: number = raw.functionReturnParameters;
         const documentation: string | undefined = raw.documentation;
@@ -18,6 +18,6 @@ export class ModernReturnProcessor extends ModernNodeProcessor<Return> {
             ? (reader.convert(raw.expression, config) as Expression)
             : undefined;
 
-        return [id, src, type, functionReturnParameters, expression, documentation, raw];
+        return [id, src, functionReturnParameters, expression, documentation, raw];
     }
 }

--- a/src/ast/modern/revert_statement_processor.ts
+++ b/src/ast/modern/revert_statement_processor.ts
@@ -9,12 +9,12 @@ export class ModernRevertStatementProcessor extends ModernNodeProcessor<RevertSt
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof RevertStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const errorCall = reader.convert(raw.errorCall, config) as FunctionCall;
 
-        return [id, src, type, errorCall, documentation, raw];
+        return [id, src, errorCall, documentation, raw];
     }
 }

--- a/src/ast/modern/source_unit_processor.ts
+++ b/src/ast/modern/source_unit_processor.ts
@@ -8,7 +8,7 @@ export class ModernSourceUnitProcessor extends ModernNodeProcessor<SourceUnit> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof SourceUnit> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const sourceEntryKey: string = raw.sourceEntryKey;
         const sourceListIndex = parseInt(src.slice(src.lastIndexOf(":") + 1), 10);
@@ -23,16 +23,6 @@ export class ModernSourceUnitProcessor extends ModernNodeProcessor<SourceUnit> {
 
         const children = reader.convertArray(raw.nodes, config);
 
-        return [
-            id,
-            src,
-            type,
-            sourceEntryKey,
-            sourceListIndex,
-            absolutePath,
-            symbols,
-            children,
-            raw
-        ];
+        return [id, src, sourceEntryKey, sourceListIndex, absolutePath, symbols, children, raw];
     }
 }

--- a/src/ast/modern/struct_definition_processor.ts
+++ b/src/ast/modern/struct_definition_processor.ts
@@ -9,7 +9,7 @@ export class ModernStructDefinitionProcessor extends ModernNodeProcessor<StructD
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof StructDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const scope: number = raw.scope;
@@ -18,6 +18,6 @@ export class ModernStructDefinitionProcessor extends ModernNodeProcessor<StructD
 
         const members = reader.convertArray(raw.members, config) as VariableDeclaration[];
 
-        return [id, src, type, name, scope, visibility, members, nameLocation, raw];
+        return [id, src, name, scope, visibility, members, nameLocation, raw];
     }
 }

--- a/src/ast/modern/structured_documentation_processor.ts
+++ b/src/ast/modern/structured_documentation_processor.ts
@@ -8,10 +8,10 @@ export class ModernStructuredDocumentationProcessor extends ModernNodeProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof StructuredDocumentation> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const text: string = raw.text;
 
-        return [id, src, type, text, raw];
+        return [id, src, text, raw];
     }
 }

--- a/src/ast/modern/throw_processor.ts
+++ b/src/ast/modern/throw_processor.ts
@@ -8,10 +8,10 @@ export class ModernThrowProcessor extends ModernNodeProcessor<Throw> {
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof Throw> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
-        return [id, src, type, documentation, raw];
+        return [id, src, documentation, raw];
     }
 }

--- a/src/ast/modern/try_catch_clause_processor.ts
+++ b/src/ast/modern/try_catch_clause_processor.ts
@@ -10,7 +10,7 @@ export class ModernTryCatchClauseProcessor extends ModernNodeProcessor<TryCatchC
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TryCatchClause> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const errorName: string = raw.errorName;
         const documentation: string | undefined = raw.documentation;
@@ -21,6 +21,6 @@ export class ModernTryCatchClauseProcessor extends ModernNodeProcessor<TryCatchC
 
         const block = reader.convert(raw.block, config) as Block;
 
-        return [id, src, type, errorName, block, parameters, documentation, raw];
+        return [id, src, errorName, block, parameters, documentation, raw];
     }
 }

--- a/src/ast/modern/try_statement_processor.ts
+++ b/src/ast/modern/try_statement_processor.ts
@@ -10,13 +10,13 @@ export class ModernTryStatementProcessor extends ModernNodeProcessor<TryStatemen
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TryStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const externalCall = reader.convert(raw.externalCall, config) as FunctionCall;
         const clauses = reader.convertArray(raw.clauses, config) as TryCatchClause[];
 
-        return [id, src, type, externalCall, clauses, documentation, raw];
+        return [id, src, externalCall, clauses, documentation, raw];
     }
 }

--- a/src/ast/modern/tuple_expression_processor.ts
+++ b/src/ast/modern/tuple_expression_processor.ts
@@ -9,12 +9,12 @@ export class ModernTupleExpressionProcessor extends ModernExpressionProcessor<Tu
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof TupleExpression> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const isInlineArray: boolean = raw.isInlineArray;
         const components = this.extractComponents(raw.components, reader, config);
 
-        return [id, src, type, typeString, isInlineArray, components, raw];
+        return [id, src, typeString, isInlineArray, components, raw];
     }
 
     private extractComponents(

--- a/src/ast/modern/type_name_processor.ts
+++ b/src/ast/modern/type_name_processor.ts
@@ -8,10 +8,10 @@ export class ModernTypeNameProcessor<T extends TypeName> extends ModernNodeProce
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<TypeNameConstructor<T>> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const typeString: string = raw.typeDescriptions.typeString;
 
-        return [id, src, type, typeString, undefined, raw];
+        return [id, src, typeString, undefined, raw];
     }
 }

--- a/src/ast/modern/unary_operation_processor.ts
+++ b/src/ast/modern/unary_operation_processor.ts
@@ -9,13 +9,13 @@ export class ModernUnaryOperationProcessor extends ModernExpressionProcessor<Una
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UnaryOperation> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const prefix: boolean = raw.prefix;
         const operator: string = raw.operator;
 
         const subExpression = reader.convert(raw.subExpression, config) as Expression;
 
-        return [id, src, type, typeString, prefix, operator, subExpression, raw];
+        return [id, src, typeString, prefix, operator, subExpression, raw];
     }
 }

--- a/src/ast/modern/unchecked_block_processor.ts
+++ b/src/ast/modern/unchecked_block_processor.ts
@@ -9,12 +9,12 @@ export class ModernUncheckedBlockProcessor extends ModernNodeProcessor<Unchecked
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UncheckedBlock> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const statements = reader.convertArray(raw.statements, config) as Statement[];
 
-        return [id, src, type, statements, documentation, raw];
+        return [id, src, statements, documentation, raw];
     }
 }

--- a/src/ast/modern/user_defined_type_name_processor.ts
+++ b/src/ast/modern/user_defined_type_name_processor.ts
@@ -9,7 +9,7 @@ export class ModernUserDefinedTypeNameProcessor extends ModernTypeNameProcessor<
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UserDefinedTypeName> {
-        const [id, src, type, typeString] = super.process(reader, config, raw);
+        const [id, src, typeString] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const referencedDeclaration: number = raw.referencedDeclaration;
@@ -18,6 +18,6 @@ export class ModernUserDefinedTypeNameProcessor extends ModernTypeNameProcessor<
             ? (reader.convert(raw.pathNode, config) as IdentifierPath)
             : undefined;
 
-        return [id, src, type, typeString, name, referencedDeclaration, path, raw];
+        return [id, src, typeString, name, referencedDeclaration, path, raw];
     }
 }

--- a/src/ast/modern/user_defined_value_type_definition_processor.ts
+++ b/src/ast/modern/user_defined_value_type_definition_processor.ts
@@ -9,12 +9,12 @@ export class ModernUserDefinedValueTypeDefinitionProcessor extends ModernNodePro
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UserDefinedValueTypeDefinition> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const name: string = raw.name;
         const nameLocation: string | undefined = raw.nameLocation;
         const underlyingType = reader.convert(raw.underlyingType, config) as ElementaryTypeName;
 
-        return [id, src, type, name, underlyingType, nameLocation, raw];
+        return [id, src, name, underlyingType, nameLocation, raw];
     }
 }

--- a/src/ast/modern/using_for_directive_processor.ts
+++ b/src/ast/modern/using_for_directive_processor.ts
@@ -10,13 +10,13 @@ export class ModernUsingForDirectiveProcessor extends ModernNodeProcessor<UsingF
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof UsingForDirective> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const libraryName = reader.convert(raw.libraryName, config) as UserDefinedTypeName;
         const typeName = raw.typeName
             ? (reader.convert(raw.typeName, config) as TypeName)
             : undefined;
 
-        return [id, src, type, libraryName, typeName, raw];
+        return [id, src, libraryName, typeName, raw];
     }
 }

--- a/src/ast/modern/variable_declaration_processor.ts
+++ b/src/ast/modern/variable_declaration_processor.ts
@@ -13,7 +13,7 @@ export class ModernVariableDeclarationProcessor extends ModernNodeProcessor<Vari
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof VariableDeclaration> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const constant: boolean = raw.constant;
         const indexed: boolean = raw.indexed || false;
@@ -52,7 +52,6 @@ export class ModernVariableDeclarationProcessor extends ModernNodeProcessor<Vari
         return [
             id,
             src,
-            type,
             constant,
             indexed,
             name,

--- a/src/ast/modern/variable_declaration_statement_processor.ts
+++ b/src/ast/modern/variable_declaration_statement_processor.ts
@@ -12,7 +12,7 @@ export class ModernVariableDeclarationStatementProcessor extends ModernNodeProce
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof VariableDeclarationStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const assignments: Array<number | null> = raw.assignments;
         const documentation: string | undefined = raw.documentation;
@@ -26,6 +26,6 @@ export class ModernVariableDeclarationStatementProcessor extends ModernNodeProce
             ? (reader.convert(raw.initialValue, config) as Expression)
             : undefined;
 
-        return [id, src, type, assignments, declarations, initialValue, documentation, raw];
+        return [id, src, assignments, declarations, initialValue, documentation, raw];
     }
 }

--- a/src/ast/modern/while_statement_processor.ts
+++ b/src/ast/modern/while_statement_processor.ts
@@ -10,13 +10,13 @@ export class ModernWhileStatementProcessor extends ModernNodeProcessor<WhileStat
         config: ASTReaderConfiguration,
         raw: any
     ): ConstructorParameters<typeof WhileStatement> {
-        const [id, src, type] = super.process(reader, config, raw);
+        const [id, src] = super.process(reader, config, raw);
 
         const documentation: string | undefined = raw.documentation;
 
         const condition = reader.convert(raw.condition, config) as Expression;
         const body = reader.convert(raw.body, config) as Statement;
 
-        return [id, src, type, condition, body, documentation, raw];
+        return [id, src, condition, body, documentation, raw];
     }
 }

--- a/src/ast/postprocessing/structured_documentation_reconstruction.ts
+++ b/src/ast/postprocessing/structured_documentation_reconstruction.ts
@@ -28,7 +28,7 @@ export class StructuredDocumentationReconstructor {
         const src = `${offset}:${length}:${sourceIndex}`;
         const text = this.extractText(docBlock);
 
-        return new StructuredDocumentation(0, src, "StructuredDocumentation", text);
+        return new StructuredDocumentation(0, src, text);
     }
 
     private getGapInfo(node: ASTNode): [number, number, number] {

--- a/test/samples/solidity/declarations/contract_050.nodes.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.txt
@@ -1,7 +1,6 @@
 SourceUnit #146
     id: 146
     src: "0:0:0"
-    type: "SourceUnit"
     sourceEntryKey: "./test/samples/solidity/declarations/contract_050.sol"
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/declarations/contract_050.sol"
@@ -18,6 +17,7 @@ SourceUnit #146
     <getter> vUserDefinedValueTypes: Array(0)
     <getter> vExportedSymbols: Map(3) { "A" -> ContractDefinition #90, "B" -> ContractDefinition #100, "C" -> ContractDefinition #145 }
     <getter> children: Array(3) [ ContractDefinition #90, ContractDefinition #100, ContractDefinition #145 ]
+    <getter> type: "SourceUnit"
     <getter> firstChild: ContractDefinition #90
     <getter> lastChild: ContractDefinition #145
     <getter> previousSibling: undefined
@@ -28,7 +28,6 @@ SourceUnit #146
     ContractDefinition #90
         id: 90
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "A"
         scope: 146
         kind: "library"
@@ -56,6 +55,7 @@ SourceUnit #146
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #89 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #89
         <getter> lastChild: FunctionDefinition #89
         <getter> previousSibling: undefined
@@ -66,7 +66,6 @@ SourceUnit #146
         FunctionDefinition #89
             id: 89
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 90
@@ -86,6 +85,7 @@ SourceUnit #146
             parent: ContractDefinition #90
             <getter> children: Array(3) [ ParameterList #78, ParameterList #81, Block #88 ]
             <getter> vScope: ContractDefinition #90
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #78
             <getter> lastChild: Block #88
             <getter> previousSibling: undefined
@@ -96,11 +96,11 @@ SourceUnit #146
             ParameterList #78
                 id: 78
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #89
                 <getter> vParameters: Array(2) [ VariableDeclaration #75, VariableDeclaration #77 ]
                 <getter> children: Array(2) [ VariableDeclaration #75, VariableDeclaration #77 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #75
                 <getter> lastChild: VariableDeclaration #77
                 <getter> previousSibling: undefined
@@ -111,7 +111,6 @@ SourceUnit #146
                 VariableDeclaration #75
                     id: 75
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -130,6 +129,7 @@ SourceUnit #146
                     parent: ParameterList #78
                     <getter> children: Array(1) [ ElementaryTypeName #74 ]
                     <getter> vScope: FunctionDefinition #89
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #74
                     <getter> lastChild: ElementaryTypeName #74
                     <getter> previousSibling: undefined
@@ -140,12 +140,12 @@ SourceUnit #146
                     ElementaryTypeName #74
                         id: 74
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #75
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -157,7 +157,6 @@ SourceUnit #146
                 VariableDeclaration #77
                     id: 77
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -176,6 +175,7 @@ SourceUnit #146
                     parent: ParameterList #78
                     <getter> children: Array(1) [ ElementaryTypeName #76 ]
                     <getter> vScope: FunctionDefinition #89
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #76
                     <getter> lastChild: ElementaryTypeName #76
                     <getter> previousSibling: VariableDeclaration #75
@@ -186,12 +186,12 @@ SourceUnit #146
                     ElementaryTypeName #76
                         id: 76
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #77
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -203,11 +203,11 @@ SourceUnit #146
             ParameterList #81
                 id: 81
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #89
                 <getter> vParameters: Array(1) [ VariableDeclaration #80 ]
                 <getter> children: Array(1) [ VariableDeclaration #80 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #80
                 <getter> lastChild: VariableDeclaration #80
                 <getter> previousSibling: ParameterList #78
@@ -218,7 +218,6 @@ SourceUnit #146
                 VariableDeclaration #80
                     id: 80
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "c"
@@ -237,6 +236,7 @@ SourceUnit #146
                     parent: ParameterList #81
                     <getter> children: Array(1) [ ElementaryTypeName #79 ]
                     <getter> vScope: FunctionDefinition #89
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #79
                     <getter> lastChild: ElementaryTypeName #79
                     <getter> previousSibling: undefined
@@ -247,12 +247,12 @@ SourceUnit #146
                     ElementaryTypeName #79
                         id: 79
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #80
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -264,12 +264,12 @@ SourceUnit #146
             Block #88
                 id: 88
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #89
                 <getter> vStatements: Array(1) [ ExpressionStatement #87 ]
                 <getter> children: Array(1) [ ExpressionStatement #87 ]
+                <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #87
                 <getter> lastChild: ExpressionStatement #87
                 <getter> previousSibling: ParameterList #81
@@ -280,12 +280,12 @@ SourceUnit #146
                 ExpressionStatement #87
                     id: 87
                     src: "0:0:0"
-                    type: "ExpressionStatement"
                     documentation: undefined
                     vExpression: Assignment #86
                     context: ASTContext #1000
                     parent: Block #88
                     <getter> children: Array(1) [ Assignment #86 ]
+                    <getter> type: "ExpressionStatement"
                     <getter> firstChild: Assignment #86
                     <getter> lastChild: Assignment #86
                     <getter> previousSibling: undefined
@@ -296,7 +296,6 @@ SourceUnit #146
                     Assignment #86
                         id: 86
                         src: "0:0:0"
-                        type: "Assignment"
                         typeString: "uint256"
                         operator: "="
                         vLeftHandSide: Identifier #82
@@ -304,6 +303,7 @@ SourceUnit #146
                         context: ASTContext #1000
                         parent: ExpressionStatement #87
                         <getter> children: Array(2) [ Identifier #82, BinaryOperation #85 ]
+                        <getter> type: "Assignment"
                         <getter> firstChild: Identifier #82
                         <getter> lastChild: BinaryOperation #85
                         <getter> previousSibling: undefined
@@ -314,7 +314,6 @@ SourceUnit #146
                         Identifier #82
                             id: 82
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "uint256"
                             name: "c"
                             referencedDeclaration: 80
@@ -322,6 +321,7 @@ SourceUnit #146
                             parent: Assignment #86
                             <getter> vReferencedDeclaration: VariableDeclaration #80
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -333,7 +333,6 @@ SourceUnit #146
                         BinaryOperation #85
                             id: 85
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "uint256"
                             operator: "+"
                             vLeftExpression: Identifier #83
@@ -341,6 +340,7 @@ SourceUnit #146
                             context: ASTContext #1000
                             parent: Assignment #86
                             <getter> children: Array(2) [ Identifier #83, Identifier #84 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: Identifier #83
                             <getter> lastChild: Identifier #84
                             <getter> previousSibling: Identifier #82
@@ -351,7 +351,6 @@ SourceUnit #146
                             Identifier #83
                                 id: 83
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "a"
                                 referencedDeclaration: 75
@@ -359,6 +358,7 @@ SourceUnit #146
                                 parent: BinaryOperation #85
                                 <getter> vReferencedDeclaration: VariableDeclaration #75
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -370,7 +370,6 @@ SourceUnit #146
                             Identifier #84
                                 id: 84
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "b"
                                 referencedDeclaration: 77
@@ -378,6 +377,7 @@ SourceUnit #146
                                 parent: BinaryOperation #85
                                 <getter> vReferencedDeclaration: VariableDeclaration #77
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -389,7 +389,6 @@ SourceUnit #146
     ContractDefinition #100
         id: 100
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "B"
         scope: 146
         kind: "interface"
@@ -417,6 +416,7 @@ SourceUnit #146
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #99 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #99
         <getter> lastChild: FunctionDefinition #99
         <getter> previousSibling: ContractDefinition #90
@@ -427,7 +427,6 @@ SourceUnit #146
         FunctionDefinition #99
             id: 99
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: false
             virtual: false
             scope: 100
@@ -447,6 +446,7 @@ SourceUnit #146
             parent: ContractDefinition #100
             <getter> children: Array(2) [ ParameterList #95, ParameterList #98 ]
             <getter> vScope: ContractDefinition #100
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #95
             <getter> lastChild: ParameterList #98
             <getter> previousSibling: undefined
@@ -457,11 +457,11 @@ SourceUnit #146
             ParameterList #95
                 id: 95
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #99
                 <getter> vParameters: Array(2) [ VariableDeclaration #92, VariableDeclaration #94 ]
                 <getter> children: Array(2) [ VariableDeclaration #92, VariableDeclaration #94 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #92
                 <getter> lastChild: VariableDeclaration #94
                 <getter> previousSibling: undefined
@@ -472,7 +472,6 @@ SourceUnit #146
                 VariableDeclaration #92
                     id: 92
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -491,6 +490,7 @@ SourceUnit #146
                     parent: ParameterList #95
                     <getter> children: Array(1) [ ElementaryTypeName #91 ]
                     <getter> vScope: FunctionDefinition #99
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #91
                     <getter> lastChild: ElementaryTypeName #91
                     <getter> previousSibling: undefined
@@ -501,12 +501,12 @@ SourceUnit #146
                     ElementaryTypeName #91
                         id: 91
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #92
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -518,7 +518,6 @@ SourceUnit #146
                 VariableDeclaration #94
                     id: 94
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -537,6 +536,7 @@ SourceUnit #146
                     parent: ParameterList #95
                     <getter> children: Array(1) [ ElementaryTypeName #93 ]
                     <getter> vScope: FunctionDefinition #99
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #93
                     <getter> lastChild: ElementaryTypeName #93
                     <getter> previousSibling: VariableDeclaration #92
@@ -547,12 +547,12 @@ SourceUnit #146
                     ElementaryTypeName #93
                         id: 93
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #94
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -564,11 +564,11 @@ SourceUnit #146
             ParameterList #98
                 id: 98
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #99
                 <getter> vParameters: Array(1) [ VariableDeclaration #97 ]
                 <getter> children: Array(1) [ VariableDeclaration #97 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #97
                 <getter> lastChild: VariableDeclaration #97
                 <getter> previousSibling: ParameterList #95
@@ -579,7 +579,6 @@ SourceUnit #146
                 VariableDeclaration #97
                     id: 97
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -598,6 +597,7 @@ SourceUnit #146
                     parent: ParameterList #98
                     <getter> children: Array(1) [ ElementaryTypeName #96 ]
                     <getter> vScope: FunctionDefinition #99
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #96
                     <getter> lastChild: ElementaryTypeName #96
                     <getter> previousSibling: undefined
@@ -608,12 +608,12 @@ SourceUnit #146
                     ElementaryTypeName #96
                         id: 96
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #97
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -625,7 +625,6 @@ SourceUnit #146
     ContractDefinition #145
         id: 145
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "C"
         scope: 146
         kind: "contract"
@@ -653,6 +652,7 @@ SourceUnit #146
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: FunctionDefinition #129
         <getter> children: Array(8) [ InheritanceSpecifier #102, EventDefinition #106, StructDefinition #109, EnumDefinition #113, UsingForDirective #116, VariableDeclaration #118, FunctionDefinition #129, FunctionDefinition #144 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: InheritanceSpecifier #102
         <getter> lastChild: FunctionDefinition #144
         <getter> previousSibling: ContractDefinition #100
@@ -663,12 +663,12 @@ SourceUnit #146
         InheritanceSpecifier #102
             id: 102
             src: "0:0:0"
-            type: "InheritanceSpecifier"
             vBaseType: UserDefinedTypeName #101
             vArguments: Array(0)
             context: ASTContext #1000
             parent: ContractDefinition #145
             <getter> children: Array(1) [ UserDefinedTypeName #101 ]
+            <getter> type: "InheritanceSpecifier"
             <getter> firstChild: UserDefinedTypeName #101
             <getter> lastChild: UserDefinedTypeName #101
             <getter> previousSibling: undefined
@@ -679,7 +679,6 @@ SourceUnit #146
             UserDefinedTypeName #101
                 id: 101
                 src: "0:0:0"
-                type: "UserDefinedTypeName"
                 typeString: "contract B"
                 name: "B"
                 referencedDeclaration: 100
@@ -688,6 +687,7 @@ SourceUnit #146
                 parent: InheritanceSpecifier #102
                 <getter> children: Array(0)
                 <getter> vReferencedDeclaration: ContractDefinition #100
+                <getter> type: "UserDefinedTypeName"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -698,7 +698,6 @@ SourceUnit #146
         EventDefinition #106
             id: 106
             src: "0:0:0"
-            type: "EventDefinition"
             anonymous: false
             name: "Ev"
             documentation: undefined
@@ -708,6 +707,7 @@ SourceUnit #146
             parent: ContractDefinition #145
             <getter> children: Array(1) [ ParameterList #105 ]
             <getter> vScope: ContractDefinition #145
+            <getter> type: "EventDefinition"
             <getter> firstChild: ParameterList #105
             <getter> lastChild: ParameterList #105
             <getter> previousSibling: InheritanceSpecifier #102
@@ -718,11 +718,11 @@ SourceUnit #146
             ParameterList #105
                 id: 105
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: EventDefinition #106
                 <getter> vParameters: Array(1) [ VariableDeclaration #104 ]
                 <getter> children: Array(1) [ VariableDeclaration #104 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #104
                 <getter> lastChild: VariableDeclaration #104
                 <getter> previousSibling: undefined
@@ -733,7 +733,6 @@ SourceUnit #146
                 VariableDeclaration #104
                     id: 104
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: true
                     name: "addr"
@@ -752,6 +751,7 @@ SourceUnit #146
                     parent: ParameterList #105
                     <getter> children: Array(1) [ ElementaryTypeName #103 ]
                     <getter> vScope: EventDefinition #106
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #103
                     <getter> lastChild: ElementaryTypeName #103
                     <getter> previousSibling: undefined
@@ -762,12 +762,12 @@ SourceUnit #146
                     ElementaryTypeName #103
                         id: 103
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "address"
                         name: "address"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #104
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -779,7 +779,6 @@ SourceUnit #146
         StructDefinition #109
             id: 109
             src: "0:0:0"
-            type: "StructDefinition"
             name: "St"
             scope: 145
             visibility: "public"
@@ -790,6 +789,7 @@ SourceUnit #146
             <getter> vMembers: Array(1) [ VariableDeclaration #108 ]
             <getter> vScope: ContractDefinition #145
             <getter> children: Array(1) [ VariableDeclaration #108 ]
+            <getter> type: "StructDefinition"
             <getter> firstChild: VariableDeclaration #108
             <getter> lastChild: VariableDeclaration #108
             <getter> previousSibling: EventDefinition #106
@@ -800,7 +800,6 @@ SourceUnit #146
             VariableDeclaration #108
                 id: 108
                 src: "0:0:0"
-                type: "VariableDeclaration"
                 constant: false
                 indexed: false
                 name: "a"
@@ -819,6 +818,7 @@ SourceUnit #146
                 parent: StructDefinition #109
                 <getter> children: Array(1) [ ElementaryTypeName #107 ]
                 <getter> vScope: StructDefinition #109
+                <getter> type: "VariableDeclaration"
                 <getter> firstChild: ElementaryTypeName #107
                 <getter> lastChild: ElementaryTypeName #107
                 <getter> previousSibling: undefined
@@ -829,12 +829,12 @@ SourceUnit #146
                 ElementaryTypeName #107
                     id: 107
                     src: "0:0:0"
-                    type: "ElementaryTypeName"
                     typeString: "uint256"
                     name: "uint"
                     stateMutability: "nonpayable"
                     context: ASTContext #1000
                     parent: VariableDeclaration #108
+                    <getter> type: "ElementaryTypeName"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -846,7 +846,6 @@ SourceUnit #146
         EnumDefinition #113
             id: 113
             src: "0:0:0"
-            type: "EnumDefinition"
             name: "En"
             nameLocation: undefined
             context: ASTContext #1000
@@ -855,6 +854,7 @@ SourceUnit #146
             <getter> vMembers: Array(3) [ EnumValue #110, EnumValue #111, EnumValue #112 ]
             <getter> vScope: ContractDefinition #145
             <getter> children: Array(3) [ EnumValue #110, EnumValue #111, EnumValue #112 ]
+            <getter> type: "EnumDefinition"
             <getter> firstChild: EnumValue #110
             <getter> lastChild: EnumValue #112
             <getter> previousSibling: StructDefinition #109
@@ -865,11 +865,11 @@ SourceUnit #146
             EnumValue #110
                 id: 110
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "A"
                 nameLocation: undefined
                 context: ASTContext #1000
                 parent: EnumDefinition #113
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -881,11 +881,11 @@ SourceUnit #146
             EnumValue #111
                 id: 111
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "B"
                 nameLocation: undefined
                 context: ASTContext #1000
                 parent: EnumDefinition #113
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -897,11 +897,11 @@ SourceUnit #146
             EnumValue #112
                 id: 112
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "C"
                 nameLocation: undefined
                 context: ASTContext #1000
                 parent: EnumDefinition #113
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -913,12 +913,12 @@ SourceUnit #146
         UsingForDirective #116
             id: 116
             src: "0:0:0"
-            type: "UsingForDirective"
             vLibraryName: UserDefinedTypeName #114
             vTypeName: ElementaryTypeName #115
             context: ASTContext #1000
             parent: ContractDefinition #145
             <getter> children: Array(2) [ UserDefinedTypeName #114, ElementaryTypeName #115 ]
+            <getter> type: "UsingForDirective"
             <getter> firstChild: UserDefinedTypeName #114
             <getter> lastChild: ElementaryTypeName #115
             <getter> previousSibling: EnumDefinition #113
@@ -929,7 +929,6 @@ SourceUnit #146
             UserDefinedTypeName #114
                 id: 114
                 src: "0:0:0"
-                type: "UserDefinedTypeName"
                 typeString: "library A"
                 name: "A"
                 referencedDeclaration: 90
@@ -938,6 +937,7 @@ SourceUnit #146
                 parent: UsingForDirective #116
                 <getter> children: Array(0)
                 <getter> vReferencedDeclaration: ContractDefinition #90
+                <getter> type: "UserDefinedTypeName"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -948,12 +948,12 @@ SourceUnit #146
             ElementaryTypeName #115
                 id: 115
                 src: "0:0:0"
-                type: "ElementaryTypeName"
                 typeString: "uint256"
                 name: "uint"
                 stateMutability: "nonpayable"
                 context: ASTContext #1000
                 parent: UsingForDirective #116
+                <getter> type: "ElementaryTypeName"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -965,7 +965,6 @@ SourceUnit #146
         VariableDeclaration #118
             id: 118
             src: "0:0:0"
-            type: "VariableDeclaration"
             constant: false
             indexed: false
             name: "val"
@@ -984,6 +983,7 @@ SourceUnit #146
             parent: ContractDefinition #145
             <getter> children: Array(1) [ ElementaryTypeName #117 ]
             <getter> vScope: ContractDefinition #145
+            <getter> type: "VariableDeclaration"
             <getter> firstChild: ElementaryTypeName #117
             <getter> lastChild: ElementaryTypeName #117
             <getter> previousSibling: UsingForDirective #116
@@ -994,12 +994,12 @@ SourceUnit #146
             ElementaryTypeName #117
                 id: 117
                 src: "0:0:0"
-                type: "ElementaryTypeName"
                 typeString: "uint256"
                 name: "uint"
                 stateMutability: "nonpayable"
                 context: ASTContext #1000
                 parent: VariableDeclaration #118
+                <getter> type: "ElementaryTypeName"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -1011,7 +1011,6 @@ SourceUnit #146
         FunctionDefinition #129
             id: 129
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 145
@@ -1031,6 +1030,7 @@ SourceUnit #146
             parent: ContractDefinition #145
             <getter> children: Array(3) [ ParameterList #119, ParameterList #120, Block #128 ]
             <getter> vScope: ContractDefinition #145
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #119
             <getter> lastChild: Block #128
             <getter> previousSibling: VariableDeclaration #118
@@ -1041,11 +1041,11 @@ SourceUnit #146
             ParameterList #119
                 id: 119
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #129
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -1056,11 +1056,11 @@ SourceUnit #146
             ParameterList #120
                 id: 120
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #129
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #119
@@ -1071,12 +1071,12 @@ SourceUnit #146
             Block #128
                 id: 128
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #129
                 <getter> vStatements: Array(1) [ ExpressionStatement #127 ]
                 <getter> children: Array(1) [ ExpressionStatement #127 ]
+                <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #127
                 <getter> lastChild: ExpressionStatement #127
                 <getter> previousSibling: ParameterList #120
@@ -1087,12 +1087,12 @@ SourceUnit #146
                 ExpressionStatement #127
                     id: 127
                     src: "0:0:0"
-                    type: "ExpressionStatement"
                     documentation: undefined
                     vExpression: Assignment #126
                     context: ASTContext #1000
                     parent: Block #128
                     <getter> children: Array(1) [ Assignment #126 ]
+                    <getter> type: "ExpressionStatement"
                     <getter> firstChild: Assignment #126
                     <getter> lastChild: Assignment #126
                     <getter> previousSibling: undefined
@@ -1103,7 +1103,6 @@ SourceUnit #146
                     Assignment #126
                         id: 126
                         src: "0:0:0"
-                        type: "Assignment"
                         typeString: "uint256"
                         operator: "="
                         vLeftHandSide: Identifier #121
@@ -1111,6 +1110,7 @@ SourceUnit #146
                         context: ASTContext #1000
                         parent: ExpressionStatement #127
                         <getter> children: Array(2) [ Identifier #121, FunctionCall #125 ]
+                        <getter> type: "Assignment"
                         <getter> firstChild: Identifier #121
                         <getter> lastChild: FunctionCall #125
                         <getter> previousSibling: undefined
@@ -1121,7 +1121,6 @@ SourceUnit #146
                         Identifier #121
                             id: 121
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "uint256"
                             name: "val"
                             referencedDeclaration: 118
@@ -1129,6 +1128,7 @@ SourceUnit #146
                             parent: Assignment #126
                             <getter> vReferencedDeclaration: VariableDeclaration #118
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -1140,7 +1140,6 @@ SourceUnit #146
                         FunctionCall #125
                             id: 125
                             src: "0:0:0"
-                            type: "FunctionCall"
                             typeString: "uint256"
                             kind: "functionCall"
                             fieldNames: undefined
@@ -1155,6 +1154,7 @@ SourceUnit #146
                             <getter> vReferencedDeclaration: FunctionDefinition #144
                             <getter> vFunctionName: "some"
                             <getter> vCallee: Identifier #122
+                            <getter> type: "FunctionCall"
                             <getter> firstChild: Identifier #122
                             <getter> lastChild: Literal #124
                             <getter> previousSibling: Identifier #121
@@ -1165,7 +1165,6 @@ SourceUnit #146
                             Identifier #122
                                 id: 122
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "function (uint256,uint256) returns (uint256)"
                                 name: "some"
                                 referencedDeclaration: 144
@@ -1173,6 +1172,7 @@ SourceUnit #146
                                 parent: FunctionCall #125
                                 <getter> vReferencedDeclaration: FunctionDefinition #144
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1184,7 +1184,6 @@ SourceUnit #146
                             Literal #123
                                 id: 123
                                 src: "0:0:0"
-                                type: "Literal"
                                 typeString: "int_const 1"
                                 kind: "number"
                                 hexValue: "31"
@@ -1192,6 +1191,7 @@ SourceUnit #146
                                 subdenomination: undefined
                                 context: ASTContext #1000
                                 parent: FunctionCall #125
+                                <getter> type: "Literal"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1203,7 +1203,6 @@ SourceUnit #146
                             Literal #124
                                 id: 124
                                 src: "0:0:0"
-                                type: "Literal"
                                 typeString: "int_const 2"
                                 kind: "number"
                                 hexValue: "32"
@@ -1211,6 +1210,7 @@ SourceUnit #146
                                 subdenomination: undefined
                                 context: ASTContext #1000
                                 parent: FunctionCall #125
+                                <getter> type: "Literal"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1222,7 +1222,6 @@ SourceUnit #146
         FunctionDefinition #144
             id: 144
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 145
@@ -1242,6 +1241,7 @@ SourceUnit #146
             parent: ContractDefinition #145
             <getter> children: Array(3) [ ParameterList #134, ParameterList #137, Block #143 ]
             <getter> vScope: ContractDefinition #145
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #134
             <getter> lastChild: Block #143
             <getter> previousSibling: FunctionDefinition #129
@@ -1252,11 +1252,11 @@ SourceUnit #146
             ParameterList #134
                 id: 134
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #144
                 <getter> vParameters: Array(2) [ VariableDeclaration #131, VariableDeclaration #133 ]
                 <getter> children: Array(2) [ VariableDeclaration #131, VariableDeclaration #133 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #131
                 <getter> lastChild: VariableDeclaration #133
                 <getter> previousSibling: undefined
@@ -1267,7 +1267,6 @@ SourceUnit #146
                 VariableDeclaration #131
                     id: 131
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -1286,6 +1285,7 @@ SourceUnit #146
                     parent: ParameterList #134
                     <getter> children: Array(1) [ ElementaryTypeName #130 ]
                     <getter> vScope: FunctionDefinition #144
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #130
                     <getter> lastChild: ElementaryTypeName #130
                     <getter> previousSibling: undefined
@@ -1296,12 +1296,12 @@ SourceUnit #146
                     ElementaryTypeName #130
                         id: 130
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #131
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -1313,7 +1313,6 @@ SourceUnit #146
                 VariableDeclaration #133
                     id: 133
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -1332,6 +1331,7 @@ SourceUnit #146
                     parent: ParameterList #134
                     <getter> children: Array(1) [ ElementaryTypeName #132 ]
                     <getter> vScope: FunctionDefinition #144
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #132
                     <getter> lastChild: ElementaryTypeName #132
                     <getter> previousSibling: VariableDeclaration #131
@@ -1342,12 +1342,12 @@ SourceUnit #146
                     ElementaryTypeName #132
                         id: 132
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #133
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -1359,11 +1359,11 @@ SourceUnit #146
             ParameterList #137
                 id: 137
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #144
                 <getter> vParameters: Array(1) [ VariableDeclaration #136 ]
                 <getter> children: Array(1) [ VariableDeclaration #136 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #136
                 <getter> lastChild: VariableDeclaration #136
                 <getter> previousSibling: ParameterList #134
@@ -1374,7 +1374,6 @@ SourceUnit #146
                 VariableDeclaration #136
                     id: 136
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -1393,6 +1392,7 @@ SourceUnit #146
                     parent: ParameterList #137
                     <getter> children: Array(1) [ ElementaryTypeName #135 ]
                     <getter> vScope: FunctionDefinition #144
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #135
                     <getter> lastChild: ElementaryTypeName #135
                     <getter> previousSibling: undefined
@@ -1403,12 +1403,12 @@ SourceUnit #146
                     ElementaryTypeName #135
                         id: 135
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #136
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -1420,12 +1420,12 @@ SourceUnit #146
             Block #143
                 id: 143
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #144
                 <getter> vStatements: Array(1) [ Return #142 ]
                 <getter> children: Array(1) [ Return #142 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #142
                 <getter> lastChild: Return #142
                 <getter> previousSibling: ParameterList #137
@@ -1436,7 +1436,6 @@ SourceUnit #146
                 Return #142
                     id: 142
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 64
                     vExpression: FunctionCall #141
@@ -1444,6 +1443,7 @@ SourceUnit #146
                     parent: Block #143
                     <getter> children: Array(1) [ FunctionCall #141 ]
                     <getter> vFunctionReturnParameters: ParameterList #64
+                    <getter> type: "Return"
                     <getter> firstChild: FunctionCall #141
                     <getter> lastChild: FunctionCall #141
                     <getter> previousSibling: undefined
@@ -1454,7 +1454,6 @@ SourceUnit #146
                     FunctionCall #141
                         id: 141
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "uint256"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -1469,6 +1468,7 @@ SourceUnit #146
                         <getter> vReferencedDeclaration: FunctionDefinition #89
                         <getter> vFunctionName: "add"
                         <getter> vCallee: MemberAccess #139
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #139
                         <getter> lastChild: Identifier #140
                         <getter> previousSibling: undefined
@@ -1479,7 +1479,6 @@ SourceUnit #146
                         MemberAccess #139
                             id: 139
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function (uint256,uint256) returns (uint256)"
                             vExpression: Identifier #138
                             memberName: "add"
@@ -1488,6 +1487,7 @@ SourceUnit #146
                             parent: FunctionCall #141
                             <getter> children: Array(1) [ Identifier #138 ]
                             <getter> vReferencedDeclaration: FunctionDefinition #89
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #138
                             <getter> lastChild: Identifier #138
                             <getter> previousSibling: undefined
@@ -1498,7 +1498,6 @@ SourceUnit #146
                             Identifier #138
                                 id: 138
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "a"
                                 referencedDeclaration: 131
@@ -1506,6 +1505,7 @@ SourceUnit #146
                                 parent: MemberAccess #139
                                 <getter> vReferencedDeclaration: VariableDeclaration #131
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1517,7 +1517,6 @@ SourceUnit #146
                         Identifier #140
                             id: 140
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "uint256"
                             name: "b"
                             referencedDeclaration: 133
@@ -1525,6 +1524,7 @@ SourceUnit #146
                             parent: FunctionCall #141
                             <getter> vReferencedDeclaration: VariableDeclaration #133
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined

--- a/test/samples/solidity/latest_08.nodes.txt
+++ b/test/samples/solidity/latest_08.nodes.txt
@@ -1,7 +1,6 @@
 SourceUnit #959
     id: 959
     src: "0:0:0"
-    type: "SourceUnit"
     sourceEntryKey: "./test/samples/solidity/latest_08.sol"
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/latest_08.sol"
@@ -18,6 +17,7 @@ SourceUnit #959
     <getter> vUserDefinedValueTypes: Array(2) [ UserDefinedValueTypeDefinition #801, UserDefinedValueTypeDefinition #803 ]
     <getter> vExportedSymbols: Map(17) { "CatchPanic" -> ContractDefinition #628, "EmitsIdentifierPath" -> ContractDefinition #550, "EnumABC" -> EnumDefinition #497, "EnumTypeMinMax_088" -> ContractDefinition #927, "ExternalFnSelectorAndAddress_0810" -> ContractDefinition #958, "Features082" -> ContractDefinition #713, "Features084" -> ContractDefinition #782, "Features087" -> ContractDefinition #799, "InterfaceWithUDTV_088" -> ContractDefinition #902, "LI" -> ImportDirective #493, "LibErrors084" -> ContractDefinition #724, "LibWithUDVT_088" -> ContractDefinition #891, "Price" -> UserDefinedValueTypeDefinition #801, "Quantity" -> UserDefinedValueTypeDefinition #803, "UncheckedMathExample" -> ContractDefinition #514, "UnitLevelError084" -> ErrorDefinition #718, "UsesNewAddressMembers" -> ContractDefinition #571 }
     <getter> children: Array(19) [ PragmaDirective #491, PragmaDirective #492, ImportDirective #493, EnumDefinition #497, ContractDefinition #514, ContractDefinition #550, ContractDefinition #571, ContractDefinition #628, ContractDefinition #713, ErrorDefinition #718, ContractDefinition #724, ContractDefinition #782, ContractDefinition #799, UserDefinedValueTypeDefinition #801, UserDefinedValueTypeDefinition #803, ContractDefinition #891, ContractDefinition #902, ContractDefinition #927, ContractDefinition #958 ]
+    <getter> type: "SourceUnit"
     <getter> firstChild: PragmaDirective #491
     <getter> lastChild: ContractDefinition #958
     <getter> previousSibling: undefined
@@ -28,12 +28,12 @@ SourceUnit #959
     PragmaDirective #491
         id: 491
         src: "0:0:0"
-        type: "PragmaDirective"
         literals: Array(4) [ "solidity", "^", "0.8", ".0" ]
         context: ASTContext #1000
         parent: SourceUnit #959
         <getter> vIdentifier: "solidity"
         <getter> vValue: "^0.8.0"
+        <getter> type: "PragmaDirective"
         <getter> children: Array(0)
         <getter> firstChild: undefined
         <getter> lastChild: undefined
@@ -45,12 +45,12 @@ SourceUnit #959
     PragmaDirective #492
         id: 492
         src: "0:0:0"
-        type: "PragmaDirective"
         literals: Array(2) [ "abicoder", "v2" ]
         context: ASTContext #1000
         parent: SourceUnit #959
         <getter> vIdentifier: "abicoder"
         <getter> vValue: "v2"
+        <getter> type: "PragmaDirective"
         <getter> children: Array(0)
         <getter> firstChild: undefined
         <getter> lastChild: undefined
@@ -62,7 +62,6 @@ SourceUnit #959
     ImportDirective #493
         id: 493
         src: "0:0:0"
-        type: "ImportDirective"
         file: "./latest_imports_08.sol"
         absolutePath: "./test/samples/solidity/latest_imports_08.sol"
         unitAlias: "LI"
@@ -75,6 +74,7 @@ SourceUnit #959
         <getter> vScope: SourceUnit #959
         <getter> vSourceUnit: SourceUnit #490
         <getter> vSymbolAliases: Array(0)
+        <getter> type: "ImportDirective"
         <getter> firstChild: undefined
         <getter> lastChild: undefined
         <getter> previousSibling: PragmaDirective #492
@@ -85,7 +85,6 @@ SourceUnit #959
     EnumDefinition #497
         id: 497
         src: "0:0:0"
-        type: "EnumDefinition"
         name: "EnumABC"
         nameLocation: "91:7:0"
         context: ASTContext #1000
@@ -94,6 +93,7 @@ SourceUnit #959
         <getter> vMembers: Array(3) [ EnumValue #494, EnumValue #495, EnumValue #496 ]
         <getter> vScope: SourceUnit #959
         <getter> children: Array(3) [ EnumValue #494, EnumValue #495, EnumValue #496 ]
+        <getter> type: "EnumDefinition"
         <getter> firstChild: EnumValue #494
         <getter> lastChild: EnumValue #496
         <getter> previousSibling: ImportDirective #493
@@ -104,11 +104,11 @@ SourceUnit #959
         EnumValue #494
             id: 494
             src: "0:0:0"
-            type: "EnumValue"
             name: "A"
             nameLocation: "105:1:0"
             context: ASTContext #1000
             parent: EnumDefinition #497
+            <getter> type: "EnumValue"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -120,11 +120,11 @@ SourceUnit #959
         EnumValue #495
             id: 495
             src: "0:0:0"
-            type: "EnumValue"
             name: "B"
             nameLocation: "108:1:0"
             context: ASTContext #1000
             parent: EnumDefinition #497
+            <getter> type: "EnumValue"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -136,11 +136,11 @@ SourceUnit #959
         EnumValue #496
             id: 496
             src: "0:0:0"
-            type: "EnumValue"
             name: "C"
             nameLocation: "111:1:0"
             context: ASTContext #1000
             parent: EnumDefinition #497
+            <getter> type: "EnumValue"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -152,7 +152,6 @@ SourceUnit #959
     ContractDefinition #514
         id: 514
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "UncheckedMathExample"
         scope: 959
         kind: "contract"
@@ -180,6 +179,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #513 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #513
         <getter> lastChild: FunctionDefinition #513
         <getter> previousSibling: EnumDefinition #497
@@ -190,7 +190,6 @@ SourceUnit #959
         FunctionDefinition #513
             id: 513
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 514
@@ -210,6 +209,7 @@ SourceUnit #959
             parent: ContractDefinition #514
             <getter> children: Array(3) [ ParameterList #498, ParameterList #501, Block #512 ]
             <getter> vScope: ContractDefinition #514
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #498
             <getter> lastChild: Block #512
             <getter> previousSibling: undefined
@@ -220,11 +220,11 @@ SourceUnit #959
             ParameterList #498
                 id: 498
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #513
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -235,11 +235,11 @@ SourceUnit #959
             ParameterList #501
                 id: 501
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #513
                 <getter> vParameters: Array(1) [ VariableDeclaration #500 ]
                 <getter> children: Array(1) [ VariableDeclaration #500 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #500
                 <getter> lastChild: VariableDeclaration #500
                 <getter> previousSibling: ParameterList #498
@@ -250,7 +250,6 @@ SourceUnit #959
                 VariableDeclaration #500
                     id: 500
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -269,6 +268,7 @@ SourceUnit #959
                     parent: ParameterList #501
                     <getter> children: Array(1) [ ElementaryTypeName #499 ]
                     <getter> vScope: FunctionDefinition #513
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #499
                     <getter> lastChild: ElementaryTypeName #499
                     <getter> previousSibling: undefined
@@ -279,12 +279,12 @@ SourceUnit #959
                     ElementaryTypeName #499
                         id: 499
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #500
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -296,12 +296,12 @@ SourceUnit #959
             Block #512
                 id: 512
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #513
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #505, UncheckedBlock #509, Return #511 ]
                 <getter> children: Array(3) [ VariableDeclarationStatement #505, UncheckedBlock #509, Return #511 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #505
                 <getter> lastChild: Return #511
                 <getter> previousSibling: ParameterList #501
@@ -312,7 +312,6 @@ SourceUnit #959
                 VariableDeclarationStatement #505
                     id: 505
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 503 ]
                     vDeclarations: Array(1) [ VariableDeclaration #503 ]
@@ -320,6 +319,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #512
                     <getter> children: Array(2) [ VariableDeclaration #503, Literal #504 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #503
                     <getter> lastChild: Literal #504
                     <getter> previousSibling: undefined
@@ -330,7 +330,6 @@ SourceUnit #959
                     VariableDeclaration #503
                         id: 503
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "x"
@@ -349,6 +348,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #505
                         <getter> children: Array(1) [ ElementaryTypeName #502 ]
                         <getter> vScope: Block #512
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: ElementaryTypeName #502
                         <getter> lastChild: ElementaryTypeName #502
                         <getter> previousSibling: undefined
@@ -359,12 +359,12 @@ SourceUnit #959
                         ElementaryTypeName #502
                             id: 502
                             src: "0:0:0"
-                            type: "ElementaryTypeName"
                             typeString: "uint256"
                             name: "uint"
                             stateMutability: "nonpayable"
                             context: ASTContext #1000
                             parent: VariableDeclaration #503
+                            <getter> type: "ElementaryTypeName"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -376,7 +376,6 @@ SourceUnit #959
                     Literal #504
                         id: 504
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "int_const 0"
                         kind: "number"
                         hexValue: "30"
@@ -384,6 +383,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: VariableDeclarationStatement #505
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -395,12 +395,12 @@ SourceUnit #959
                 UncheckedBlock #509
                     id: 509
                     src: "0:0:0"
-                    type: "UncheckedBlock"
                     documentation: undefined
                     context: ASTContext #1000
                     parent: Block #512
                     <getter> vStatements: Array(1) [ ExpressionStatement #508 ]
                     <getter> children: Array(1) [ ExpressionStatement #508 ]
+                    <getter> type: "UncheckedBlock"
                     <getter> firstChild: ExpressionStatement #508
                     <getter> lastChild: ExpressionStatement #508
                     <getter> previousSibling: VariableDeclarationStatement #505
@@ -411,12 +411,12 @@ SourceUnit #959
                     ExpressionStatement #508
                         id: 508
                         src: "0:0:0"
-                        type: "ExpressionStatement"
                         documentation: undefined
                         vExpression: UnaryOperation #507
                         context: ASTContext #1000
                         parent: UncheckedBlock #509
                         <getter> children: Array(1) [ UnaryOperation #507 ]
+                        <getter> type: "ExpressionStatement"
                         <getter> firstChild: UnaryOperation #507
                         <getter> lastChild: UnaryOperation #507
                         <getter> previousSibling: undefined
@@ -427,7 +427,6 @@ SourceUnit #959
                         UnaryOperation #507
                             id: 507
                             src: "0:0:0"
-                            type: "UnaryOperation"
                             typeString: "uint256"
                             prefix: false
                             operator: "--"
@@ -435,6 +434,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: ExpressionStatement #508
                             <getter> children: Array(1) [ Identifier #506 ]
+                            <getter> type: "UnaryOperation"
                             <getter> firstChild: Identifier #506
                             <getter> lastChild: Identifier #506
                             <getter> previousSibling: undefined
@@ -445,7 +445,6 @@ SourceUnit #959
                             Identifier #506
                                 id: 506
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "x"
                                 referencedDeclaration: 503
@@ -453,6 +452,7 @@ SourceUnit #959
                                 parent: UnaryOperation #507
                                 <getter> vReferencedDeclaration: VariableDeclaration #503
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -464,7 +464,6 @@ SourceUnit #959
                 Return #511
                     id: 511
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 11
                     vExpression: Identifier #510
@@ -472,6 +471,7 @@ SourceUnit #959
                     parent: Block #512
                     <getter> children: Array(1) [ Identifier #510 ]
                     <getter> vFunctionReturnParameters: ParameterList #11
+                    <getter> type: "Return"
                     <getter> firstChild: Identifier #510
                     <getter> lastChild: Identifier #510
                     <getter> previousSibling: UncheckedBlock #509
@@ -482,7 +482,6 @@ SourceUnit #959
                     Identifier #510
                         id: 510
                         src: "0:0:0"
-                        type: "Identifier"
                         typeString: "uint256"
                         name: "x"
                         referencedDeclaration: 503
@@ -490,6 +489,7 @@ SourceUnit #959
                         parent: Return #511
                         <getter> vReferencedDeclaration: VariableDeclaration #503
                         <getter> vIdentifierType: "userDefined"
+                        <getter> type: "Identifier"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -501,7 +501,6 @@ SourceUnit #959
     ContractDefinition #550
         id: 550
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "EmitsIdentifierPath"
         scope: 959
         kind: "contract"
@@ -529,6 +528,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: FunctionDefinition #526
         <getter> children: Array(5) [ InheritanceSpecifier #516, UsingForDirective #520, FunctionDefinition #526, FunctionDefinition #539, FunctionDefinition #549 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: InheritanceSpecifier #516
         <getter> lastChild: FunctionDefinition #549
         <getter> previousSibling: ContractDefinition #514
@@ -539,12 +539,12 @@ SourceUnit #959
         InheritanceSpecifier #516
             id: 516
             src: "0:0:0"
-            type: "InheritanceSpecifier"
             vBaseType: IdentifierPath #515
             vArguments: Array(0)
             context: ASTContext #1000
             parent: ContractDefinition #550
             <getter> children: Array(1) [ IdentifierPath #515 ]
+            <getter> type: "InheritanceSpecifier"
             <getter> firstChild: IdentifierPath #515
             <getter> lastChild: IdentifierPath #515
             <getter> previousSibling: undefined
@@ -555,12 +555,12 @@ SourceUnit #959
             IdentifierPath #515
                 id: 515
                 src: "0:0:0"
-                type: "IdentifierPath"
                 name: "LI.SomeContract"
                 referencedDeclaration: 488
                 context: ASTContext #1000
                 parent: InheritanceSpecifier #516
                 <getter> vReferencedDeclaration: ContractDefinition #488
+                <getter> type: "IdentifierPath"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -572,12 +572,12 @@ SourceUnit #959
         UsingForDirective #520
             id: 520
             src: "0:0:0"
-            type: "UsingForDirective"
             vLibraryName: IdentifierPath #517
             vTypeName: UserDefinedTypeName #519
             context: ASTContext #1000
             parent: ContractDefinition #550
             <getter> children: Array(2) [ IdentifierPath #517, UserDefinedTypeName #519 ]
+            <getter> type: "UsingForDirective"
             <getter> firstChild: IdentifierPath #517
             <getter> lastChild: UserDefinedTypeName #519
             <getter> previousSibling: InheritanceSpecifier #516
@@ -588,12 +588,12 @@ SourceUnit #959
             IdentifierPath #517
                 id: 517
                 src: "0:0:0"
-                type: "IdentifierPath"
                 name: "LI.SomeLib"
                 referencedDeclaration: 489
                 context: ASTContext #1000
                 parent: UsingForDirective #520
                 <getter> vReferencedDeclaration: ContractDefinition #489
+                <getter> type: "IdentifierPath"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -605,7 +605,6 @@ SourceUnit #959
             UserDefinedTypeName #519
                 id: 519
                 src: "0:0:0"
-                type: "UserDefinedTypeName"
                 typeString: "struct SomeContract.SomeStruct"
                 name: undefined
                 referencedDeclaration: 479
@@ -614,6 +613,7 @@ SourceUnit #959
                 parent: UsingForDirective #520
                 <getter> children: Array(1) [ IdentifierPath #518 ]
                 <getter> vReferencedDeclaration: StructDefinition #479
+                <getter> type: "UserDefinedTypeName"
                 <getter> firstChild: IdentifierPath #518
                 <getter> lastChild: IdentifierPath #518
                 <getter> previousSibling: IdentifierPath #517
@@ -624,12 +624,12 @@ SourceUnit #959
                 IdentifierPath #518
                     id: 518
                     src: "0:0:0"
-                    type: "IdentifierPath"
                     name: "LI.SomeContract.SomeStruct"
                     referencedDeclaration: 479
                     context: ASTContext #1000
                     parent: UserDefinedTypeName #519
                     <getter> vReferencedDeclaration: StructDefinition #479
+                    <getter> type: "IdentifierPath"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -641,7 +641,6 @@ SourceUnit #959
         FunctionDefinition #526
             id: 526
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 550
@@ -661,6 +660,7 @@ SourceUnit #959
             parent: ContractDefinition #550
             <getter> children: Array(4) [ ParameterList #521, ModifierInvocation #524, ParameterList #522, Block #525 ]
             <getter> vScope: ContractDefinition #550
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #521
             <getter> lastChild: Block #525
             <getter> previousSibling: UsingForDirective #520
@@ -671,11 +671,11 @@ SourceUnit #959
             ParameterList #521
                 id: 521
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #526
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -686,7 +686,6 @@ SourceUnit #959
             ModifierInvocation #524
                 id: 524
                 src: "0:0:0"
-                type: "ModifierInvocation"
                 kind: "baseConstructorSpecifier"
                 vModifierName: IdentifierPath #523
                 vArguments: Array(0)
@@ -694,6 +693,7 @@ SourceUnit #959
                 parent: FunctionDefinition #526
                 <getter> children: Array(1) [ IdentifierPath #523 ]
                 <getter> vModifier: ContractDefinition #488
+                <getter> type: "ModifierInvocation"
                 <getter> firstChild: IdentifierPath #523
                 <getter> lastChild: IdentifierPath #523
                 <getter> previousSibling: ParameterList #521
@@ -704,12 +704,12 @@ SourceUnit #959
                 IdentifierPath #523
                     id: 523
                     src: "0:0:0"
-                    type: "IdentifierPath"
                     name: "LI.SomeContract"
                     referencedDeclaration: 488
                     context: ASTContext #1000
                     parent: ModifierInvocation #524
                     <getter> vReferencedDeclaration: ContractDefinition #488
+                    <getter> type: "IdentifierPath"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -721,11 +721,11 @@ SourceUnit #959
             ParameterList #522
                 id: 522
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #526
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ModifierInvocation #524
@@ -736,12 +736,12 @@ SourceUnit #959
             Block #525
                 id: 525
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #526
                 <getter> vStatements: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "Block"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #522
@@ -752,7 +752,6 @@ SourceUnit #959
         FunctionDefinition #539
             id: 539
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 550
@@ -772,6 +771,7 @@ SourceUnit #959
             parent: ContractDefinition #550
             <getter> children: Array(3) [ ParameterList #527, ParameterList #528, Block #538 ]
             <getter> vScope: ContractDefinition #550
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #527
             <getter> lastChild: Block #538
             <getter> previousSibling: FunctionDefinition #526
@@ -782,11 +782,11 @@ SourceUnit #959
             ParameterList #527
                 id: 527
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #539
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -797,11 +797,11 @@ SourceUnit #959
             ParameterList #528
                 id: 528
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #539
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #527
@@ -812,12 +812,12 @@ SourceUnit #959
             Block #538
                 id: 538
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #539
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #537 ]
                 <getter> children: Array(1) [ VariableDeclarationStatement #537 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #537
                 <getter> lastChild: VariableDeclarationStatement #537
                 <getter> previousSibling: ParameterList #528
@@ -828,7 +828,6 @@ SourceUnit #959
                 VariableDeclarationStatement #537
                     id: 537
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 531 ]
                     vDeclarations: Array(1) [ VariableDeclaration #531 ]
@@ -836,6 +835,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #538
                     <getter> children: Array(2) [ VariableDeclaration #531, FunctionCall #536 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #531
                     <getter> lastChild: FunctionCall #536
                     <getter> previousSibling: undefined
@@ -846,7 +846,6 @@ SourceUnit #959
                     VariableDeclaration #531
                         id: 531
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "s"
@@ -865,6 +864,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #537
                         <getter> children: Array(1) [ UserDefinedTypeName #530 ]
                         <getter> vScope: Block #538
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: UserDefinedTypeName #530
                         <getter> lastChild: UserDefinedTypeName #530
                         <getter> previousSibling: undefined
@@ -875,7 +875,6 @@ SourceUnit #959
                         UserDefinedTypeName #530
                             id: 530
                             src: "0:0:0"
-                            type: "UserDefinedTypeName"
                             typeString: "struct SomeContract.SomeStruct"
                             name: undefined
                             referencedDeclaration: 479
@@ -884,6 +883,7 @@ SourceUnit #959
                             parent: VariableDeclaration #531
                             <getter> children: Array(1) [ IdentifierPath #529 ]
                             <getter> vReferencedDeclaration: StructDefinition #479
+                            <getter> type: "UserDefinedTypeName"
                             <getter> firstChild: IdentifierPath #529
                             <getter> lastChild: IdentifierPath #529
                             <getter> previousSibling: undefined
@@ -894,12 +894,12 @@ SourceUnit #959
                             IdentifierPath #529
                                 id: 529
                                 src: "0:0:0"
-                                type: "IdentifierPath"
                                 name: "LI.SomeContract.SomeStruct"
                                 referencedDeclaration: 479
                                 context: ASTContext #1000
                                 parent: UserDefinedTypeName #530
                                 <getter> vReferencedDeclaration: StructDefinition #479
+                                <getter> type: "IdentifierPath"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -911,7 +911,6 @@ SourceUnit #959
                     FunctionCall #536
                         id: 536
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "struct SomeContract.SomeStruct memory"
                         kind: "structConstructorCall"
                         fieldNames: undefined
@@ -926,6 +925,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: StructDefinition #479
                         <getter> vFunctionName: "SomeStruct"
                         <getter> vCallee: MemberAccess #534
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #534
                         <getter> lastChild: Literal #535
                         <getter> previousSibling: VariableDeclaration #531
@@ -936,7 +936,6 @@ SourceUnit #959
                         MemberAccess #534
                             id: 534
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "type(struct SomeContract.SomeStruct storage pointer)"
                             vExpression: MemberAccess #533
                             memberName: "SomeStruct"
@@ -945,6 +944,7 @@ SourceUnit #959
                             parent: FunctionCall #536
                             <getter> children: Array(1) [ MemberAccess #533 ]
                             <getter> vReferencedDeclaration: StructDefinition #479
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: MemberAccess #533
                             <getter> lastChild: MemberAccess #533
                             <getter> previousSibling: undefined
@@ -955,7 +955,6 @@ SourceUnit #959
                             MemberAccess #533
                                 id: 533
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "type(contract SomeContract)"
                                 vExpression: Identifier #532
                                 memberName: "SomeContract"
@@ -964,6 +963,7 @@ SourceUnit #959
                                 parent: MemberAccess #534
                                 <getter> children: Array(1) [ Identifier #532 ]
                                 <getter> vReferencedDeclaration: ContractDefinition #488
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: Identifier #532
                                 <getter> lastChild: Identifier #532
                                 <getter> previousSibling: undefined
@@ -974,7 +974,6 @@ SourceUnit #959
                                 Identifier #532
                                     id: 532
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "module \"./test/samples/solidity/latest_imports_08.sol\""
                                     name: "LI"
                                     referencedDeclaration: 493
@@ -982,6 +981,7 @@ SourceUnit #959
                                     parent: MemberAccess #533
                                     <getter> vReferencedDeclaration: ImportDirective #493
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -993,7 +993,6 @@ SourceUnit #959
                         Literal #535
                             id: 535
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "int_const 10"
                             kind: "number"
                             hexValue: "3130"
@@ -1001,6 +1000,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: FunctionCall #536
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -1012,7 +1012,6 @@ SourceUnit #959
         FunctionDefinition #549
             id: 549
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 550
@@ -1032,6 +1031,7 @@ SourceUnit #959
             parent: ContractDefinition #550
             <getter> children: Array(4) [ ParameterList #540, OverrideSpecifier #545, ParameterList #543, Block #548 ]
             <getter> vScope: ContractDefinition #550
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #540
             <getter> lastChild: Block #548
             <getter> previousSibling: FunctionDefinition #539
@@ -1042,11 +1042,11 @@ SourceUnit #959
             ParameterList #540
                 id: 540
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #549
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -1057,11 +1057,11 @@ SourceUnit #959
             OverrideSpecifier #545
                 id: 545
                 src: "0:0:0"
-                type: "OverrideSpecifier"
                 context: ASTContext #1000
                 parent: FunctionDefinition #549
                 <getter> vOverrides: Array(1) [ IdentifierPath #544 ]
                 <getter> children: Array(1) [ IdentifierPath #544 ]
+                <getter> type: "OverrideSpecifier"
                 <getter> firstChild: IdentifierPath #544
                 <getter> lastChild: IdentifierPath #544
                 <getter> previousSibling: ParameterList #540
@@ -1072,12 +1072,12 @@ SourceUnit #959
                 IdentifierPath #544
                     id: 544
                     src: "0:0:0"
-                    type: "IdentifierPath"
                     name: "LI.SomeContract"
                     referencedDeclaration: 488
                     context: ASTContext #1000
                     parent: OverrideSpecifier #545
                     <getter> vReferencedDeclaration: ContractDefinition #488
+                    <getter> type: "IdentifierPath"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -1089,11 +1089,11 @@ SourceUnit #959
             ParameterList #543
                 id: 543
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #549
                 <getter> vParameters: Array(1) [ VariableDeclaration #542 ]
                 <getter> children: Array(1) [ VariableDeclaration #542 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #542
                 <getter> lastChild: VariableDeclaration #542
                 <getter> previousSibling: OverrideSpecifier #545
@@ -1104,7 +1104,6 @@ SourceUnit #959
                 VariableDeclaration #542
                     id: 542
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -1123,6 +1122,7 @@ SourceUnit #959
                     parent: ParameterList #543
                     <getter> children: Array(1) [ ElementaryTypeName #541 ]
                     <getter> vScope: FunctionDefinition #549
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #541
                     <getter> lastChild: ElementaryTypeName #541
                     <getter> previousSibling: undefined
@@ -1133,12 +1133,12 @@ SourceUnit #959
                     ElementaryTypeName #541
                         id: 541
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #542
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -1150,12 +1150,12 @@ SourceUnit #959
             Block #548
                 id: 548
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #549
                 <getter> vStatements: Array(1) [ Return #547 ]
                 <getter> children: Array(1) [ Return #547 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #547
                 <getter> lastChild: Return #547
                 <getter> previousSibling: ParameterList #543
@@ -1166,7 +1166,6 @@ SourceUnit #959
                 Return #547
                     id: 547
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 58
                     vExpression: Literal #546
@@ -1174,6 +1173,7 @@ SourceUnit #959
                     parent: Block #548
                     <getter> children: Array(1) [ Literal #546 ]
                     <getter> vFunctionReturnParameters: ParameterList #58
+                    <getter> type: "Return"
                     <getter> firstChild: Literal #546
                     <getter> lastChild: Literal #546
                     <getter> previousSibling: undefined
@@ -1184,7 +1184,6 @@ SourceUnit #959
                     Literal #546
                         id: 546
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "int_const 2"
                         kind: "number"
                         hexValue: "32"
@@ -1192,6 +1191,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: Return #547
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -1203,7 +1203,6 @@ SourceUnit #959
     ContractDefinition #571
         id: 571
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "UsesNewAddressMembers"
         scope: 959
         kind: "contract"
@@ -1231,6 +1230,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #570 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #570
         <getter> lastChild: FunctionDefinition #570
         <getter> previousSibling: ContractDefinition #550
@@ -1241,7 +1241,6 @@ SourceUnit #959
         FunctionDefinition #570
             id: 570
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 571
@@ -1261,6 +1260,7 @@ SourceUnit #959
             parent: ContractDefinition #571
             <getter> children: Array(3) [ ParameterList #551, ParameterList #552, Block #569 ]
             <getter> vScope: ContractDefinition #571
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #551
             <getter> lastChild: Block #569
             <getter> previousSibling: undefined
@@ -1271,11 +1271,11 @@ SourceUnit #959
             ParameterList #551
                 id: 551
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #570
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -1286,11 +1286,11 @@ SourceUnit #959
             ParameterList #552
                 id: 552
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #570
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #551
@@ -1301,12 +1301,12 @@ SourceUnit #959
             Block #569
                 id: 569
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #570
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #560, VariableDeclarationStatement #568 ]
                 <getter> children: Array(2) [ VariableDeclarationStatement #560, VariableDeclarationStatement #568 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #560
                 <getter> lastChild: VariableDeclarationStatement #568
                 <getter> previousSibling: ParameterList #552
@@ -1317,7 +1317,6 @@ SourceUnit #959
                 VariableDeclarationStatement #560
                     id: 560
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 554 ]
                     vDeclarations: Array(1) [ VariableDeclaration #554 ]
@@ -1325,6 +1324,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #569
                     <getter> children: Array(2) [ VariableDeclaration #554, MemberAccess #559 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #554
                     <getter> lastChild: MemberAccess #559
                     <getter> previousSibling: undefined
@@ -1335,7 +1335,6 @@ SourceUnit #959
                     VariableDeclaration #554
                         id: 554
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "code"
@@ -1354,6 +1353,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #560
                         <getter> children: Array(1) [ ElementaryTypeName #553 ]
                         <getter> vScope: Block #569
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: ElementaryTypeName #553
                         <getter> lastChild: ElementaryTypeName #553
                         <getter> previousSibling: undefined
@@ -1364,12 +1364,12 @@ SourceUnit #959
                         ElementaryTypeName #553
                             id: 553
                             src: "0:0:0"
-                            type: "ElementaryTypeName"
                             typeString: "bytes"
                             name: "bytes"
                             stateMutability: "nonpayable"
                             context: ASTContext #1000
                             parent: VariableDeclaration #554
+                            <getter> type: "ElementaryTypeName"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -1381,7 +1381,6 @@ SourceUnit #959
                     MemberAccess #559
                         id: 559
                         src: "0:0:0"
-                        type: "MemberAccess"
                         typeString: "bytes memory"
                         vExpression: FunctionCall #558
                         memberName: "code"
@@ -1390,6 +1389,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #560
                         <getter> children: Array(1) [ FunctionCall #558 ]
                         <getter> vReferencedDeclaration: undefined
+                        <getter> type: "MemberAccess"
                         <getter> firstChild: FunctionCall #558
                         <getter> lastChild: FunctionCall #558
                         <getter> previousSibling: VariableDeclaration #554
@@ -1400,7 +1400,6 @@ SourceUnit #959
                         FunctionCall #558
                             id: 558
                             src: "0:0:0"
-                            type: "FunctionCall"
                             typeString: "address"
                             kind: "typeConversion"
                             fieldNames: undefined
@@ -1415,6 +1414,7 @@ SourceUnit #959
                             <getter> vReferencedDeclaration: undefined
                             <getter> vFunctionName: "address"
                             <getter> vCallee: ElementaryTypeNameExpression #556
+                            <getter> type: "FunctionCall"
                             <getter> firstChild: ElementaryTypeNameExpression #556
                             <getter> lastChild: Literal #557
                             <getter> previousSibling: undefined
@@ -1425,12 +1425,12 @@ SourceUnit #959
                             ElementaryTypeNameExpression #556
                                 id: 556
                                 src: "0:0:0"
-                                type: "ElementaryTypeNameExpression"
                                 typeString: "type(address)"
                                 typeName: ElementaryTypeName #555
                                 context: ASTContext #1000
                                 parent: FunctionCall #558
                                 <getter> children: Array(1) [ ElementaryTypeName #555 ]
+                                <getter> type: "ElementaryTypeNameExpression"
                                 <getter> firstChild: ElementaryTypeName #555
                                 <getter> lastChild: ElementaryTypeName #555
                                 <getter> previousSibling: undefined
@@ -1441,12 +1441,12 @@ SourceUnit #959
                                 ElementaryTypeName #555
                                     id: 555
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: undefined
                                     name: "address"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: ElementaryTypeNameExpression #556
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -1458,7 +1458,6 @@ SourceUnit #959
                             Literal #557
                                 id: 557
                                 src: "0:0:0"
-                                type: "Literal"
                                 typeString: "int_const 0"
                                 kind: "number"
                                 hexValue: "30"
@@ -1466,6 +1465,7 @@ SourceUnit #959
                                 subdenomination: undefined
                                 context: ASTContext #1000
                                 parent: FunctionCall #558
+                                <getter> type: "Literal"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1477,7 +1477,6 @@ SourceUnit #959
                 VariableDeclarationStatement #568
                     id: 568
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 562 ]
                     vDeclarations: Array(1) [ VariableDeclaration #562 ]
@@ -1485,6 +1484,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #569
                     <getter> children: Array(2) [ VariableDeclaration #562, MemberAccess #567 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #562
                     <getter> lastChild: MemberAccess #567
                     <getter> previousSibling: VariableDeclarationStatement #560
@@ -1495,7 +1495,6 @@ SourceUnit #959
                     VariableDeclaration #562
                         id: 562
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "codeHash"
@@ -1514,6 +1513,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #568
                         <getter> children: Array(1) [ ElementaryTypeName #561 ]
                         <getter> vScope: Block #569
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: ElementaryTypeName #561
                         <getter> lastChild: ElementaryTypeName #561
                         <getter> previousSibling: undefined
@@ -1524,12 +1524,12 @@ SourceUnit #959
                         ElementaryTypeName #561
                             id: 561
                             src: "0:0:0"
-                            type: "ElementaryTypeName"
                             typeString: "bytes32"
                             name: "bytes32"
                             stateMutability: "nonpayable"
                             context: ASTContext #1000
                             parent: VariableDeclaration #562
+                            <getter> type: "ElementaryTypeName"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -1541,7 +1541,6 @@ SourceUnit #959
                     MemberAccess #567
                         id: 567
                         src: "0:0:0"
-                        type: "MemberAccess"
                         typeString: "bytes32"
                         vExpression: FunctionCall #566
                         memberName: "codehash"
@@ -1550,6 +1549,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #568
                         <getter> children: Array(1) [ FunctionCall #566 ]
                         <getter> vReferencedDeclaration: undefined
+                        <getter> type: "MemberAccess"
                         <getter> firstChild: FunctionCall #566
                         <getter> lastChild: FunctionCall #566
                         <getter> previousSibling: VariableDeclaration #562
@@ -1560,7 +1560,6 @@ SourceUnit #959
                         FunctionCall #566
                             id: 566
                             src: "0:0:0"
-                            type: "FunctionCall"
                             typeString: "address"
                             kind: "typeConversion"
                             fieldNames: undefined
@@ -1575,6 +1574,7 @@ SourceUnit #959
                             <getter> vReferencedDeclaration: undefined
                             <getter> vFunctionName: "address"
                             <getter> vCallee: ElementaryTypeNameExpression #564
+                            <getter> type: "FunctionCall"
                             <getter> firstChild: ElementaryTypeNameExpression #564
                             <getter> lastChild: Literal #565
                             <getter> previousSibling: undefined
@@ -1585,12 +1585,12 @@ SourceUnit #959
                             ElementaryTypeNameExpression #564
                                 id: 564
                                 src: "0:0:0"
-                                type: "ElementaryTypeNameExpression"
                                 typeString: "type(address)"
                                 typeName: ElementaryTypeName #563
                                 context: ASTContext #1000
                                 parent: FunctionCall #566
                                 <getter> children: Array(1) [ ElementaryTypeName #563 ]
+                                <getter> type: "ElementaryTypeNameExpression"
                                 <getter> firstChild: ElementaryTypeName #563
                                 <getter> lastChild: ElementaryTypeName #563
                                 <getter> previousSibling: undefined
@@ -1601,12 +1601,12 @@ SourceUnit #959
                                 ElementaryTypeName #563
                                     id: 563
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: undefined
                                     name: "address"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: ElementaryTypeNameExpression #564
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -1618,7 +1618,6 @@ SourceUnit #959
                             Literal #565
                                 id: 565
                                 src: "0:0:0"
-                                type: "Literal"
                                 typeString: "int_const 0"
                                 kind: "number"
                                 hexValue: "30"
@@ -1626,6 +1625,7 @@ SourceUnit #959
                                 subdenomination: undefined
                                 context: ASTContext #1000
                                 parent: FunctionCall #566
+                                <getter> type: "Literal"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1637,7 +1637,6 @@ SourceUnit #959
     ContractDefinition #628
         id: 628
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "CatchPanic"
         scope: 959
         kind: "contract"
@@ -1665,6 +1664,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #627 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #627
         <getter> lastChild: FunctionDefinition #627
         <getter> previousSibling: ContractDefinition #571
@@ -1675,7 +1675,6 @@ SourceUnit #959
         FunctionDefinition #627
             id: 627
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 628
@@ -1695,6 +1694,7 @@ SourceUnit #959
             parent: ContractDefinition #628
             <getter> children: Array(3) [ ParameterList #572, ParameterList #573, Block #626 ]
             <getter> vScope: ContractDefinition #628
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #572
             <getter> lastChild: Block #626
             <getter> previousSibling: undefined
@@ -1705,11 +1705,11 @@ SourceUnit #959
             ParameterList #572
                 id: 572
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #627
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -1720,11 +1720,11 @@ SourceUnit #959
             ParameterList #573
                 id: 573
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #627
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #572
@@ -1735,12 +1735,12 @@ SourceUnit #959
             Block #626
                 id: 626
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #627
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #581, TryStatement #625 ]
                 <getter> children: Array(2) [ VariableDeclarationStatement #581, TryStatement #625 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #581
                 <getter> lastChild: TryStatement #625
                 <getter> previousSibling: ParameterList #573
@@ -1751,7 +1751,6 @@ SourceUnit #959
                 VariableDeclarationStatement #581
                     id: 581
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 576 ]
                     vDeclarations: Array(1) [ VariableDeclaration #576 ]
@@ -1759,6 +1758,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #626
                     <getter> children: Array(2) [ VariableDeclaration #576, FunctionCall #580 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #576
                     <getter> lastChild: FunctionCall #580
                     <getter> previousSibling: undefined
@@ -1769,7 +1769,6 @@ SourceUnit #959
                     VariableDeclaration #576
                         id: 576
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "c"
@@ -1788,6 +1787,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #581
                         <getter> children: Array(1) [ UserDefinedTypeName #575 ]
                         <getter> vScope: Block #626
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: UserDefinedTypeName #575
                         <getter> lastChild: UserDefinedTypeName #575
                         <getter> previousSibling: undefined
@@ -1798,7 +1798,6 @@ SourceUnit #959
                         UserDefinedTypeName #575
                             id: 575
                             src: "0:0:0"
-                            type: "UserDefinedTypeName"
                             typeString: "contract UsesNewAddressMembers"
                             name: undefined
                             referencedDeclaration: 571
@@ -1807,6 +1806,7 @@ SourceUnit #959
                             parent: VariableDeclaration #576
                             <getter> children: Array(1) [ IdentifierPath #574 ]
                             <getter> vReferencedDeclaration: ContractDefinition #571
+                            <getter> type: "UserDefinedTypeName"
                             <getter> firstChild: IdentifierPath #574
                             <getter> lastChild: IdentifierPath #574
                             <getter> previousSibling: undefined
@@ -1817,12 +1817,12 @@ SourceUnit #959
                             IdentifierPath #574
                                 id: 574
                                 src: "0:0:0"
-                                type: "IdentifierPath"
                                 name: "UsesNewAddressMembers"
                                 referencedDeclaration: 84
                                 context: ASTContext #1000
                                 parent: UserDefinedTypeName #575
                                 <getter> vReferencedDeclaration: ContractDefinition #84
+                                <getter> type: "IdentifierPath"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1834,7 +1834,6 @@ SourceUnit #959
                     FunctionCall #580
                         id: 580
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "contract UsesNewAddressMembers"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -1849,6 +1848,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "new"
                         <getter> vCallee: NewExpression #579
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: NewExpression #579
                         <getter> lastChild: NewExpression #579
                         <getter> previousSibling: VariableDeclaration #576
@@ -1859,12 +1859,12 @@ SourceUnit #959
                         NewExpression #579
                             id: 579
                             src: "0:0:0"
-                            type: "NewExpression"
                             typeString: "function () returns (contract UsesNewAddressMembers)"
                             vTypeName: UserDefinedTypeName #578
                             context: ASTContext #1000
                             parent: FunctionCall #580
                             <getter> children: Array(1) [ UserDefinedTypeName #578 ]
+                            <getter> type: "NewExpression"
                             <getter> firstChild: UserDefinedTypeName #578
                             <getter> lastChild: UserDefinedTypeName #578
                             <getter> previousSibling: undefined
@@ -1875,7 +1875,6 @@ SourceUnit #959
                             UserDefinedTypeName #578
                                 id: 578
                                 src: "0:0:0"
-                                type: "UserDefinedTypeName"
                                 typeString: "contract UsesNewAddressMembers"
                                 name: undefined
                                 referencedDeclaration: 571
@@ -1884,6 +1883,7 @@ SourceUnit #959
                                 parent: NewExpression #579
                                 <getter> children: Array(1) [ IdentifierPath #577 ]
                                 <getter> vReferencedDeclaration: ContractDefinition #571
+                                <getter> type: "UserDefinedTypeName"
                                 <getter> firstChild: IdentifierPath #577
                                 <getter> lastChild: IdentifierPath #577
                                 <getter> previousSibling: undefined
@@ -1894,12 +1894,12 @@ SourceUnit #959
                                 IdentifierPath #577
                                     id: 577
                                     src: "0:0:0"
-                                    type: "IdentifierPath"
                                     name: "UsesNewAddressMembers"
                                     referencedDeclaration: 84
                                     context: ASTContext #1000
                                     parent: UserDefinedTypeName #578
                                     <getter> vReferencedDeclaration: ContractDefinition #84
+                                    <getter> type: "IdentifierPath"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -1911,13 +1911,13 @@ SourceUnit #959
                 TryStatement #625
                     id: 625
                     src: "0:0:0"
-                    type: "TryStatement"
                     documentation: undefined
                     vExternalCall: FunctionCall #584
                     vClauses: Array(4) [ TryCatchClause #586, TryCatchClause #595, TryCatchClause #618, TryCatchClause #624 ]
                     context: ASTContext #1000
                     parent: Block #626
                     <getter> children: Array(5) [ FunctionCall #584, TryCatchClause #586, TryCatchClause #595, TryCatchClause #618, TryCatchClause #624 ]
+                    <getter> type: "TryStatement"
                     <getter> firstChild: FunctionCall #584
                     <getter> lastChild: TryCatchClause #624
                     <getter> previousSibling: VariableDeclarationStatement #581
@@ -1928,7 +1928,6 @@ SourceUnit #959
                     FunctionCall #584
                         id: 584
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -1943,6 +1942,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: FunctionDefinition #570
                         <getter> vFunctionName: "test"
                         <getter> vCallee: MemberAccess #583
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #583
                         <getter> lastChild: MemberAccess #583
                         <getter> previousSibling: undefined
@@ -1953,7 +1953,6 @@ SourceUnit #959
                         MemberAccess #583
                             id: 583
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function () external"
                             vExpression: Identifier #582
                             memberName: "test"
@@ -1962,6 +1961,7 @@ SourceUnit #959
                             parent: FunctionCall #584
                             <getter> children: Array(1) [ Identifier #582 ]
                             <getter> vReferencedDeclaration: FunctionDefinition #570
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #582
                             <getter> lastChild: Identifier #582
                             <getter> previousSibling: undefined
@@ -1972,7 +1972,6 @@ SourceUnit #959
                             Identifier #582
                                 id: 582
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "contract UsesNewAddressMembers"
                                 name: "c"
                                 referencedDeclaration: 576
@@ -1980,6 +1979,7 @@ SourceUnit #959
                                 parent: MemberAccess #583
                                 <getter> vReferencedDeclaration: VariableDeclaration #576
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -1991,7 +1991,6 @@ SourceUnit #959
                     TryCatchClause #586
                         id: 586
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: ""
                         vParameters: undefined
@@ -1999,6 +1998,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #625
                         <getter> children: Array(1) [ Block #585 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: Block #585
                         <getter> lastChild: Block #585
                         <getter> previousSibling: FunctionCall #584
@@ -2009,12 +2009,12 @@ SourceUnit #959
                         Block #585
                             id: 585
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #586
                             <getter> vStatements: Array(0)
                             <getter> children: Array(0)
+                            <getter> type: "Block"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -2025,7 +2025,6 @@ SourceUnit #959
                     TryCatchClause #595
                         id: 595
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: "Error"
                         vParameters: ParameterList #594
@@ -2033,6 +2032,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #625
                         <getter> children: Array(2) [ ParameterList #594, Block #591 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: ParameterList #594
                         <getter> lastChild: Block #591
                         <getter> previousSibling: TryCatchClause #586
@@ -2043,11 +2043,11 @@ SourceUnit #959
                         ParameterList #594
                             id: 594
                             src: "0:0:0"
-                            type: "ParameterList"
                             context: ASTContext #1000
                             parent: TryCatchClause #595
                             <getter> vParameters: Array(1) [ VariableDeclaration #593 ]
                             <getter> children: Array(1) [ VariableDeclaration #593 ]
+                            <getter> type: "ParameterList"
                             <getter> firstChild: VariableDeclaration #593
                             <getter> lastChild: VariableDeclaration #593
                             <getter> previousSibling: undefined
@@ -2058,7 +2058,6 @@ SourceUnit #959
                             VariableDeclaration #593
                                 id: 593
                                 src: "0:0:0"
-                                type: "VariableDeclaration"
                                 constant: false
                                 indexed: false
                                 name: "reason"
@@ -2077,6 +2076,7 @@ SourceUnit #959
                                 parent: ParameterList #594
                                 <getter> children: Array(1) [ ElementaryTypeName #592 ]
                                 <getter> vScope: TryCatchClause #595
+                                <getter> type: "VariableDeclaration"
                                 <getter> firstChild: ElementaryTypeName #592
                                 <getter> lastChild: ElementaryTypeName #592
                                 <getter> previousSibling: undefined
@@ -2087,12 +2087,12 @@ SourceUnit #959
                                 ElementaryTypeName #592
                                     id: 592
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: "string"
                                     name: "string"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: VariableDeclaration #593
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -2104,12 +2104,12 @@ SourceUnit #959
                         Block #591
                             id: 591
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #595
                             <getter> vStatements: Array(1) [ ExpressionStatement #590 ]
                             <getter> children: Array(1) [ ExpressionStatement #590 ]
+                            <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #590
                             <getter> lastChild: ExpressionStatement #590
                             <getter> previousSibling: ParameterList #594
@@ -2120,12 +2120,12 @@ SourceUnit #959
                             ExpressionStatement #590
                                 id: 590
                                 src: "0:0:0"
-                                type: "ExpressionStatement"
                                 documentation: undefined
                                 vExpression: FunctionCall #589
                                 context: ASTContext #1000
                                 parent: Block #591
                                 <getter> children: Array(1) [ FunctionCall #589 ]
+                                <getter> type: "ExpressionStatement"
                                 <getter> firstChild: FunctionCall #589
                                 <getter> lastChild: FunctionCall #589
                                 <getter> previousSibling: undefined
@@ -2136,7 +2136,6 @@ SourceUnit #959
                                 FunctionCall #589
                                     id: 589
                                     src: "0:0:0"
-                                    type: "FunctionCall"
                                     typeString: "tuple()"
                                     kind: "functionCall"
                                     fieldNames: undefined
@@ -2151,6 +2150,7 @@ SourceUnit #959
                                     <getter> vReferencedDeclaration: undefined
                                     <getter> vFunctionName: "revert"
                                     <getter> vCallee: Identifier #587
+                                    <getter> type: "FunctionCall"
                                     <getter> firstChild: Identifier #587
                                     <getter> lastChild: Identifier #588
                                     <getter> previousSibling: undefined
@@ -2161,7 +2161,6 @@ SourceUnit #959
                                     Identifier #587
                                         id: 587
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "function (string memory) pure"
                                         name: "revert"
                                         referencedDeclaration: -1
@@ -2169,6 +2168,7 @@ SourceUnit #959
                                         parent: FunctionCall #589
                                         <getter> vReferencedDeclaration: undefined
                                         <getter> vIdentifierType: "builtin"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2180,7 +2180,6 @@ SourceUnit #959
                                     Identifier #588
                                         id: 588
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "string memory"
                                         name: "reason"
                                         referencedDeclaration: 593
@@ -2188,6 +2187,7 @@ SourceUnit #959
                                         parent: FunctionCall #589
                                         <getter> vReferencedDeclaration: VariableDeclaration #593
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2199,7 +2199,6 @@ SourceUnit #959
                     TryCatchClause #618
                         id: 618
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: "Panic"
                         vParameters: ParameterList #617
@@ -2207,6 +2206,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #625
                         <getter> children: Array(2) [ ParameterList #617, Block #614 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: ParameterList #617
                         <getter> lastChild: Block #614
                         <getter> previousSibling: TryCatchClause #595
@@ -2217,11 +2217,11 @@ SourceUnit #959
                         ParameterList #617
                             id: 617
                             src: "0:0:0"
-                            type: "ParameterList"
                             context: ASTContext #1000
                             parent: TryCatchClause #618
                             <getter> vParameters: Array(1) [ VariableDeclaration #616 ]
                             <getter> children: Array(1) [ VariableDeclaration #616 ]
+                            <getter> type: "ParameterList"
                             <getter> firstChild: VariableDeclaration #616
                             <getter> lastChild: VariableDeclaration #616
                             <getter> previousSibling: undefined
@@ -2232,7 +2232,6 @@ SourceUnit #959
                             VariableDeclaration #616
                                 id: 616
                                 src: "0:0:0"
-                                type: "VariableDeclaration"
                                 constant: false
                                 indexed: false
                                 name: "_code"
@@ -2251,6 +2250,7 @@ SourceUnit #959
                                 parent: ParameterList #617
                                 <getter> children: Array(1) [ ElementaryTypeName #615 ]
                                 <getter> vScope: TryCatchClause #618
+                                <getter> type: "VariableDeclaration"
                                 <getter> firstChild: ElementaryTypeName #615
                                 <getter> lastChild: ElementaryTypeName #615
                                 <getter> previousSibling: undefined
@@ -2261,12 +2261,12 @@ SourceUnit #959
                                 ElementaryTypeName #615
                                     id: 615
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: "uint256"
                                     name: "uint"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: VariableDeclaration #616
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -2278,12 +2278,12 @@ SourceUnit #959
                         Block #614
                             id: 614
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #618
                             <getter> vStatements: Array(1) [ IfStatement #613 ]
                             <getter> children: Array(1) [ IfStatement #613 ]
+                            <getter> type: "Block"
                             <getter> firstChild: IfStatement #613
                             <getter> lastChild: IfStatement #613
                             <getter> previousSibling: ParameterList #617
@@ -2294,7 +2294,6 @@ SourceUnit #959
                             IfStatement #613
                                 id: 613
                                 src: "0:0:0"
-                                type: "IfStatement"
                                 documentation: undefined
                                 vCondition: BinaryOperation #598
                                 vTrueBody: Block #603
@@ -2302,6 +2301,7 @@ SourceUnit #959
                                 context: ASTContext #1000
                                 parent: Block #614
                                 <getter> children: Array(3) [ BinaryOperation #598, Block #603, IfStatement #612 ]
+                                <getter> type: "IfStatement"
                                 <getter> firstChild: BinaryOperation #598
                                 <getter> lastChild: IfStatement #612
                                 <getter> previousSibling: undefined
@@ -2312,7 +2312,6 @@ SourceUnit #959
                                 BinaryOperation #598
                                     id: 598
                                     src: "0:0:0"
-                                    type: "BinaryOperation"
                                     typeString: "bool"
                                     operator: "=="
                                     vLeftExpression: Identifier #596
@@ -2320,6 +2319,7 @@ SourceUnit #959
                                     context: ASTContext #1000
                                     parent: IfStatement #613
                                     <getter> children: Array(2) [ Identifier #596, Literal #597 ]
+                                    <getter> type: "BinaryOperation"
                                     <getter> firstChild: Identifier #596
                                     <getter> lastChild: Literal #597
                                     <getter> previousSibling: undefined
@@ -2330,7 +2330,6 @@ SourceUnit #959
                                     Identifier #596
                                         id: 596
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "uint256"
                                         name: "_code"
                                         referencedDeclaration: 616
@@ -2338,6 +2337,7 @@ SourceUnit #959
                                         parent: BinaryOperation #598
                                         <getter> vReferencedDeclaration: VariableDeclaration #616
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2349,7 +2349,6 @@ SourceUnit #959
                                     Literal #597
                                         id: 597
                                         src: "0:0:0"
-                                        type: "Literal"
                                         typeString: "int_const 1"
                                         kind: "number"
                                         hexValue: "30783031"
@@ -2357,6 +2356,7 @@ SourceUnit #959
                                         subdenomination: undefined
                                         context: ASTContext #1000
                                         parent: BinaryOperation #598
+                                        <getter> type: "Literal"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2368,12 +2368,12 @@ SourceUnit #959
                                 Block #603
                                     id: 603
                                     src: "0:0:0"
-                                    type: "Block"
                                     documentation: undefined
                                     context: ASTContext #1000
                                     parent: IfStatement #613
                                     <getter> vStatements: Array(1) [ ExpressionStatement #602 ]
                                     <getter> children: Array(1) [ ExpressionStatement #602 ]
+                                    <getter> type: "Block"
                                     <getter> firstChild: ExpressionStatement #602
                                     <getter> lastChild: ExpressionStatement #602
                                     <getter> previousSibling: BinaryOperation #598
@@ -2384,12 +2384,12 @@ SourceUnit #959
                                     ExpressionStatement #602
                                         id: 602
                                         src: "0:0:0"
-                                        type: "ExpressionStatement"
                                         documentation: undefined
                                         vExpression: FunctionCall #601
                                         context: ASTContext #1000
                                         parent: Block #603
                                         <getter> children: Array(1) [ FunctionCall #601 ]
+                                        <getter> type: "ExpressionStatement"
                                         <getter> firstChild: FunctionCall #601
                                         <getter> lastChild: FunctionCall #601
                                         <getter> previousSibling: undefined
@@ -2400,7 +2400,6 @@ SourceUnit #959
                                         FunctionCall #601
                                             id: 601
                                             src: "0:0:0"
-                                            type: "FunctionCall"
                                             typeString: "tuple()"
                                             kind: "functionCall"
                                             fieldNames: undefined
@@ -2415,6 +2414,7 @@ SourceUnit #959
                                             <getter> vReferencedDeclaration: undefined
                                             <getter> vFunctionName: "revert"
                                             <getter> vCallee: Identifier #599
+                                            <getter> type: "FunctionCall"
                                             <getter> firstChild: Identifier #599
                                             <getter> lastChild: Literal #600
                                             <getter> previousSibling: undefined
@@ -2425,7 +2425,6 @@ SourceUnit #959
                                             Identifier #599
                                                 id: 599
                                                 src: "0:0:0"
-                                                type: "Identifier"
                                                 typeString: "function (string memory) pure"
                                                 name: "revert"
                                                 referencedDeclaration: -1
@@ -2433,6 +2432,7 @@ SourceUnit #959
                                                 parent: FunctionCall #601
                                                 <getter> vReferencedDeclaration: undefined
                                                 <getter> vIdentifierType: "builtin"
+                                                <getter> type: "Identifier"
                                                 <getter> children: Array(0)
                                                 <getter> firstChild: undefined
                                                 <getter> lastChild: undefined
@@ -2444,7 +2444,6 @@ SourceUnit #959
                                             Literal #600
                                                 id: 600
                                                 src: "0:0:0"
-                                                type: "Literal"
                                                 typeString: "literal_string \"Assertion failed\""
                                                 kind: "string"
                                                 hexValue: "417373657274696f6e206661696c6564"
@@ -2452,6 +2451,7 @@ SourceUnit #959
                                                 subdenomination: undefined
                                                 context: ASTContext #1000
                                                 parent: FunctionCall #601
+                                                <getter> type: "Literal"
                                                 <getter> children: Array(0)
                                                 <getter> firstChild: undefined
                                                 <getter> lastChild: undefined
@@ -2463,7 +2463,6 @@ SourceUnit #959
                                 IfStatement #612
                                     id: 612
                                     src: "0:0:0"
-                                    type: "IfStatement"
                                     documentation: undefined
                                     vCondition: BinaryOperation #606
                                     vTrueBody: Block #611
@@ -2471,6 +2470,7 @@ SourceUnit #959
                                     context: ASTContext #1000
                                     parent: IfStatement #613
                                     <getter> children: Array(2) [ BinaryOperation #606, Block #611 ]
+                                    <getter> type: "IfStatement"
                                     <getter> firstChild: BinaryOperation #606
                                     <getter> lastChild: Block #611
                                     <getter> previousSibling: Block #603
@@ -2481,7 +2481,6 @@ SourceUnit #959
                                     BinaryOperation #606
                                         id: 606
                                         src: "0:0:0"
-                                        type: "BinaryOperation"
                                         typeString: "bool"
                                         operator: "=="
                                         vLeftExpression: Identifier #604
@@ -2489,6 +2488,7 @@ SourceUnit #959
                                         context: ASTContext #1000
                                         parent: IfStatement #612
                                         <getter> children: Array(2) [ Identifier #604, Literal #605 ]
+                                        <getter> type: "BinaryOperation"
                                         <getter> firstChild: Identifier #604
                                         <getter> lastChild: Literal #605
                                         <getter> previousSibling: undefined
@@ -2499,7 +2499,6 @@ SourceUnit #959
                                         Identifier #604
                                             id: 604
                                             src: "0:0:0"
-                                            type: "Identifier"
                                             typeString: "uint256"
                                             name: "_code"
                                             referencedDeclaration: 616
@@ -2507,6 +2506,7 @@ SourceUnit #959
                                             parent: BinaryOperation #606
                                             <getter> vReferencedDeclaration: VariableDeclaration #616
                                             <getter> vIdentifierType: "userDefined"
+                                            <getter> type: "Identifier"
                                             <getter> children: Array(0)
                                             <getter> firstChild: undefined
                                             <getter> lastChild: undefined
@@ -2518,7 +2518,6 @@ SourceUnit #959
                                         Literal #605
                                             id: 605
                                             src: "0:0:0"
-                                            type: "Literal"
                                             typeString: "int_const 17"
                                             kind: "number"
                                             hexValue: "30783131"
@@ -2526,6 +2525,7 @@ SourceUnit #959
                                             subdenomination: undefined
                                             context: ASTContext #1000
                                             parent: BinaryOperation #606
+                                            <getter> type: "Literal"
                                             <getter> children: Array(0)
                                             <getter> firstChild: undefined
                                             <getter> lastChild: undefined
@@ -2537,12 +2537,12 @@ SourceUnit #959
                                     Block #611
                                         id: 611
                                         src: "0:0:0"
-                                        type: "Block"
                                         documentation: undefined
                                         context: ASTContext #1000
                                         parent: IfStatement #612
                                         <getter> vStatements: Array(1) [ ExpressionStatement #610 ]
                                         <getter> children: Array(1) [ ExpressionStatement #610 ]
+                                        <getter> type: "Block"
                                         <getter> firstChild: ExpressionStatement #610
                                         <getter> lastChild: ExpressionStatement #610
                                         <getter> previousSibling: BinaryOperation #606
@@ -2553,12 +2553,12 @@ SourceUnit #959
                                         ExpressionStatement #610
                                             id: 610
                                             src: "0:0:0"
-                                            type: "ExpressionStatement"
                                             documentation: undefined
                                             vExpression: FunctionCall #609
                                             context: ASTContext #1000
                                             parent: Block #611
                                             <getter> children: Array(1) [ FunctionCall #609 ]
+                                            <getter> type: "ExpressionStatement"
                                             <getter> firstChild: FunctionCall #609
                                             <getter> lastChild: FunctionCall #609
                                             <getter> previousSibling: undefined
@@ -2569,7 +2569,6 @@ SourceUnit #959
                                             FunctionCall #609
                                                 id: 609
                                                 src: "0:0:0"
-                                                type: "FunctionCall"
                                                 typeString: "tuple()"
                                                 kind: "functionCall"
                                                 fieldNames: undefined
@@ -2584,6 +2583,7 @@ SourceUnit #959
                                                 <getter> vReferencedDeclaration: undefined
                                                 <getter> vFunctionName: "revert"
                                                 <getter> vCallee: Identifier #607
+                                                <getter> type: "FunctionCall"
                                                 <getter> firstChild: Identifier #607
                                                 <getter> lastChild: Literal #608
                                                 <getter> previousSibling: undefined
@@ -2594,7 +2594,6 @@ SourceUnit #959
                                                 Identifier #607
                                                     id: 607
                                                     src: "0:0:0"
-                                                    type: "Identifier"
                                                     typeString: "function (string memory) pure"
                                                     name: "revert"
                                                     referencedDeclaration: -1
@@ -2602,6 +2601,7 @@ SourceUnit #959
                                                     parent: FunctionCall #609
                                                     <getter> vReferencedDeclaration: undefined
                                                     <getter> vIdentifierType: "builtin"
+                                                    <getter> type: "Identifier"
                                                     <getter> children: Array(0)
                                                     <getter> firstChild: undefined
                                                     <getter> lastChild: undefined
@@ -2613,7 +2613,6 @@ SourceUnit #959
                                                 Literal #608
                                                     id: 608
                                                     src: "0:0:0"
-                                                    type: "Literal"
                                                     typeString: "literal_string \"Underflow/overflow\""
                                                     kind: "string"
                                                     hexValue: "556e646572666c6f772f6f766572666c6f77"
@@ -2621,6 +2620,7 @@ SourceUnit #959
                                                     subdenomination: undefined
                                                     context: ASTContext #1000
                                                     parent: FunctionCall #609
+                                                    <getter> type: "Literal"
                                                     <getter> children: Array(0)
                                                     <getter> firstChild: undefined
                                                     <getter> lastChild: undefined
@@ -2632,7 +2632,6 @@ SourceUnit #959
                     TryCatchClause #624
                         id: 624
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: ""
                         vParameters: undefined
@@ -2640,6 +2639,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #625
                         <getter> children: Array(1) [ Block #623 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: Block #623
                         <getter> lastChild: Block #623
                         <getter> previousSibling: TryCatchClause #618
@@ -2650,12 +2650,12 @@ SourceUnit #959
                         Block #623
                             id: 623
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #624
                             <getter> vStatements: Array(1) [ ExpressionStatement #622 ]
                             <getter> children: Array(1) [ ExpressionStatement #622 ]
+                            <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #622
                             <getter> lastChild: ExpressionStatement #622
                             <getter> previousSibling: undefined
@@ -2666,12 +2666,12 @@ SourceUnit #959
                             ExpressionStatement #622
                                 id: 622
                                 src: "0:0:0"
-                                type: "ExpressionStatement"
                                 documentation: undefined
                                 vExpression: FunctionCall #621
                                 context: ASTContext #1000
                                 parent: Block #623
                                 <getter> children: Array(1) [ FunctionCall #621 ]
+                                <getter> type: "ExpressionStatement"
                                 <getter> firstChild: FunctionCall #621
                                 <getter> lastChild: FunctionCall #621
                                 <getter> previousSibling: undefined
@@ -2682,7 +2682,6 @@ SourceUnit #959
                                 FunctionCall #621
                                     id: 621
                                     src: "0:0:0"
-                                    type: "FunctionCall"
                                     typeString: "tuple()"
                                     kind: "functionCall"
                                     fieldNames: undefined
@@ -2697,6 +2696,7 @@ SourceUnit #959
                                     <getter> vReferencedDeclaration: undefined
                                     <getter> vFunctionName: "revert"
                                     <getter> vCallee: Identifier #619
+                                    <getter> type: "FunctionCall"
                                     <getter> firstChild: Identifier #619
                                     <getter> lastChild: Literal #620
                                     <getter> previousSibling: undefined
@@ -2707,7 +2707,6 @@ SourceUnit #959
                                     Identifier #619
                                         id: 619
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "function (string memory) pure"
                                         name: "revert"
                                         referencedDeclaration: -1
@@ -2715,6 +2714,7 @@ SourceUnit #959
                                         parent: FunctionCall #621
                                         <getter> vReferencedDeclaration: undefined
                                         <getter> vIdentifierType: "builtin"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2726,7 +2726,6 @@ SourceUnit #959
                                     Literal #620
                                         id: 620
                                         src: "0:0:0"
-                                        type: "Literal"
                                         typeString: "literal_string \"Internal error\""
                                         kind: "string"
                                         hexValue: "496e7465726e616c206572726f72"
@@ -2734,6 +2733,7 @@ SourceUnit #959
                                         subdenomination: undefined
                                         context: ASTContext #1000
                                         parent: FunctionCall #621
+                                        <getter> type: "Literal"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -2745,7 +2745,6 @@ SourceUnit #959
     ContractDefinition #713
         id: 713
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "Features082"
         scope: 959
         kind: "contract"
@@ -2773,6 +2772,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(4) [ EventDefinition #632, EnumDefinition #636, ModifierDefinition #640, FunctionDefinition #712 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: EventDefinition #632
         <getter> lastChild: FunctionDefinition #712
         <getter> previousSibling: ContractDefinition #628
@@ -2783,7 +2783,6 @@ SourceUnit #959
         EventDefinition #632
             id: 632
             src: "0:0:0"
-            type: "EventDefinition"
             anonymous: false
             name: "Ev"
             documentation: undefined
@@ -2793,6 +2792,7 @@ SourceUnit #959
             parent: ContractDefinition #713
             <getter> children: Array(1) [ ParameterList #631 ]
             <getter> vScope: ContractDefinition #713
+            <getter> type: "EventDefinition"
             <getter> firstChild: ParameterList #631
             <getter> lastChild: ParameterList #631
             <getter> previousSibling: undefined
@@ -2803,11 +2803,11 @@ SourceUnit #959
             ParameterList #631
                 id: 631
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: EventDefinition #632
                 <getter> vParameters: Array(1) [ VariableDeclaration #630 ]
                 <getter> children: Array(1) [ VariableDeclaration #630 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #630
                 <getter> lastChild: VariableDeclaration #630
                 <getter> previousSibling: undefined
@@ -2818,7 +2818,6 @@ SourceUnit #959
                 VariableDeclaration #630
                     id: 630
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -2837,6 +2836,7 @@ SourceUnit #959
                     parent: ParameterList #631
                     <getter> children: Array(1) [ ElementaryTypeName #629 ]
                     <getter> vScope: EventDefinition #632
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #629
                     <getter> lastChild: ElementaryTypeName #629
                     <getter> previousSibling: undefined
@@ -2847,12 +2847,12 @@ SourceUnit #959
                     ElementaryTypeName #629
                         id: 629
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #630
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -2864,7 +2864,6 @@ SourceUnit #959
         EnumDefinition #636
             id: 636
             src: "0:0:0"
-            type: "EnumDefinition"
             name: "EnumXYZ"
             nameLocation: "1379:7:0"
             context: ASTContext #1000
@@ -2873,6 +2872,7 @@ SourceUnit #959
             <getter> vMembers: Array(3) [ EnumValue #633, EnumValue #634, EnumValue #635 ]
             <getter> vScope: ContractDefinition #713
             <getter> children: Array(3) [ EnumValue #633, EnumValue #634, EnumValue #635 ]
+            <getter> type: "EnumDefinition"
             <getter> firstChild: EnumValue #633
             <getter> lastChild: EnumValue #635
             <getter> previousSibling: EventDefinition #632
@@ -2883,11 +2883,11 @@ SourceUnit #959
             EnumValue #633
                 id: 633
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "X"
                 nameLocation: "1397:1:0"
                 context: ASTContext #1000
                 parent: EnumDefinition #636
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -2899,11 +2899,11 @@ SourceUnit #959
             EnumValue #634
                 id: 634
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "Y"
                 nameLocation: "1400:1:0"
                 context: ASTContext #1000
                 parent: EnumDefinition #636
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -2915,11 +2915,11 @@ SourceUnit #959
             EnumValue #635
                 id: 635
                 src: "0:0:0"
-                type: "EnumValue"
                 name: "Z"
                 nameLocation: "1403:1:0"
                 context: ASTContext #1000
                 parent: EnumDefinition #636
+                <getter> type: "EnumValue"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -2931,7 +2931,6 @@ SourceUnit #959
         ModifierDefinition #640
             id: 640
             src: "0:0:0"
-            type: "ModifierDefinition"
             name: "modStructDocs"
             virtual: false
             visibility: "internal"
@@ -2944,6 +2943,7 @@ SourceUnit #959
             parent: ContractDefinition #713
             <getter> children: Array(2) [ ParameterList #637, Block #639 ]
             <getter> vScope: ContractDefinition #713
+            <getter> type: "ModifierDefinition"
             <getter> firstChild: ParameterList #637
             <getter> lastChild: Block #639
             <getter> previousSibling: EnumDefinition #636
@@ -2954,11 +2954,11 @@ SourceUnit #959
             ParameterList #637
                 id: 637
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: ModifierDefinition #640
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -2969,12 +2969,12 @@ SourceUnit #959
             Block #639
                 id: 639
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: ModifierDefinition #640
                 <getter> vStatements: Array(1) [ PlaceholderStatement #638 ]
                 <getter> children: Array(1) [ PlaceholderStatement #638 ]
+                <getter> type: "Block"
                 <getter> firstChild: PlaceholderStatement #638
                 <getter> lastChild: PlaceholderStatement #638
                 <getter> previousSibling: ParameterList #637
@@ -2985,10 +2985,10 @@ SourceUnit #959
                 PlaceholderStatement #638
                     id: 638
                     src: "0:0:0"
-                    type: "PlaceholderStatement"
                     documentation: "PlaceholderStatement docstring"
                     context: ASTContext #1000
                     parent: Block #639
+                    <getter> type: "PlaceholderStatement"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -3000,7 +3000,6 @@ SourceUnit #959
         FunctionDefinition #712
             id: 712
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 713
@@ -3020,6 +3019,7 @@ SourceUnit #959
             parent: ContractDefinition #713
             <getter> children: Array(4) [ ParameterList #641, ModifierInvocation #644, ParameterList #642, Block #711 ]
             <getter> vScope: ContractDefinition #713
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #641
             <getter> lastChild: Block #711
             <getter> previousSibling: ModifierDefinition #640
@@ -3030,11 +3030,11 @@ SourceUnit #959
             ParameterList #641
                 id: 641
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #712
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -3045,7 +3045,6 @@ SourceUnit #959
             ModifierInvocation #644
                 id: 644
                 src: "0:0:0"
-                type: "ModifierInvocation"
                 kind: "modifierInvocation"
                 vModifierName: IdentifierPath #643
                 vArguments: Array(0)
@@ -3053,6 +3052,7 @@ SourceUnit #959
                 parent: FunctionDefinition #712
                 <getter> children: Array(1) [ IdentifierPath #643 ]
                 <getter> vModifier: ModifierDefinition #153
+                <getter> type: "ModifierInvocation"
                 <getter> firstChild: IdentifierPath #643
                 <getter> lastChild: IdentifierPath #643
                 <getter> previousSibling: ParameterList #641
@@ -3063,12 +3063,12 @@ SourceUnit #959
                 IdentifierPath #643
                     id: 643
                     src: "0:0:0"
-                    type: "IdentifierPath"
                     name: "modStructDocs"
                     referencedDeclaration: 153
                     context: ASTContext #1000
                     parent: ModifierInvocation #644
                     <getter> vReferencedDeclaration: ModifierDefinition #153
+                    <getter> type: "IdentifierPath"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -3080,11 +3080,11 @@ SourceUnit #959
             ParameterList #642
                 id: 642
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #712
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ModifierInvocation #644
@@ -3095,12 +3095,12 @@ SourceUnit #959
             Block #711
                 id: 711
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #712
                 <getter> vStatements: Array(13) [ VariableDeclarationStatement #649, ExpressionStatement #651, Block #652, EmitStatement #656, WhileStatement #660, DoWhileStatement #664, ForStatement #677, IfStatement #681, VariableDeclarationStatement #689, TryStatement #707, InlineAssembly #708, UncheckedBlock #709, Return #710 ]
                 <getter> children: Array(13) [ VariableDeclarationStatement #649, ExpressionStatement #651, Block #652, EmitStatement #656, WhileStatement #660, DoWhileStatement #664, ForStatement #677, IfStatement #681, VariableDeclarationStatement #689, TryStatement #707, InlineAssembly #708, UncheckedBlock #709, Return #710 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #649
                 <getter> lastChild: Return #710
                 <getter> previousSibling: ParameterList #642
@@ -3111,7 +3111,6 @@ SourceUnit #959
                 VariableDeclarationStatement #649
                     id: 649
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: "VariableDeclarationStatement docstring"
                     assignments: Array(1) [ 646 ]
                     vDeclarations: Array(1) [ VariableDeclaration #646 ]
@@ -3119,6 +3118,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(2) [ VariableDeclaration #646, TupleExpression #648 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #646
                     <getter> lastChild: TupleExpression #648
                     <getter> previousSibling: undefined
@@ -3129,7 +3129,6 @@ SourceUnit #959
                     VariableDeclaration #646
                         id: 646
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "a"
@@ -3148,6 +3147,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #649
                         <getter> children: Array(1) [ ElementaryTypeName #645 ]
                         <getter> vScope: Block #711
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: ElementaryTypeName #645
                         <getter> lastChild: ElementaryTypeName #645
                         <getter> previousSibling: undefined
@@ -3158,12 +3158,12 @@ SourceUnit #959
                         ElementaryTypeName #645
                             id: 645
                             src: "0:0:0"
-                            type: "ElementaryTypeName"
                             typeString: "uint256"
                             name: "uint"
                             stateMutability: "nonpayable"
                             context: ASTContext #1000
                             parent: VariableDeclaration #646
+                            <getter> type: "ElementaryTypeName"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3175,7 +3175,6 @@ SourceUnit #959
                     TupleExpression #648
                         id: 648
                         src: "0:0:0"
-                        type: "TupleExpression"
                         typeString: "int_const 1"
                         isInlineArray: false
                         vOriginalComponents: Array(1) [ Literal #647 ]
@@ -3184,6 +3183,7 @@ SourceUnit #959
                         <getter> children: Array(1) [ Literal #647 ]
                         <getter> components: Array(1) [ 647 ]
                         <getter> vComponents: Array(1) [ Literal #647 ]
+                        <getter> type: "TupleExpression"
                         <getter> firstChild: Literal #647
                         <getter> lastChild: Literal #647
                         <getter> previousSibling: VariableDeclaration #646
@@ -3194,7 +3194,6 @@ SourceUnit #959
                         Literal #647
                             id: 647
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "int_const 1"
                             kind: "number"
                             hexValue: "31"
@@ -3202,6 +3201,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: TupleExpression #648
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3213,12 +3213,12 @@ SourceUnit #959
                 ExpressionStatement #651
                     id: 651
                     src: "0:0:0"
-                    type: "ExpressionStatement"
                     documentation: "ExpressionStatement docstring"
                     vExpression: Literal #650
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(1) [ Literal #650 ]
+                    <getter> type: "ExpressionStatement"
                     <getter> firstChild: Literal #650
                     <getter> lastChild: Literal #650
                     <getter> previousSibling: VariableDeclarationStatement #649
@@ -3229,7 +3229,6 @@ SourceUnit #959
                     Literal #650
                         id: 650
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "int_const 1"
                         kind: "number"
                         hexValue: "31"
@@ -3237,6 +3236,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: ExpressionStatement #651
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -3248,12 +3248,12 @@ SourceUnit #959
                 Block #652
                     id: 652
                     src: "0:0:0"
-                    type: "Block"
                     documentation: "Block docstring"
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> vStatements: Array(0)
                     <getter> children: Array(0)
+                    <getter> type: "Block"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: ExpressionStatement #651
@@ -3264,12 +3264,12 @@ SourceUnit #959
                 EmitStatement #656
                     id: 656
                     src: "0:0:0"
-                    type: "EmitStatement"
                     documentation: "EmitStatement docstring"
                     vEventCall: FunctionCall #655
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(1) [ FunctionCall #655 ]
+                    <getter> type: "EmitStatement"
                     <getter> firstChild: FunctionCall #655
                     <getter> lastChild: FunctionCall #655
                     <getter> previousSibling: Block #652
@@ -3280,7 +3280,6 @@ SourceUnit #959
                     FunctionCall #655
                         id: 655
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -3295,6 +3294,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: EventDefinition #632
                         <getter> vFunctionName: "Ev"
                         <getter> vCallee: Identifier #653
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: Identifier #653
                         <getter> lastChild: Literal #654
                         <getter> previousSibling: undefined
@@ -3305,7 +3305,6 @@ SourceUnit #959
                         Identifier #653
                             id: 653
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "function (uint256)"
                             name: "Ev"
                             referencedDeclaration: 632
@@ -3313,6 +3312,7 @@ SourceUnit #959
                             parent: FunctionCall #655
                             <getter> vReferencedDeclaration: EventDefinition #632
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3324,7 +3324,6 @@ SourceUnit #959
                         Literal #654
                             id: 654
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "int_const 1"
                             kind: "number"
                             hexValue: "31"
@@ -3332,6 +3331,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: FunctionCall #655
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3343,13 +3343,13 @@ SourceUnit #959
                 WhileStatement #660
                     id: 660
                     src: "0:0:0"
-                    type: "WhileStatement"
                     documentation: "WhileStatement docstring"
                     vCondition: Literal #657
                     vBody: Block #659
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(2) [ Literal #657, Block #659 ]
+                    <getter> type: "WhileStatement"
                     <getter> firstChild: Literal #657
                     <getter> lastChild: Block #659
                     <getter> previousSibling: EmitStatement #656
@@ -3360,7 +3360,6 @@ SourceUnit #959
                     Literal #657
                         id: 657
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "bool"
                         kind: "bool"
                         hexValue: "66616c7365"
@@ -3368,6 +3367,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: WhileStatement #660
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -3379,12 +3379,12 @@ SourceUnit #959
                     Block #659
                         id: 659
                         src: "0:0:0"
-                        type: "Block"
                         documentation: "Body Block docstring"
                         context: ASTContext #1000
                         parent: WhileStatement #660
                         <getter> vStatements: Array(1) [ Continue #658 ]
                         <getter> children: Array(1) [ Continue #658 ]
+                        <getter> type: "Block"
                         <getter> firstChild: Continue #658
                         <getter> lastChild: Continue #658
                         <getter> previousSibling: Literal #657
@@ -3395,10 +3395,10 @@ SourceUnit #959
                         Continue #658
                             id: 658
                             src: "0:0:0"
-                            type: "Continue"
                             documentation: "Continue docstring"
                             context: ASTContext #1000
                             parent: Block #659
+                            <getter> type: "Continue"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3410,13 +3410,13 @@ SourceUnit #959
                 DoWhileStatement #664
                     id: 664
                     src: "0:0:0"
-                    type: "DoWhileStatement"
                     documentation: "DoWhileStatement docstring"
                     vCondition: Literal #661
                     vBody: Block #663
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(2) [ Literal #661, Block #663 ]
+                    <getter> type: "DoWhileStatement"
                     <getter> firstChild: Literal #661
                     <getter> lastChild: Block #663
                     <getter> previousSibling: WhileStatement #660
@@ -3427,7 +3427,6 @@ SourceUnit #959
                     Literal #661
                         id: 661
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "bool"
                         kind: "bool"
                         hexValue: "74727565"
@@ -3435,6 +3434,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: DoWhileStatement #664
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -3446,12 +3446,12 @@ SourceUnit #959
                     Block #663
                         id: 663
                         src: "0:0:0"
-                        type: "Block"
                         documentation: "Body Block docstring"
                         context: ASTContext #1000
                         parent: DoWhileStatement #664
                         <getter> vStatements: Array(1) [ Break #662 ]
                         <getter> children: Array(1) [ Break #662 ]
+                        <getter> type: "Block"
                         <getter> firstChild: Break #662
                         <getter> lastChild: Break #662
                         <getter> previousSibling: Literal #661
@@ -3462,10 +3462,10 @@ SourceUnit #959
                         Break #662
                             id: 662
                             src: "0:0:0"
-                            type: "Break"
                             documentation: "Break docstring"
                             context: ASTContext #1000
                             parent: Block #663
+                            <getter> type: "Break"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3477,7 +3477,6 @@ SourceUnit #959
                 ForStatement #677
                     id: 677
                     src: "0:0:0"
-                    type: "ForStatement"
                     documentation: "ForStatement docstring"
                     vInitializationExpression: VariableDeclarationStatement #670
                     vCondition: BinaryOperation #673
@@ -3486,6 +3485,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(4) [ VariableDeclarationStatement #670, BinaryOperation #673, ExpressionStatement #676, Block #665 ]
+                    <getter> type: "ForStatement"
                     <getter> firstChild: VariableDeclarationStatement #670
                     <getter> lastChild: Block #665
                     <getter> previousSibling: DoWhileStatement #664
@@ -3496,7 +3496,6 @@ SourceUnit #959
                     VariableDeclarationStatement #670
                         id: 670
                         src: "0:0:0"
-                        type: "VariableDeclarationStatement"
                         documentation: undefined
                         assignments: Array(1) [ 667 ]
                         vDeclarations: Array(1) [ VariableDeclaration #667 ]
@@ -3504,6 +3503,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: ForStatement #677
                         <getter> children: Array(2) [ VariableDeclaration #667, TupleExpression #669 ]
+                        <getter> type: "VariableDeclarationStatement"
                         <getter> firstChild: VariableDeclaration #667
                         <getter> lastChild: TupleExpression #669
                         <getter> previousSibling: undefined
@@ -3514,7 +3514,6 @@ SourceUnit #959
                         VariableDeclaration #667
                             id: 667
                             src: "0:0:0"
-                            type: "VariableDeclaration"
                             constant: false
                             indexed: false
                             name: "n"
@@ -3533,6 +3532,7 @@ SourceUnit #959
                             parent: VariableDeclarationStatement #670
                             <getter> children: Array(1) [ ElementaryTypeName #666 ]
                             <getter> vScope: ForStatement #677
+                            <getter> type: "VariableDeclaration"
                             <getter> firstChild: ElementaryTypeName #666
                             <getter> lastChild: ElementaryTypeName #666
                             <getter> previousSibling: undefined
@@ -3543,12 +3543,12 @@ SourceUnit #959
                             ElementaryTypeName #666
                                 id: 666
                                 src: "0:0:0"
-                                type: "ElementaryTypeName"
                                 typeString: "uint256"
                                 name: "uint"
                                 stateMutability: "nonpayable"
                                 context: ASTContext #1000
                                 parent: VariableDeclaration #667
+                                <getter> type: "ElementaryTypeName"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -3560,7 +3560,6 @@ SourceUnit #959
                         TupleExpression #669
                             id: 669
                             src: "0:0:0"
-                            type: "TupleExpression"
                             typeString: "int_const 1"
                             isInlineArray: false
                             vOriginalComponents: Array(1) [ Literal #668 ]
@@ -3569,6 +3568,7 @@ SourceUnit #959
                             <getter> children: Array(1) [ Literal #668 ]
                             <getter> components: Array(1) [ 668 ]
                             <getter> vComponents: Array(1) [ Literal #668 ]
+                            <getter> type: "TupleExpression"
                             <getter> firstChild: Literal #668
                             <getter> lastChild: Literal #668
                             <getter> previousSibling: VariableDeclaration #667
@@ -3579,7 +3579,6 @@ SourceUnit #959
                             Literal #668
                                 id: 668
                                 src: "0:0:0"
-                                type: "Literal"
                                 typeString: "int_const 1"
                                 kind: "number"
                                 hexValue: "31"
@@ -3587,6 +3586,7 @@ SourceUnit #959
                                 subdenomination: undefined
                                 context: ASTContext #1000
                                 parent: TupleExpression #669
+                                <getter> type: "Literal"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -3598,7 +3598,6 @@ SourceUnit #959
                     BinaryOperation #673
                         id: 673
                         src: "0:0:0"
-                        type: "BinaryOperation"
                         typeString: "bool"
                         operator: "<"
                         vLeftExpression: Identifier #671
@@ -3606,6 +3605,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: ForStatement #677
                         <getter> children: Array(2) [ Identifier #671, Literal #672 ]
+                        <getter> type: "BinaryOperation"
                         <getter> firstChild: Identifier #671
                         <getter> lastChild: Literal #672
                         <getter> previousSibling: VariableDeclarationStatement #670
@@ -3616,7 +3616,6 @@ SourceUnit #959
                         Identifier #671
                             id: 671
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "uint256"
                             name: "n"
                             referencedDeclaration: 667
@@ -3624,6 +3623,7 @@ SourceUnit #959
                             parent: BinaryOperation #673
                             <getter> vReferencedDeclaration: VariableDeclaration #667
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3635,7 +3635,6 @@ SourceUnit #959
                         Literal #672
                             id: 672
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "int_const 1"
                             kind: "number"
                             hexValue: "31"
@@ -3643,6 +3642,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: BinaryOperation #673
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -3654,12 +3654,12 @@ SourceUnit #959
                     ExpressionStatement #676
                         id: 676
                         src: "0:0:0"
-                        type: "ExpressionStatement"
                         documentation: undefined
                         vExpression: UnaryOperation #675
                         context: ASTContext #1000
                         parent: ForStatement #677
                         <getter> children: Array(1) [ UnaryOperation #675 ]
+                        <getter> type: "ExpressionStatement"
                         <getter> firstChild: UnaryOperation #675
                         <getter> lastChild: UnaryOperation #675
                         <getter> previousSibling: BinaryOperation #673
@@ -3670,7 +3670,6 @@ SourceUnit #959
                         UnaryOperation #675
                             id: 675
                             src: "0:0:0"
-                            type: "UnaryOperation"
                             typeString: "uint256"
                             prefix: false
                             operator: "++"
@@ -3678,6 +3677,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: ExpressionStatement #676
                             <getter> children: Array(1) [ Identifier #674 ]
+                            <getter> type: "UnaryOperation"
                             <getter> firstChild: Identifier #674
                             <getter> lastChild: Identifier #674
                             <getter> previousSibling: undefined
@@ -3688,7 +3688,6 @@ SourceUnit #959
                             Identifier #674
                                 id: 674
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "n"
                                 referencedDeclaration: 667
@@ -3696,6 +3695,7 @@ SourceUnit #959
                                 parent: UnaryOperation #675
                                 <getter> vReferencedDeclaration: VariableDeclaration #667
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -3707,12 +3707,12 @@ SourceUnit #959
                     Block #665
                         id: 665
                         src: "0:0:0"
-                        type: "Block"
                         documentation: "Body Block docstring"
                         context: ASTContext #1000
                         parent: ForStatement #677
                         <getter> vStatements: Array(0)
                         <getter> children: Array(0)
+                        <getter> type: "Block"
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
                         <getter> previousSibling: ExpressionStatement #676
@@ -3723,7 +3723,6 @@ SourceUnit #959
                 IfStatement #681
                     id: 681
                     src: "0:0:0"
-                    type: "IfStatement"
                     documentation: "IfStatement docstring"
                     vCondition: Literal #678
                     vTrueBody: Block #679
@@ -3731,6 +3730,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(3) [ Literal #678, Block #679, Block #680 ]
+                    <getter> type: "IfStatement"
                     <getter> firstChild: Literal #678
                     <getter> lastChild: Block #680
                     <getter> previousSibling: ForStatement #677
@@ -3741,7 +3741,6 @@ SourceUnit #959
                     Literal #678
                         id: 678
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "bool"
                         kind: "bool"
                         hexValue: "66616c7365"
@@ -3749,6 +3748,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: IfStatement #681
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -3760,12 +3760,12 @@ SourceUnit #959
                     Block #679
                         id: 679
                         src: "0:0:0"
-                        type: "Block"
                         documentation: "True body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #681
                         <getter> vStatements: Array(0)
                         <getter> children: Array(0)
+                        <getter> type: "Block"
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
                         <getter> previousSibling: Literal #678
@@ -3776,12 +3776,12 @@ SourceUnit #959
                     Block #680
                         id: 680
                         src: "0:0:0"
-                        type: "Block"
                         documentation: "False body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #681
                         <getter> vStatements: Array(0)
                         <getter> children: Array(0)
+                        <getter> type: "Block"
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
                         <getter> previousSibling: Block #679
@@ -3792,7 +3792,6 @@ SourceUnit #959
                 VariableDeclarationStatement #689
                     id: 689
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 684 ]
                     vDeclarations: Array(1) [ VariableDeclaration #684 ]
@@ -3800,6 +3799,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(2) [ VariableDeclaration #684, FunctionCall #688 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #684
                     <getter> lastChild: FunctionCall #688
                     <getter> previousSibling: IfStatement #681
@@ -3810,7 +3810,6 @@ SourceUnit #959
                     VariableDeclaration #684
                         id: 684
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "cp"
@@ -3829,6 +3828,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #689
                         <getter> children: Array(1) [ UserDefinedTypeName #683 ]
                         <getter> vScope: Block #711
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: UserDefinedTypeName #683
                         <getter> lastChild: UserDefinedTypeName #683
                         <getter> previousSibling: undefined
@@ -3839,7 +3839,6 @@ SourceUnit #959
                         UserDefinedTypeName #683
                             id: 683
                             src: "0:0:0"
-                            type: "UserDefinedTypeName"
                             typeString: "contract CatchPanic"
                             name: undefined
                             referencedDeclaration: 628
@@ -3848,6 +3847,7 @@ SourceUnit #959
                             parent: VariableDeclaration #684
                             <getter> children: Array(1) [ IdentifierPath #682 ]
                             <getter> vReferencedDeclaration: ContractDefinition #628
+                            <getter> type: "UserDefinedTypeName"
                             <getter> firstChild: IdentifierPath #682
                             <getter> lastChild: IdentifierPath #682
                             <getter> previousSibling: undefined
@@ -3858,12 +3858,12 @@ SourceUnit #959
                             IdentifierPath #682
                                 id: 682
                                 src: "0:0:0"
-                                type: "IdentifierPath"
                                 name: "CatchPanic"
                                 referencedDeclaration: 141
                                 context: ASTContext #1000
                                 parent: UserDefinedTypeName #683
                                 <getter> vReferencedDeclaration: ContractDefinition #141
+                                <getter> type: "IdentifierPath"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -3875,7 +3875,6 @@ SourceUnit #959
                     FunctionCall #688
                         id: 688
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "contract CatchPanic"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -3890,6 +3889,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "new"
                         <getter> vCallee: NewExpression #687
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: NewExpression #687
                         <getter> lastChild: NewExpression #687
                         <getter> previousSibling: VariableDeclaration #684
@@ -3900,12 +3900,12 @@ SourceUnit #959
                         NewExpression #687
                             id: 687
                             src: "0:0:0"
-                            type: "NewExpression"
                             typeString: "function () returns (contract CatchPanic)"
                             vTypeName: UserDefinedTypeName #686
                             context: ASTContext #1000
                             parent: FunctionCall #688
                             <getter> children: Array(1) [ UserDefinedTypeName #686 ]
+                            <getter> type: "NewExpression"
                             <getter> firstChild: UserDefinedTypeName #686
                             <getter> lastChild: UserDefinedTypeName #686
                             <getter> previousSibling: undefined
@@ -3916,7 +3916,6 @@ SourceUnit #959
                             UserDefinedTypeName #686
                                 id: 686
                                 src: "0:0:0"
-                                type: "UserDefinedTypeName"
                                 typeString: "contract CatchPanic"
                                 name: undefined
                                 referencedDeclaration: 628
@@ -3925,6 +3924,7 @@ SourceUnit #959
                                 parent: NewExpression #687
                                 <getter> children: Array(1) [ IdentifierPath #685 ]
                                 <getter> vReferencedDeclaration: ContractDefinition #628
+                                <getter> type: "UserDefinedTypeName"
                                 <getter> firstChild: IdentifierPath #685
                                 <getter> lastChild: IdentifierPath #685
                                 <getter> previousSibling: undefined
@@ -3935,12 +3935,12 @@ SourceUnit #959
                                 IdentifierPath #685
                                     id: 685
                                     src: "0:0:0"
-                                    type: "IdentifierPath"
                                     name: "CatchPanic"
                                     referencedDeclaration: 141
                                     context: ASTContext #1000
                                     parent: UserDefinedTypeName #686
                                     <getter> vReferencedDeclaration: ContractDefinition #141
+                                    <getter> type: "IdentifierPath"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -3952,13 +3952,13 @@ SourceUnit #959
                 TryStatement #707
                     id: 707
                     src: "0:0:0"
-                    type: "TryStatement"
                     documentation: "TryStatement docstring"
                     vExternalCall: FunctionCall #692
                     vClauses: Array(4) [ TryCatchClause #694, TryCatchClause #699, TryCatchClause #704, TryCatchClause #706 ]
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> children: Array(5) [ FunctionCall #692, TryCatchClause #694, TryCatchClause #699, TryCatchClause #704, TryCatchClause #706 ]
+                    <getter> type: "TryStatement"
                     <getter> firstChild: FunctionCall #692
                     <getter> lastChild: TryCatchClause #706
                     <getter> previousSibling: VariableDeclarationStatement #689
@@ -3969,7 +3969,6 @@ SourceUnit #959
                     FunctionCall #692
                         id: 692
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -3984,6 +3983,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: FunctionDefinition #627
                         <getter> vFunctionName: "test"
                         <getter> vCallee: MemberAccess #691
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #691
                         <getter> lastChild: MemberAccess #691
                         <getter> previousSibling: undefined
@@ -3994,7 +3994,6 @@ SourceUnit #959
                         MemberAccess #691
                             id: 691
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function () external"
                             vExpression: Identifier #690
                             memberName: "test"
@@ -4003,6 +4002,7 @@ SourceUnit #959
                             parent: FunctionCall #692
                             <getter> children: Array(1) [ Identifier #690 ]
                             <getter> vReferencedDeclaration: FunctionDefinition #627
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #690
                             <getter> lastChild: Identifier #690
                             <getter> previousSibling: undefined
@@ -4013,7 +4013,6 @@ SourceUnit #959
                             Identifier #690
                                 id: 690
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "contract CatchPanic"
                                 name: "cp"
                                 referencedDeclaration: 684
@@ -4021,6 +4020,7 @@ SourceUnit #959
                                 parent: MemberAccess #691
                                 <getter> vReferencedDeclaration: VariableDeclaration #684
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -4032,7 +4032,6 @@ SourceUnit #959
                     TryCatchClause #694
                         id: 694
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: ""
                         vParameters: undefined
@@ -4040,6 +4039,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #707
                         <getter> children: Array(1) [ Block #693 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: Block #693
                         <getter> lastChild: Block #693
                         <getter> previousSibling: FunctionCall #692
@@ -4050,12 +4050,12 @@ SourceUnit #959
                         Block #693
                             id: 693
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #694
                             <getter> vStatements: Array(0)
                             <getter> children: Array(0)
+                            <getter> type: "Block"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -4066,7 +4066,6 @@ SourceUnit #959
                     TryCatchClause #699
                         id: 699
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: "Error"
                         vParameters: ParameterList #698
@@ -4074,6 +4073,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #707
                         <getter> children: Array(2) [ ParameterList #698, Block #695 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: ParameterList #698
                         <getter> lastChild: Block #695
                         <getter> previousSibling: TryCatchClause #694
@@ -4084,11 +4084,11 @@ SourceUnit #959
                         ParameterList #698
                             id: 698
                             src: "0:0:0"
-                            type: "ParameterList"
                             context: ASTContext #1000
                             parent: TryCatchClause #699
                             <getter> vParameters: Array(1) [ VariableDeclaration #697 ]
                             <getter> children: Array(1) [ VariableDeclaration #697 ]
+                            <getter> type: "ParameterList"
                             <getter> firstChild: VariableDeclaration #697
                             <getter> lastChild: VariableDeclaration #697
                             <getter> previousSibling: undefined
@@ -4099,7 +4099,6 @@ SourceUnit #959
                             VariableDeclaration #697
                                 id: 697
                                 src: "0:0:0"
-                                type: "VariableDeclaration"
                                 constant: false
                                 indexed: false
                                 name: "reason"
@@ -4118,6 +4117,7 @@ SourceUnit #959
                                 parent: ParameterList #698
                                 <getter> children: Array(1) [ ElementaryTypeName #696 ]
                                 <getter> vScope: TryCatchClause #699
+                                <getter> type: "VariableDeclaration"
                                 <getter> firstChild: ElementaryTypeName #696
                                 <getter> lastChild: ElementaryTypeName #696
                                 <getter> previousSibling: undefined
@@ -4128,12 +4128,12 @@ SourceUnit #959
                                 ElementaryTypeName #696
                                     id: 696
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: "string"
                                     name: "string"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: VariableDeclaration #697
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -4145,12 +4145,12 @@ SourceUnit #959
                         Block #695
                             id: 695
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #699
                             <getter> vStatements: Array(0)
                             <getter> children: Array(0)
+                            <getter> type: "Block"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: ParameterList #698
@@ -4161,7 +4161,6 @@ SourceUnit #959
                     TryCatchClause #704
                         id: 704
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: "Panic"
                         vParameters: ParameterList #703
@@ -4169,6 +4168,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #707
                         <getter> children: Array(2) [ ParameterList #703, Block #700 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: ParameterList #703
                         <getter> lastChild: Block #700
                         <getter> previousSibling: TryCatchClause #699
@@ -4179,11 +4179,11 @@ SourceUnit #959
                         ParameterList #703
                             id: 703
                             src: "0:0:0"
-                            type: "ParameterList"
                             context: ASTContext #1000
                             parent: TryCatchClause #704
                             <getter> vParameters: Array(1) [ VariableDeclaration #702 ]
                             <getter> children: Array(1) [ VariableDeclaration #702 ]
+                            <getter> type: "ParameterList"
                             <getter> firstChild: VariableDeclaration #702
                             <getter> lastChild: VariableDeclaration #702
                             <getter> previousSibling: undefined
@@ -4194,7 +4194,6 @@ SourceUnit #959
                             VariableDeclaration #702
                                 id: 702
                                 src: "0:0:0"
-                                type: "VariableDeclaration"
                                 constant: false
                                 indexed: false
                                 name: "_code"
@@ -4213,6 +4212,7 @@ SourceUnit #959
                                 parent: ParameterList #703
                                 <getter> children: Array(1) [ ElementaryTypeName #701 ]
                                 <getter> vScope: TryCatchClause #704
+                                <getter> type: "VariableDeclaration"
                                 <getter> firstChild: ElementaryTypeName #701
                                 <getter> lastChild: ElementaryTypeName #701
                                 <getter> previousSibling: undefined
@@ -4223,12 +4223,12 @@ SourceUnit #959
                                 ElementaryTypeName #701
                                     id: 701
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: "uint256"
                                     name: "uint"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: VariableDeclaration #702
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -4240,12 +4240,12 @@ SourceUnit #959
                         Block #700
                             id: 700
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #704
                             <getter> vStatements: Array(0)
                             <getter> children: Array(0)
+                            <getter> type: "Block"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: ParameterList #703
@@ -4256,7 +4256,6 @@ SourceUnit #959
                     TryCatchClause #706
                         id: 706
                         src: "0:0:0"
-                        type: "TryCatchClause"
                         documentation: undefined
                         errorName: ""
                         vParameters: undefined
@@ -4264,6 +4263,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: TryStatement #707
                         <getter> children: Array(1) [ Block #705 ]
+                        <getter> type: "TryCatchClause"
                         <getter> firstChild: Block #705
                         <getter> lastChild: Block #705
                         <getter> previousSibling: TryCatchClause #704
@@ -4274,12 +4274,12 @@ SourceUnit #959
                         Block #705
                             id: 705
                             src: "0:0:0"
-                            type: "Block"
                             documentation: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #706
                             <getter> vStatements: Array(0)
                             <getter> children: Array(0)
+                            <getter> type: "Block"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -4290,13 +4290,13 @@ SourceUnit #959
                 InlineAssembly #708
                     id: 708
                     src: "0:0:0"
-                    type: "InlineAssembly"
                     documentation: "InlineAssembly docstring"
                     externalReferences: Array(0)
                     operations: undefined
                     yul: Object { nodeType: "YulBlock", src: "3235:2:0", statements: Array(0) }
                     context: ASTContext #1000
                     parent: Block #711
+                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -4308,12 +4308,12 @@ SourceUnit #959
                 UncheckedBlock #709
                     id: 709
                     src: "0:0:0"
-                    type: "UncheckedBlock"
                     documentation: "UncheckedBlock docstring"
                     context: ASTContext #1000
                     parent: Block #711
                     <getter> vStatements: Array(0)
                     <getter> children: Array(0)
+                    <getter> type: "UncheckedBlock"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: InlineAssembly #708
@@ -4324,7 +4324,6 @@ SourceUnit #959
                 Return #710
                     id: 710
                     src: "0:0:0"
-                    type: "Return"
                     documentation: "Return docstring"
                     functionReturnParameters: 157
                     vExpression: undefined
@@ -4332,6 +4331,7 @@ SourceUnit #959
                     parent: Block #711
                     <getter> children: Array(0)
                     <getter> vFunctionReturnParameters: ParameterList #157
+                    <getter> type: "Return"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: UncheckedBlock #709
@@ -4342,7 +4342,6 @@ SourceUnit #959
     ErrorDefinition #718
         id: 718
         src: "0:0:0"
-        type: "ErrorDefinition"
         name: "UnitLevelError084"
         documentation: StructuredDocumentation #717
         nameLocation: "3393:17:0"
@@ -4351,6 +4350,7 @@ SourceUnit #959
         parent: SourceUnit #959
         <getter> children: Array(2) [ StructuredDocumentation #717, ParameterList #716 ]
         <getter> vScope: SourceUnit #959
+        <getter> type: "ErrorDefinition"
         <getter> firstChild: StructuredDocumentation #717
         <getter> lastChild: ParameterList #716
         <getter> previousSibling: ContractDefinition #713
@@ -4361,10 +4361,10 @@ SourceUnit #959
         StructuredDocumentation #717
             id: 717
             src: "0:0:0"
-            type: "StructuredDocumentation"
             text: "UnitLevelError error docstring"
             context: ASTContext #1000
             parent: ErrorDefinition #718
+            <getter> type: "StructuredDocumentation"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -4376,11 +4376,11 @@ SourceUnit #959
         ParameterList #716
             id: 716
             src: "0:0:0"
-            type: "ParameterList"
             context: ASTContext #1000
             parent: ErrorDefinition #718
             <getter> vParameters: Array(1) [ VariableDeclaration #715 ]
             <getter> children: Array(1) [ VariableDeclaration #715 ]
+            <getter> type: "ParameterList"
             <getter> firstChild: VariableDeclaration #715
             <getter> lastChild: VariableDeclaration #715
             <getter> previousSibling: StructuredDocumentation #717
@@ -4391,7 +4391,6 @@ SourceUnit #959
             VariableDeclaration #715
                 id: 715
                 src: "0:0:0"
-                type: "VariableDeclaration"
                 constant: false
                 indexed: false
                 name: "code"
@@ -4410,6 +4409,7 @@ SourceUnit #959
                 parent: ParameterList #716
                 <getter> children: Array(1) [ ElementaryTypeName #714 ]
                 <getter> vScope: ErrorDefinition #718
+                <getter> type: "VariableDeclaration"
                 <getter> firstChild: ElementaryTypeName #714
                 <getter> lastChild: ElementaryTypeName #714
                 <getter> previousSibling: undefined
@@ -4420,12 +4420,12 @@ SourceUnit #959
                 ElementaryTypeName #714
                     id: 714
                     src: "0:0:0"
-                    type: "ElementaryTypeName"
                     typeString: "uint256"
                     name: "uint"
                     stateMutability: "nonpayable"
                     context: ASTContext #1000
                     parent: VariableDeclaration #715
+                    <getter> type: "ElementaryTypeName"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -4437,7 +4437,6 @@ SourceUnit #959
     ContractDefinition #724
         id: 724
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "LibErrors084"
         scope: 959
         kind: "library"
@@ -4465,6 +4464,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ ErrorDefinition #723 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: ErrorDefinition #723
         <getter> lastChild: ErrorDefinition #723
         <getter> previousSibling: ErrorDefinition #718
@@ -4475,7 +4475,6 @@ SourceUnit #959
         ErrorDefinition #723
             id: 723
             src: "0:0:0"
-            type: "ErrorDefinition"
             name: "Lib"
             documentation: StructuredDocumentation #722
             nameLocation: "3498:3:0"
@@ -4484,6 +4483,7 @@ SourceUnit #959
             parent: ContractDefinition #724
             <getter> children: Array(2) [ StructuredDocumentation #722, ParameterList #721 ]
             <getter> vScope: ContractDefinition #724
+            <getter> type: "ErrorDefinition"
             <getter> firstChild: StructuredDocumentation #722
             <getter> lastChild: ParameterList #721
             <getter> previousSibling: undefined
@@ -4494,10 +4494,10 @@ SourceUnit #959
             StructuredDocumentation #722
                 id: 722
                 src: "0:0:0"
-                type: "StructuredDocumentation"
                 text: "LibErrors084.Lib error docstring"
                 context: ASTContext #1000
                 parent: ErrorDefinition #723
+                <getter> type: "StructuredDocumentation"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -4509,11 +4509,11 @@ SourceUnit #959
             ParameterList #721
                 id: 721
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: ErrorDefinition #723
                 <getter> vParameters: Array(1) [ VariableDeclaration #720 ]
                 <getter> children: Array(1) [ VariableDeclaration #720 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #720
                 <getter> lastChild: VariableDeclaration #720
                 <getter> previousSibling: StructuredDocumentation #722
@@ -4524,7 +4524,6 @@ SourceUnit #959
                 VariableDeclaration #720
                     id: 720
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -4543,6 +4542,7 @@ SourceUnit #959
                     parent: ParameterList #721
                     <getter> children: Array(1) [ ElementaryTypeName #719 ]
                     <getter> vScope: ErrorDefinition #723
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #719
                     <getter> lastChild: ElementaryTypeName #719
                     <getter> previousSibling: undefined
@@ -4553,12 +4553,12 @@ SourceUnit #959
                     ElementaryTypeName #719
                         id: 719
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "bytes"
                         name: "bytes"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #720
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -4570,7 +4570,6 @@ SourceUnit #959
     ContractDefinition #782
         id: 782
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "Features084"
         scope: 959
         kind: "contract"
@@ -4598,6 +4597,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(7) [ ErrorDefinition #727, FunctionDefinition #732, FunctionDefinition #749, FunctionDefinition #757, FunctionDefinition #766, FunctionDefinition #773, FunctionDefinition #781 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: ErrorDefinition #727
         <getter> lastChild: FunctionDefinition #781
         <getter> previousSibling: ContractDefinition #724
@@ -4608,7 +4608,6 @@ SourceUnit #959
         ErrorDefinition #727
             id: 727
             src: "0:0:0"
-            type: "ErrorDefinition"
             name: "Own"
             documentation: StructuredDocumentation #726
             nameLocation: "3588:3:0"
@@ -4617,6 +4616,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(2) [ StructuredDocumentation #726, ParameterList #725 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "ErrorDefinition"
             <getter> firstChild: StructuredDocumentation #726
             <getter> lastChild: ParameterList #725
             <getter> previousSibling: undefined
@@ -4627,10 +4627,10 @@ SourceUnit #959
             StructuredDocumentation #726
                 id: 726
                 src: "0:0:0"
-                type: "StructuredDocumentation"
                 text: "Features084.Own error docstring"
                 context: ASTContext #1000
                 parent: ErrorDefinition #727
+                <getter> type: "StructuredDocumentation"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -4642,11 +4642,11 @@ SourceUnit #959
             ParameterList #725
                 id: 725
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: ErrorDefinition #727
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: StructuredDocumentation #726
@@ -4657,7 +4657,6 @@ SourceUnit #959
         FunctionDefinition #732
             id: 732
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -4677,6 +4676,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #728, ParameterList #729, Block #731 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #728
             <getter> lastChild: Block #731
             <getter> previousSibling: ErrorDefinition #727
@@ -4687,11 +4687,11 @@ SourceUnit #959
             ParameterList #728
                 id: 728
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #732
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -4702,11 +4702,11 @@ SourceUnit #959
             ParameterList #729
                 id: 729
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #732
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #728
@@ -4717,12 +4717,12 @@ SourceUnit #959
             Block #731
                 id: 731
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #732
                 <getter> vStatements: Array(1) [ InlineAssembly #730 ]
                 <getter> children: Array(1) [ InlineAssembly #730 ]
+                <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #730
                 <getter> lastChild: InlineAssembly #730
                 <getter> previousSibling: ParameterList #729
@@ -4733,13 +4733,13 @@ SourceUnit #959
                 InlineAssembly #730
                     id: 730
                     src: "0:0:0"
-                    type: "InlineAssembly"
                     documentation: undefined
                     externalReferences: Array(0)
                     operations: undefined
                     yul: Object { nodeType: "YulBlock", src: "3661:221:0", statements: Array(6) [ Object { nodeType: "YulVariableDeclaration", src: "3675:15:0", value: Object { hexValue: "74657374", kind: "string", nodeType: "YulLiteral", src: "3684:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nodeType: "YulTypedName", src: "3679:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3703:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nodeType: "YulLiteral", src: "3712:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nodeType: "YulTypedName", src: "3707:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3770:23:0", value: Object { hexValue: "1234abcd", kind: "string", nodeType: "YulLiteral", src: "3779:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nodeType: "YulTypedName", src: "3774:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3814:1:0", type: "", value: "0" }, Object { name: "x", nodeType: "YulIdentifier", src: "3817:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3807:6:0" }, nodeType: "YulFunctionCall", src: "3807:12:0" }, nodeType: "YulExpressionStatement", src: "3807:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3839:1:0", type: "", value: "1" }, Object { name: "y", nodeType: "YulIdentifier", src: "3842:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3832:6:0" }, nodeType: "YulFunctionCall", src: "3832:12:0" }, nodeType: "YulExpressionStatement", src: "3832:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nodeType: "YulLiteral", src: "3862:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nodeType: "YulIdentifier", src: "3858:3:0" }, nodeType: "YulFunctionCall", src: "3858:14:0" }, nodeType: "YulExpressionStatement", src: "3858:14:0" } ] }
                     context: ASTContext #1000
                     parent: Block #731
+                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -4751,7 +4751,6 @@ SourceUnit #959
         FunctionDefinition #749
             id: 749
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -4771,6 +4770,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #737, ParameterList #740, Block #748 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #737
             <getter> lastChild: Block #748
             <getter> previousSibling: FunctionDefinition #732
@@ -4781,11 +4781,11 @@ SourceUnit #959
             ParameterList #737
                 id: 737
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #749
                 <getter> vParameters: Array(2) [ VariableDeclaration #734, VariableDeclaration #736 ]
                 <getter> children: Array(2) [ VariableDeclaration #734, VariableDeclaration #736 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #734
                 <getter> lastChild: VariableDeclaration #736
                 <getter> previousSibling: undefined
@@ -4796,7 +4796,6 @@ SourceUnit #959
                 VariableDeclaration #734
                     id: 734
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -4815,6 +4814,7 @@ SourceUnit #959
                     parent: ParameterList #737
                     <getter> children: Array(1) [ ElementaryTypeName #733 ]
                     <getter> vScope: FunctionDefinition #749
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #733
                     <getter> lastChild: ElementaryTypeName #733
                     <getter> previousSibling: undefined
@@ -4825,12 +4825,12 @@ SourceUnit #959
                     ElementaryTypeName #733
                         id: 733
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "bytes"
                         name: "bytes"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #734
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -4842,7 +4842,6 @@ SourceUnit #959
                 VariableDeclaration #736
                     id: 736
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -4861,6 +4860,7 @@ SourceUnit #959
                     parent: ParameterList #737
                     <getter> children: Array(1) [ ElementaryTypeName #735 ]
                     <getter> vScope: FunctionDefinition #749
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #735
                     <getter> lastChild: ElementaryTypeName #735
                     <getter> previousSibling: VariableDeclaration #734
@@ -4871,12 +4871,12 @@ SourceUnit #959
                     ElementaryTypeName #735
                         id: 735
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "bytes"
                         name: "bytes"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #736
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -4888,11 +4888,11 @@ SourceUnit #959
             ParameterList #740
                 id: 740
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #749
                 <getter> vParameters: Array(1) [ VariableDeclaration #739 ]
                 <getter> children: Array(1) [ VariableDeclaration #739 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #739
                 <getter> lastChild: VariableDeclaration #739
                 <getter> previousSibling: ParameterList #737
@@ -4903,7 +4903,6 @@ SourceUnit #959
                 VariableDeclaration #739
                     id: 739
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "c"
@@ -4922,6 +4921,7 @@ SourceUnit #959
                     parent: ParameterList #740
                     <getter> children: Array(1) [ ElementaryTypeName #738 ]
                     <getter> vScope: FunctionDefinition #749
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #738
                     <getter> lastChild: ElementaryTypeName #738
                     <getter> previousSibling: undefined
@@ -4932,12 +4932,12 @@ SourceUnit #959
                     ElementaryTypeName #738
                         id: 738
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "bytes"
                         name: "bytes"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #739
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -4949,12 +4949,12 @@ SourceUnit #959
             Block #748
                 id: 748
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #749
                 <getter> vStatements: Array(1) [ Return #747 ]
                 <getter> children: Array(1) [ Return #747 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #747
                 <getter> lastChild: Return #747
                 <getter> previousSibling: ParameterList #740
@@ -4965,7 +4965,6 @@ SourceUnit #959
                 Return #747
                     id: 747
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 253
                     vExpression: FunctionCall #746
@@ -4973,6 +4972,7 @@ SourceUnit #959
                     parent: Block #748
                     <getter> children: Array(1) [ FunctionCall #746 ]
                     <getter> vFunctionReturnParameters: ParameterList #253
+                    <getter> type: "Return"
                     <getter> firstChild: FunctionCall #746
                     <getter> lastChild: FunctionCall #746
                     <getter> previousSibling: undefined
@@ -4983,7 +4983,6 @@ SourceUnit #959
                     FunctionCall #746
                         id: 746
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "bytes memory"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -4998,6 +4997,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "concat"
                         <getter> vCallee: MemberAccess #743
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #743
                         <getter> lastChild: Identifier #745
                         <getter> previousSibling: undefined
@@ -5008,7 +5008,6 @@ SourceUnit #959
                         MemberAccess #743
                             id: 743
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function () pure returns (bytes memory)"
                             vExpression: ElementaryTypeNameExpression #742
                             memberName: "concat"
@@ -5017,6 +5016,7 @@ SourceUnit #959
                             parent: FunctionCall #746
                             <getter> children: Array(1) [ ElementaryTypeNameExpression #742 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: ElementaryTypeNameExpression #742
                             <getter> lastChild: ElementaryTypeNameExpression #742
                             <getter> previousSibling: undefined
@@ -5027,12 +5027,12 @@ SourceUnit #959
                             ElementaryTypeNameExpression #742
                                 id: 742
                                 src: "0:0:0"
-                                type: "ElementaryTypeNameExpression"
                                 typeString: "type(bytes storage pointer)"
                                 typeName: ElementaryTypeName #741
                                 context: ASTContext #1000
                                 parent: MemberAccess #743
                                 <getter> children: Array(1) [ ElementaryTypeName #741 ]
+                                <getter> type: "ElementaryTypeNameExpression"
                                 <getter> firstChild: ElementaryTypeName #741
                                 <getter> lastChild: ElementaryTypeName #741
                                 <getter> previousSibling: undefined
@@ -5043,12 +5043,12 @@ SourceUnit #959
                                 ElementaryTypeName #741
                                     id: 741
                                     src: "0:0:0"
-                                    type: "ElementaryTypeName"
                                     typeString: undefined
                                     name: "bytes"
                                     stateMutability: "nonpayable"
                                     context: ASTContext #1000
                                     parent: ElementaryTypeNameExpression #742
+                                    <getter> type: "ElementaryTypeName"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -5060,7 +5060,6 @@ SourceUnit #959
                         Identifier #744
                             id: 744
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "bytes memory"
                             name: "a"
                             referencedDeclaration: 734
@@ -5068,6 +5067,7 @@ SourceUnit #959
                             parent: FunctionCall #746
                             <getter> vReferencedDeclaration: VariableDeclaration #734
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5079,7 +5079,6 @@ SourceUnit #959
                         Identifier #745
                             id: 745
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "bytes memory"
                             name: "b"
                             referencedDeclaration: 736
@@ -5087,6 +5086,7 @@ SourceUnit #959
                             parent: FunctionCall #746
                             <getter> vReferencedDeclaration: VariableDeclaration #736
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5098,7 +5098,6 @@ SourceUnit #959
         FunctionDefinition #757
             id: 757
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -5118,6 +5117,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #750, ParameterList #751, Block #756 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #750
             <getter> lastChild: Block #756
             <getter> previousSibling: FunctionDefinition #749
@@ -5128,11 +5128,11 @@ SourceUnit #959
             ParameterList #750
                 id: 750
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #757
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5143,11 +5143,11 @@ SourceUnit #959
             ParameterList #751
                 id: 751
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #757
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #750
@@ -5158,12 +5158,12 @@ SourceUnit #959
             Block #756
                 id: 756
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #757
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #755 ]
                 <getter> children: Array(1) [ VariableDeclarationStatement #755 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #755
                 <getter> lastChild: VariableDeclarationStatement #755
                 <getter> previousSibling: ParameterList #751
@@ -5174,7 +5174,6 @@ SourceUnit #959
                 VariableDeclarationStatement #755
                     id: 755
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: "VariableDeclarationStatement docstring"
                     assignments: Array(1) [ 753 ]
                     vDeclarations: Array(1) [ VariableDeclaration #753 ]
@@ -5182,6 +5181,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #756
                     <getter> children: Array(2) [ VariableDeclaration #753, Literal #754 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #753
                     <getter> lastChild: Literal #754
                     <getter> previousSibling: undefined
@@ -5192,7 +5192,6 @@ SourceUnit #959
                     VariableDeclaration #753
                         id: 753
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "a"
@@ -5211,6 +5210,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #755
                         <getter> children: Array(1) [ ElementaryTypeName #752 ]
                         <getter> vScope: Block #756
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: ElementaryTypeName #752
                         <getter> lastChild: ElementaryTypeName #752
                         <getter> previousSibling: undefined
@@ -5221,12 +5221,12 @@ SourceUnit #959
                         ElementaryTypeName #752
                             id: 752
                             src: "0:0:0"
-                            type: "ElementaryTypeName"
                             typeString: "uint256"
                             name: "uint"
                             stateMutability: "nonpayable"
                             context: ASTContext #1000
                             parent: VariableDeclaration #753
+                            <getter> type: "ElementaryTypeName"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5238,7 +5238,6 @@ SourceUnit #959
                     Literal #754
                         id: 754
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "int_const 10"
                         kind: "number"
                         hexValue: "3130"
@@ -5246,6 +5245,7 @@ SourceUnit #959
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: VariableDeclarationStatement #755
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -5257,7 +5257,6 @@ SourceUnit #959
         FunctionDefinition #766
             id: 766
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -5277,6 +5276,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #758, ParameterList #759, Block #765 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #758
             <getter> lastChild: Block #765
             <getter> previousSibling: FunctionDefinition #757
@@ -5287,11 +5287,11 @@ SourceUnit #959
             ParameterList #758
                 id: 758
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #766
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5302,11 +5302,11 @@ SourceUnit #959
             ParameterList #759
                 id: 759
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #766
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #758
@@ -5317,12 +5317,12 @@ SourceUnit #959
             Block #765
                 id: 765
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #766
                 <getter> vStatements: Array(1) [ RevertStatement #764 ]
                 <getter> children: Array(1) [ RevertStatement #764 ]
+                <getter> type: "Block"
                 <getter> firstChild: RevertStatement #764
                 <getter> lastChild: RevertStatement #764
                 <getter> previousSibling: ParameterList #759
@@ -5333,12 +5333,12 @@ SourceUnit #959
                 RevertStatement #764
                     id: 764
                     src: "0:0:0"
-                    type: "RevertStatement"
                     documentation: "RevertStatement docstring"
                     errorCall: FunctionCall #763
                     context: ASTContext #1000
                     parent: Block #765
                     <getter> children: Array(1) [ FunctionCall #763 ]
+                    <getter> type: "RevertStatement"
                     <getter> firstChild: FunctionCall #763
                     <getter> lastChild: FunctionCall #763
                     <getter> previousSibling: undefined
@@ -5349,7 +5349,6 @@ SourceUnit #959
                     FunctionCall #763
                         id: 763
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -5364,6 +5363,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: ErrorDefinition #723
                         <getter> vFunctionName: "Lib"
                         <getter> vCallee: MemberAccess #761
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #761
                         <getter> lastChild: Literal #762
                         <getter> previousSibling: undefined
@@ -5374,7 +5374,6 @@ SourceUnit #959
                         MemberAccess #761
                             id: 761
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function (bytes memory) pure"
                             vExpression: Identifier #760
                             memberName: "Lib"
@@ -5383,6 +5382,7 @@ SourceUnit #959
                             parent: FunctionCall #763
                             <getter> children: Array(1) [ Identifier #760 ]
                             <getter> vReferencedDeclaration: ErrorDefinition #723
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #760
                             <getter> lastChild: Identifier #760
                             <getter> previousSibling: undefined
@@ -5393,7 +5393,6 @@ SourceUnit #959
                             Identifier #760
                                 id: 760
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "type(library LibErrors084)"
                                 name: "LibErrors084"
                                 referencedDeclaration: 724
@@ -5401,6 +5400,7 @@ SourceUnit #959
                                 parent: MemberAccess #761
                                 <getter> vReferencedDeclaration: ContractDefinition #724
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -5412,7 +5412,6 @@ SourceUnit #959
                         Literal #762
                             id: 762
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "literal_string hex\"001122\""
                             kind: "hexString"
                             hexValue: "001122"
@@ -5420,6 +5419,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: FunctionCall #763
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5431,7 +5431,6 @@ SourceUnit #959
         FunctionDefinition #773
             id: 773
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -5451,6 +5450,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #767, ParameterList #768, Block #772 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #767
             <getter> lastChild: Block #772
             <getter> previousSibling: FunctionDefinition #766
@@ -5461,11 +5461,11 @@ SourceUnit #959
             ParameterList #767
                 id: 767
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #773
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5476,11 +5476,11 @@ SourceUnit #959
             ParameterList #768
                 id: 768
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #773
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #767
@@ -5491,12 +5491,12 @@ SourceUnit #959
             Block #772
                 id: 772
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #773
                 <getter> vStatements: Array(1) [ RevertStatement #771 ]
                 <getter> children: Array(1) [ RevertStatement #771 ]
+                <getter> type: "Block"
                 <getter> firstChild: RevertStatement #771
                 <getter> lastChild: RevertStatement #771
                 <getter> previousSibling: ParameterList #768
@@ -5507,12 +5507,12 @@ SourceUnit #959
                 RevertStatement #771
                     id: 771
                     src: "0:0:0"
-                    type: "RevertStatement"
                     documentation: undefined
                     errorCall: FunctionCall #770
                     context: ASTContext #1000
                     parent: Block #772
                     <getter> children: Array(1) [ FunctionCall #770 ]
+                    <getter> type: "RevertStatement"
                     <getter> firstChild: FunctionCall #770
                     <getter> lastChild: FunctionCall #770
                     <getter> previousSibling: undefined
@@ -5523,7 +5523,6 @@ SourceUnit #959
                     FunctionCall #770
                         id: 770
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -5538,6 +5537,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: ErrorDefinition #727
                         <getter> vFunctionName: "Own"
                         <getter> vCallee: Identifier #769
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: Identifier #769
                         <getter> lastChild: Identifier #769
                         <getter> previousSibling: undefined
@@ -5548,7 +5548,6 @@ SourceUnit #959
                         Identifier #769
                             id: 769
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "function () pure"
                             name: "Own"
                             referencedDeclaration: 727
@@ -5556,6 +5555,7 @@ SourceUnit #959
                             parent: FunctionCall #770
                             <getter> vReferencedDeclaration: ErrorDefinition #727
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5567,7 +5567,6 @@ SourceUnit #959
         FunctionDefinition #781
             id: 781
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 782
@@ -5587,6 +5586,7 @@ SourceUnit #959
             parent: ContractDefinition #782
             <getter> children: Array(3) [ ParameterList #774, ParameterList #775, Block #780 ]
             <getter> vScope: ContractDefinition #782
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #774
             <getter> lastChild: Block #780
             <getter> previousSibling: FunctionDefinition #773
@@ -5597,11 +5597,11 @@ SourceUnit #959
             ParameterList #774
                 id: 774
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #781
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5612,11 +5612,11 @@ SourceUnit #959
             ParameterList #775
                 id: 775
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #781
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #774
@@ -5627,12 +5627,12 @@ SourceUnit #959
             Block #780
                 id: 780
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #781
                 <getter> vStatements: Array(1) [ RevertStatement #779 ]
                 <getter> children: Array(1) [ RevertStatement #779 ]
+                <getter> type: "Block"
                 <getter> firstChild: RevertStatement #779
                 <getter> lastChild: RevertStatement #779
                 <getter> previousSibling: ParameterList #775
@@ -5643,12 +5643,12 @@ SourceUnit #959
                 RevertStatement #779
                     id: 779
                     src: "0:0:0"
-                    type: "RevertStatement"
                     documentation: undefined
                     errorCall: FunctionCall #778
                     context: ASTContext #1000
                     parent: Block #780
                     <getter> children: Array(1) [ FunctionCall #778 ]
+                    <getter> type: "RevertStatement"
                     <getter> firstChild: FunctionCall #778
                     <getter> lastChild: FunctionCall #778
                     <getter> previousSibling: undefined
@@ -5659,7 +5659,6 @@ SourceUnit #959
                     FunctionCall #778
                         id: 778
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -5674,6 +5673,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: ErrorDefinition #718
                         <getter> vFunctionName: "UnitLevelError084"
                         <getter> vCallee: Identifier #776
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: Identifier #776
                         <getter> lastChild: Literal #777
                         <getter> previousSibling: undefined
@@ -5684,7 +5684,6 @@ SourceUnit #959
                         Identifier #776
                             id: 776
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "function (uint256) pure"
                             name: "UnitLevelError084"
                             referencedDeclaration: 718
@@ -5692,6 +5691,7 @@ SourceUnit #959
                             parent: FunctionCall #778
                             <getter> vReferencedDeclaration: ErrorDefinition #718
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5703,7 +5703,6 @@ SourceUnit #959
                         Literal #777
                             id: 777
                             src: "0:0:0"
-                            type: "Literal"
                             typeString: "int_const 1"
                             kind: "number"
                             hexValue: "31"
@@ -5711,6 +5710,7 @@ SourceUnit #959
                             subdenomination: undefined
                             context: ASTContext #1000
                             parent: FunctionCall #778
+                            <getter> type: "Literal"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5722,7 +5722,6 @@ SourceUnit #959
     ContractDefinition #799
         id: 799
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "Features087"
         scope: 959
         kind: "contract"
@@ -5750,6 +5749,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(2) [ FunctionDefinition #791, FunctionDefinition #798 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #791
         <getter> lastChild: FunctionDefinition #798
         <getter> previousSibling: ContractDefinition #782
@@ -5760,7 +5760,6 @@ SourceUnit #959
         FunctionDefinition #791
             id: 791
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 799
@@ -5780,6 +5779,7 @@ SourceUnit #959
             parent: ContractDefinition #799
             <getter> children: Array(3) [ ParameterList #783, ParameterList #786, Block #790 ]
             <getter> vScope: ContractDefinition #799
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #783
             <getter> lastChild: Block #790
             <getter> previousSibling: undefined
@@ -5790,11 +5790,11 @@ SourceUnit #959
             ParameterList #783
                 id: 783
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #791
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5805,11 +5805,11 @@ SourceUnit #959
             ParameterList #786
                 id: 786
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #791
                 <getter> vParameters: Array(1) [ VariableDeclaration #785 ]
                 <getter> children: Array(1) [ VariableDeclaration #785 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #785
                 <getter> lastChild: VariableDeclaration #785
                 <getter> previousSibling: ParameterList #783
@@ -5820,7 +5820,6 @@ SourceUnit #959
                 VariableDeclaration #785
                     id: 785
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -5839,6 +5838,7 @@ SourceUnit #959
                     parent: ParameterList #786
                     <getter> children: Array(1) [ ElementaryTypeName #784 ]
                     <getter> vScope: FunctionDefinition #791
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #784
                     <getter> lastChild: ElementaryTypeName #784
                     <getter> previousSibling: undefined
@@ -5849,12 +5849,12 @@ SourceUnit #959
                     ElementaryTypeName #784
                         id: 784
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #785
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -5866,12 +5866,12 @@ SourceUnit #959
             Block #790
                 id: 790
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #791
                 <getter> vStatements: Array(1) [ Return #789 ]
                 <getter> children: Array(1) [ Return #789 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #789
                 <getter> lastChild: Return #789
                 <getter> previousSibling: ParameterList #786
@@ -5882,7 +5882,6 @@ SourceUnit #959
                 Return #789
                     id: 789
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 301
                     vExpression: MemberAccess #788
@@ -5890,6 +5889,7 @@ SourceUnit #959
                     parent: Block #790
                     <getter> children: Array(1) [ MemberAccess #788 ]
                     <getter> vFunctionReturnParameters: ParameterList #301
+                    <getter> type: "Return"
                     <getter> firstChild: MemberAccess #788
                     <getter> lastChild: MemberAccess #788
                     <getter> previousSibling: undefined
@@ -5900,7 +5900,6 @@ SourceUnit #959
                     MemberAccess #788
                         id: 788
                         src: "0:0:0"
-                        type: "MemberAccess"
                         typeString: "uint256"
                         vExpression: Identifier #787
                         memberName: "basefee"
@@ -5909,6 +5908,7 @@ SourceUnit #959
                         parent: Return #789
                         <getter> children: Array(1) [ Identifier #787 ]
                         <getter> vReferencedDeclaration: undefined
+                        <getter> type: "MemberAccess"
                         <getter> firstChild: Identifier #787
                         <getter> lastChild: Identifier #787
                         <getter> previousSibling: undefined
@@ -5919,7 +5919,6 @@ SourceUnit #959
                         Identifier #787
                             id: 787
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "block"
                             name: "block"
                             referencedDeclaration: -1
@@ -5927,6 +5926,7 @@ SourceUnit #959
                             parent: MemberAccess #788
                             <getter> vReferencedDeclaration: undefined
                             <getter> vIdentifierType: "builtin"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -5938,7 +5938,6 @@ SourceUnit #959
         FunctionDefinition #798
             id: 798
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 799
@@ -5958,6 +5957,7 @@ SourceUnit #959
             parent: ContractDefinition #799
             <getter> children: Array(3) [ ParameterList #792, ParameterList #795, Block #797 ]
             <getter> vScope: ContractDefinition #799
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #792
             <getter> lastChild: Block #797
             <getter> previousSibling: FunctionDefinition #791
@@ -5968,11 +5968,11 @@ SourceUnit #959
             ParameterList #792
                 id: 792
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #798
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -5983,11 +5983,11 @@ SourceUnit #959
             ParameterList #795
                 id: 795
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #798
                 <getter> vParameters: Array(1) [ VariableDeclaration #794 ]
                 <getter> children: Array(1) [ VariableDeclaration #794 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #794
                 <getter> lastChild: VariableDeclaration #794
                 <getter> previousSibling: ParameterList #792
@@ -5998,7 +5998,6 @@ SourceUnit #959
                 VariableDeclaration #794
                     id: 794
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "ret"
@@ -6017,6 +6016,7 @@ SourceUnit #959
                     parent: ParameterList #795
                     <getter> children: Array(1) [ ElementaryTypeName #793 ]
                     <getter> vScope: FunctionDefinition #798
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #793
                     <getter> lastChild: ElementaryTypeName #793
                     <getter> previousSibling: undefined
@@ -6027,12 +6027,12 @@ SourceUnit #959
                     ElementaryTypeName #793
                         id: 793
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #794
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -6044,12 +6044,12 @@ SourceUnit #959
             Block #797
                 id: 797
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #798
                 <getter> vStatements: Array(1) [ InlineAssembly #796 ]
                 <getter> children: Array(1) [ InlineAssembly #796 ]
+                <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #796
                 <getter> lastChild: InlineAssembly #796
                 <getter> previousSibling: ParameterList #795
@@ -6060,13 +6060,13 @@ SourceUnit #959
                 InlineAssembly #796
                     id: 796
                     src: "0:0:0"
-                    type: "InlineAssembly"
                     documentation: undefined
                     externalReferences: Array(1) [ Object { declaration: 309, isOffset: false, isSlot: false, src: "4698:3:0", valueSize: 1 } ]
                     operations: undefined
                     yul: Object { nodeType: "YulBlock", src: "4684:40:0", statements: Array(1) [ Object { nodeType: "YulAssignment", src: "4698:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nodeType: "YulIdentifier", src: "4705:7:0" }, nodeType: "YulFunctionCall", src: "4705:9:0" }, variableNames: Array(1) [ Object { name: "ret", nodeType: "YulIdentifier", src: "4698:3:0" } ] } ] }
                     context: ASTContext #1000
                     parent: Block #797
+                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -6078,7 +6078,6 @@ SourceUnit #959
     UserDefinedValueTypeDefinition #801
         id: 801
         src: "0:0:0"
-        type: "UserDefinedValueTypeDefinition"
         name: "Price"
         underlyingType: ElementaryTypeName #800
         nameLocation: "4739:5:0"
@@ -6087,6 +6086,7 @@ SourceUnit #959
         <getter> children: Array(1) [ ElementaryTypeName #800 ]
         <getter> canonicalName: "Price"
         <getter> vScope: SourceUnit #959
+        <getter> type: "UserDefinedValueTypeDefinition"
         <getter> firstChild: ElementaryTypeName #800
         <getter> lastChild: ElementaryTypeName #800
         <getter> previousSibling: ContractDefinition #799
@@ -6097,12 +6097,12 @@ SourceUnit #959
         ElementaryTypeName #800
             id: 800
             src: "0:0:0"
-            type: "ElementaryTypeName"
             typeString: "uint128"
             name: "uint128"
             stateMutability: "nonpayable"
             context: ASTContext #1000
             parent: UserDefinedValueTypeDefinition #801
+            <getter> type: "ElementaryTypeName"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -6114,7 +6114,6 @@ SourceUnit #959
     UserDefinedValueTypeDefinition #803
         id: 803
         src: "0:0:0"
-        type: "UserDefinedValueTypeDefinition"
         name: "Quantity"
         underlyingType: ElementaryTypeName #802
         nameLocation: "4762:8:0"
@@ -6123,6 +6122,7 @@ SourceUnit #959
         <getter> children: Array(1) [ ElementaryTypeName #802 ]
         <getter> canonicalName: "Quantity"
         <getter> vScope: SourceUnit #959
+        <getter> type: "UserDefinedValueTypeDefinition"
         <getter> firstChild: ElementaryTypeName #802
         <getter> lastChild: ElementaryTypeName #802
         <getter> previousSibling: UserDefinedValueTypeDefinition #801
@@ -6133,12 +6133,12 @@ SourceUnit #959
         ElementaryTypeName #802
             id: 802
             src: "0:0:0"
-            type: "ElementaryTypeName"
             typeString: "uint128"
             name: "uint128"
             stateMutability: "nonpayable"
             context: ASTContext #1000
             parent: UserDefinedValueTypeDefinition #803
+            <getter> type: "ElementaryTypeName"
             <getter> children: Array(0)
             <getter> firstChild: undefined
             <getter> lastChild: undefined
@@ -6150,7 +6150,6 @@ SourceUnit #959
     ContractDefinition #891
         id: 891
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "LibWithUDVT_088"
         scope: 959
         kind: "library"
@@ -6178,6 +6177,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(1) [ UserDefinedValueTypeDefinition #805 ]
         <getter> vConstructor: undefined
         <getter> children: Array(6) [ UserDefinedValueTypeDefinition #805, VariableDeclaration #810, FunctionDefinition #836, FunctionDefinition #858, FunctionDefinition #874, FunctionDefinition #890 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: UserDefinedValueTypeDefinition #805
         <getter> lastChild: FunctionDefinition #890
         <getter> previousSibling: UserDefinedValueTypeDefinition #803
@@ -6188,7 +6188,6 @@ SourceUnit #959
         UserDefinedValueTypeDefinition #805
             id: 805
             src: "0:0:0"
-            type: "UserDefinedValueTypeDefinition"
             name: "UFixed"
             underlyingType: ElementaryTypeName #804
             nameLocation: "4819:6:0"
@@ -6197,6 +6196,7 @@ SourceUnit #959
             <getter> children: Array(1) [ ElementaryTypeName #804 ]
             <getter> canonicalName: "LibWithUDVT_088.UFixed"
             <getter> vScope: ContractDefinition #891
+            <getter> type: "UserDefinedValueTypeDefinition"
             <getter> firstChild: ElementaryTypeName #804
             <getter> lastChild: ElementaryTypeName #804
             <getter> previousSibling: undefined
@@ -6207,12 +6207,12 @@ SourceUnit #959
             ElementaryTypeName #804
                 id: 804
                 src: "0:0:0"
-                type: "ElementaryTypeName"
                 typeString: "uint256"
                 name: "uint256"
                 stateMutability: "nonpayable"
                 context: ASTContext #1000
                 parent: UserDefinedValueTypeDefinition #805
+                <getter> type: "ElementaryTypeName"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -6224,7 +6224,6 @@ SourceUnit #959
         VariableDeclaration #810
             id: 810
             src: "0:0:0"
-            type: "VariableDeclaration"
             constant: true
             indexed: false
             name: "multiplier"
@@ -6243,6 +6242,7 @@ SourceUnit #959
             parent: ContractDefinition #891
             <getter> children: Array(2) [ ElementaryTypeName #806, BinaryOperation #809 ]
             <getter> vScope: ContractDefinition #891
+            <getter> type: "VariableDeclaration"
             <getter> firstChild: ElementaryTypeName #806
             <getter> lastChild: BinaryOperation #809
             <getter> previousSibling: UserDefinedValueTypeDefinition #805
@@ -6253,12 +6253,12 @@ SourceUnit #959
             ElementaryTypeName #806
                 id: 806
                 src: "0:0:0"
-                type: "ElementaryTypeName"
                 typeString: "uint256"
                 name: "uint"
                 stateMutability: "nonpayable"
                 context: ASTContext #1000
                 parent: VariableDeclaration #810
+                <getter> type: "ElementaryTypeName"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -6270,7 +6270,6 @@ SourceUnit #959
             BinaryOperation #809
                 id: 809
                 src: "0:0:0"
-                type: "BinaryOperation"
                 typeString: "int_const 1000000000000000000"
                 operator: "**"
                 vLeftExpression: Literal #807
@@ -6278,6 +6277,7 @@ SourceUnit #959
                 context: ASTContext #1000
                 parent: VariableDeclaration #810
                 <getter> children: Array(2) [ Literal #807, Literal #808 ]
+                <getter> type: "BinaryOperation"
                 <getter> firstChild: Literal #807
                 <getter> lastChild: Literal #808
                 <getter> previousSibling: ElementaryTypeName #806
@@ -6288,7 +6288,6 @@ SourceUnit #959
                 Literal #807
                     id: 807
                     src: "0:0:0"
-                    type: "Literal"
                     typeString: "int_const 10"
                     kind: "number"
                     hexValue: "3130"
@@ -6296,6 +6295,7 @@ SourceUnit #959
                     subdenomination: undefined
                     context: ASTContext #1000
                     parent: BinaryOperation #809
+                    <getter> type: "Literal"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -6307,7 +6307,6 @@ SourceUnit #959
                 Literal #808
                     id: 808
                     src: "0:0:0"
-                    type: "Literal"
                     typeString: "int_const 18"
                     kind: "number"
                     hexValue: "3138"
@@ -6315,6 +6314,7 @@ SourceUnit #959
                     subdenomination: undefined
                     context: ASTContext #1000
                     parent: BinaryOperation #809
+                    <getter> type: "Literal"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -6326,7 +6326,6 @@ SourceUnit #959
         FunctionDefinition #836
             id: 836
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 891
@@ -6346,6 +6345,7 @@ SourceUnit #959
             parent: ContractDefinition #891
             <getter> children: Array(3) [ ParameterList #817, ParameterList #821, Block #835 ]
             <getter> vScope: ContractDefinition #891
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #817
             <getter> lastChild: Block #835
             <getter> previousSibling: VariableDeclaration #810
@@ -6356,11 +6356,11 @@ SourceUnit #959
             ParameterList #817
                 id: 817
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #836
                 <getter> vParameters: Array(2) [ VariableDeclaration #813, VariableDeclaration #816 ]
                 <getter> children: Array(2) [ VariableDeclaration #813, VariableDeclaration #816 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #813
                 <getter> lastChild: VariableDeclaration #816
                 <getter> previousSibling: undefined
@@ -6371,7 +6371,6 @@ SourceUnit #959
                 VariableDeclaration #813
                     id: 813
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -6390,6 +6389,7 @@ SourceUnit #959
                     parent: ParameterList #817
                     <getter> children: Array(1) [ UserDefinedTypeName #812 ]
                     <getter> vScope: FunctionDefinition #836
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #812
                     <getter> lastChild: UserDefinedTypeName #812
                     <getter> previousSibling: undefined
@@ -6400,7 +6400,6 @@ SourceUnit #959
                     UserDefinedTypeName #812
                         id: 812
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -6409,6 +6408,7 @@ SourceUnit #959
                         parent: VariableDeclaration #813
                         <getter> children: Array(1) [ IdentifierPath #811 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #811
                         <getter> lastChild: IdentifierPath #811
                         <getter> previousSibling: undefined
@@ -6419,12 +6419,12 @@ SourceUnit #959
                         IdentifierPath #811
                             id: 811
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #812
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -6436,7 +6436,6 @@ SourceUnit #959
                 VariableDeclaration #816
                     id: 816
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -6455,6 +6454,7 @@ SourceUnit #959
                     parent: ParameterList #817
                     <getter> children: Array(1) [ UserDefinedTypeName #815 ]
                     <getter> vScope: FunctionDefinition #836
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #815
                     <getter> lastChild: UserDefinedTypeName #815
                     <getter> previousSibling: VariableDeclaration #813
@@ -6465,7 +6465,6 @@ SourceUnit #959
                     UserDefinedTypeName #815
                         id: 815
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -6474,6 +6473,7 @@ SourceUnit #959
                         parent: VariableDeclaration #816
                         <getter> children: Array(1) [ IdentifierPath #814 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #814
                         <getter> lastChild: IdentifierPath #814
                         <getter> previousSibling: undefined
@@ -6484,12 +6484,12 @@ SourceUnit #959
                         IdentifierPath #814
                             id: 814
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #815
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -6501,11 +6501,11 @@ SourceUnit #959
             ParameterList #821
                 id: 821
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #836
                 <getter> vParameters: Array(1) [ VariableDeclaration #820 ]
                 <getter> children: Array(1) [ VariableDeclaration #820 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #820
                 <getter> lastChild: VariableDeclaration #820
                 <getter> previousSibling: ParameterList #817
@@ -6516,7 +6516,6 @@ SourceUnit #959
                 VariableDeclaration #820
                     id: 820
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -6535,6 +6534,7 @@ SourceUnit #959
                     parent: ParameterList #821
                     <getter> children: Array(1) [ UserDefinedTypeName #819 ]
                     <getter> vScope: FunctionDefinition #836
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #819
                     <getter> lastChild: UserDefinedTypeName #819
                     <getter> previousSibling: undefined
@@ -6545,7 +6545,6 @@ SourceUnit #959
                     UserDefinedTypeName #819
                         id: 819
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -6554,6 +6553,7 @@ SourceUnit #959
                         parent: VariableDeclaration #820
                         <getter> children: Array(1) [ IdentifierPath #818 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #818
                         <getter> lastChild: IdentifierPath #818
                         <getter> previousSibling: undefined
@@ -6564,12 +6564,12 @@ SourceUnit #959
                         IdentifierPath #818
                             id: 818
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #819
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -6581,12 +6581,12 @@ SourceUnit #959
             Block #835
                 id: 835
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #836
                 <getter> vStatements: Array(1) [ Return #834 ]
                 <getter> children: Array(1) [ Return #834 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #834
                 <getter> lastChild: Return #834
                 <getter> previousSibling: ParameterList #821
@@ -6597,7 +6597,6 @@ SourceUnit #959
                 Return #834
                     id: 834
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 336
                     vExpression: FunctionCall #833
@@ -6605,6 +6604,7 @@ SourceUnit #959
                     parent: Block #835
                     <getter> children: Array(1) [ FunctionCall #833 ]
                     <getter> vFunctionReturnParameters: ParameterList #336
+                    <getter> type: "Return"
                     <getter> firstChild: FunctionCall #833
                     <getter> lastChild: FunctionCall #833
                     <getter> previousSibling: undefined
@@ -6615,7 +6615,6 @@ SourceUnit #959
                     FunctionCall #833
                         id: 833
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "LibWithUDVT_088.UFixed"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -6630,6 +6629,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "wrap"
                         <getter> vCallee: MemberAccess #823
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #823
                         <getter> lastChild: BinaryOperation #832
                         <getter> previousSibling: undefined
@@ -6640,7 +6640,6 @@ SourceUnit #959
                         MemberAccess #823
                             id: 823
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function (uint256) pure returns (LibWithUDVT_088.UFixed)"
                             vExpression: Identifier #822
                             memberName: "wrap"
@@ -6649,6 +6648,7 @@ SourceUnit #959
                             parent: FunctionCall #833
                             <getter> children: Array(1) [ Identifier #822 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #822
                             <getter> lastChild: Identifier #822
                             <getter> previousSibling: undefined
@@ -6659,7 +6659,6 @@ SourceUnit #959
                             Identifier #822
                                 id: 822
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "type(LibWithUDVT_088.UFixed)"
                                 name: "UFixed"
                                 referencedDeclaration: 805
@@ -6667,6 +6666,7 @@ SourceUnit #959
                                 parent: MemberAccess #823
                                 <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -6678,7 +6678,6 @@ SourceUnit #959
                         BinaryOperation #832
                             id: 832
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "uint256"
                             operator: "+"
                             vLeftExpression: FunctionCall #827
@@ -6686,6 +6685,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: FunctionCall #833
                             <getter> children: Array(2) [ FunctionCall #827, FunctionCall #831 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: FunctionCall #827
                             <getter> lastChild: FunctionCall #831
                             <getter> previousSibling: MemberAccess #823
@@ -6696,7 +6696,6 @@ SourceUnit #959
                             FunctionCall #827
                                 id: 827
                                 src: "0:0:0"
-                                type: "FunctionCall"
                                 typeString: "uint256"
                                 kind: "functionCall"
                                 fieldNames: undefined
@@ -6711,6 +6710,7 @@ SourceUnit #959
                                 <getter> vReferencedDeclaration: undefined
                                 <getter> vFunctionName: "unwrap"
                                 <getter> vCallee: MemberAccess #825
+                                <getter> type: "FunctionCall"
                                 <getter> firstChild: MemberAccess #825
                                 <getter> lastChild: Identifier #826
                                 <getter> previousSibling: undefined
@@ -6721,7 +6721,6 @@ SourceUnit #959
                                 MemberAccess #825
                                     id: 825
                                     src: "0:0:0"
-                                    type: "MemberAccess"
                                     typeString: "function (LibWithUDVT_088.UFixed) pure returns (uint256)"
                                     vExpression: Identifier #824
                                     memberName: "unwrap"
@@ -6730,6 +6729,7 @@ SourceUnit #959
                                     parent: FunctionCall #827
                                     <getter> children: Array(1) [ Identifier #824 ]
                                     <getter> vReferencedDeclaration: undefined
+                                    <getter> type: "MemberAccess"
                                     <getter> firstChild: Identifier #824
                                     <getter> lastChild: Identifier #824
                                     <getter> previousSibling: undefined
@@ -6740,7 +6740,6 @@ SourceUnit #959
                                     Identifier #824
                                         id: 824
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "type(LibWithUDVT_088.UFixed)"
                                         name: "UFixed"
                                         referencedDeclaration: 805
@@ -6748,6 +6747,7 @@ SourceUnit #959
                                         parent: MemberAccess #825
                                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -6759,7 +6759,6 @@ SourceUnit #959
                                 Identifier #826
                                     id: 826
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "LibWithUDVT_088.UFixed"
                                     name: "a"
                                     referencedDeclaration: 813
@@ -6767,6 +6766,7 @@ SourceUnit #959
                                     parent: FunctionCall #827
                                     <getter> vReferencedDeclaration: VariableDeclaration #813
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -6778,7 +6778,6 @@ SourceUnit #959
                             FunctionCall #831
                                 id: 831
                                 src: "0:0:0"
-                                type: "FunctionCall"
                                 typeString: "uint256"
                                 kind: "functionCall"
                                 fieldNames: undefined
@@ -6793,6 +6792,7 @@ SourceUnit #959
                                 <getter> vReferencedDeclaration: undefined
                                 <getter> vFunctionName: "unwrap"
                                 <getter> vCallee: MemberAccess #829
+                                <getter> type: "FunctionCall"
                                 <getter> firstChild: MemberAccess #829
                                 <getter> lastChild: Identifier #830
                                 <getter> previousSibling: FunctionCall #827
@@ -6803,7 +6803,6 @@ SourceUnit #959
                                 MemberAccess #829
                                     id: 829
                                     src: "0:0:0"
-                                    type: "MemberAccess"
                                     typeString: "function (LibWithUDVT_088.UFixed) pure returns (uint256)"
                                     vExpression: Identifier #828
                                     memberName: "unwrap"
@@ -6812,6 +6811,7 @@ SourceUnit #959
                                     parent: FunctionCall #831
                                     <getter> children: Array(1) [ Identifier #828 ]
                                     <getter> vReferencedDeclaration: undefined
+                                    <getter> type: "MemberAccess"
                                     <getter> firstChild: Identifier #828
                                     <getter> lastChild: Identifier #828
                                     <getter> previousSibling: undefined
@@ -6822,7 +6822,6 @@ SourceUnit #959
                                     Identifier #828
                                         id: 828
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "type(LibWithUDVT_088.UFixed)"
                                         name: "UFixed"
                                         referencedDeclaration: 805
@@ -6830,6 +6829,7 @@ SourceUnit #959
                                         parent: MemberAccess #829
                                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -6841,7 +6841,6 @@ SourceUnit #959
                                 Identifier #830
                                     id: 830
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "LibWithUDVT_088.UFixed"
                                     name: "b"
                                     referencedDeclaration: 816
@@ -6849,6 +6848,7 @@ SourceUnit #959
                                     parent: FunctionCall #831
                                     <getter> vReferencedDeclaration: VariableDeclaration #816
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -6860,7 +6860,6 @@ SourceUnit #959
         FunctionDefinition #858
             id: 858
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 891
@@ -6880,6 +6879,7 @@ SourceUnit #959
             parent: ContractDefinition #891
             <getter> children: Array(3) [ ParameterList #842, ParameterList #846, Block #857 ]
             <getter> vScope: ContractDefinition #891
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #842
             <getter> lastChild: Block #857
             <getter> previousSibling: FunctionDefinition #836
@@ -6890,11 +6890,11 @@ SourceUnit #959
             ParameterList #842
                 id: 842
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #858
                 <getter> vParameters: Array(2) [ VariableDeclaration #839, VariableDeclaration #841 ]
                 <getter> children: Array(2) [ VariableDeclaration #839, VariableDeclaration #841 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #839
                 <getter> lastChild: VariableDeclaration #841
                 <getter> previousSibling: undefined
@@ -6905,7 +6905,6 @@ SourceUnit #959
                 VariableDeclaration #839
                     id: 839
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -6924,6 +6923,7 @@ SourceUnit #959
                     parent: ParameterList #842
                     <getter> children: Array(1) [ UserDefinedTypeName #838 ]
                     <getter> vScope: FunctionDefinition #858
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #838
                     <getter> lastChild: UserDefinedTypeName #838
                     <getter> previousSibling: undefined
@@ -6934,7 +6934,6 @@ SourceUnit #959
                     UserDefinedTypeName #838
                         id: 838
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -6943,6 +6942,7 @@ SourceUnit #959
                         parent: VariableDeclaration #839
                         <getter> children: Array(1) [ IdentifierPath #837 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #837
                         <getter> lastChild: IdentifierPath #837
                         <getter> previousSibling: undefined
@@ -6953,12 +6953,12 @@ SourceUnit #959
                         IdentifierPath #837
                             id: 837
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #838
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -6970,7 +6970,6 @@ SourceUnit #959
                 VariableDeclaration #841
                     id: 841
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "b"
@@ -6989,6 +6988,7 @@ SourceUnit #959
                     parent: ParameterList #842
                     <getter> children: Array(1) [ ElementaryTypeName #840 ]
                     <getter> vScope: FunctionDefinition #858
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #840
                     <getter> lastChild: ElementaryTypeName #840
                     <getter> previousSibling: VariableDeclaration #839
@@ -6999,12 +6999,12 @@ SourceUnit #959
                     ElementaryTypeName #840
                         id: 840
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint256"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #841
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -7016,11 +7016,11 @@ SourceUnit #959
             ParameterList #846
                 id: 846
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #858
                 <getter> vParameters: Array(1) [ VariableDeclaration #845 ]
                 <getter> children: Array(1) [ VariableDeclaration #845 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #845
                 <getter> lastChild: VariableDeclaration #845
                 <getter> previousSibling: ParameterList #842
@@ -7031,7 +7031,6 @@ SourceUnit #959
                 VariableDeclaration #845
                     id: 845
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -7050,6 +7049,7 @@ SourceUnit #959
                     parent: ParameterList #846
                     <getter> children: Array(1) [ UserDefinedTypeName #844 ]
                     <getter> vScope: FunctionDefinition #858
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #844
                     <getter> lastChild: UserDefinedTypeName #844
                     <getter> previousSibling: undefined
@@ -7060,7 +7060,6 @@ SourceUnit #959
                     UserDefinedTypeName #844
                         id: 844
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -7069,6 +7068,7 @@ SourceUnit #959
                         parent: VariableDeclaration #845
                         <getter> children: Array(1) [ IdentifierPath #843 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #843
                         <getter> lastChild: IdentifierPath #843
                         <getter> previousSibling: undefined
@@ -7079,12 +7079,12 @@ SourceUnit #959
                         IdentifierPath #843
                             id: 843
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #844
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -7096,12 +7096,12 @@ SourceUnit #959
             Block #857
                 id: 857
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #858
                 <getter> vStatements: Array(1) [ Return #856 ]
                 <getter> children: Array(1) [ Return #856 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #856
                 <getter> lastChild: Return #856
                 <getter> previousSibling: ParameterList #846
@@ -7112,7 +7112,6 @@ SourceUnit #959
                 Return #856
                     id: 856
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 361
                     vExpression: FunctionCall #855
@@ -7120,6 +7119,7 @@ SourceUnit #959
                     parent: Block #857
                     <getter> children: Array(1) [ FunctionCall #855 ]
                     <getter> vFunctionReturnParameters: ParameterList #361
+                    <getter> type: "Return"
                     <getter> firstChild: FunctionCall #855
                     <getter> lastChild: FunctionCall #855
                     <getter> previousSibling: undefined
@@ -7130,7 +7130,6 @@ SourceUnit #959
                     FunctionCall #855
                         id: 855
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "LibWithUDVT_088.UFixed"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -7145,6 +7144,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "wrap"
                         <getter> vCallee: MemberAccess #848
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #848
                         <getter> lastChild: BinaryOperation #854
                         <getter> previousSibling: undefined
@@ -7155,7 +7155,6 @@ SourceUnit #959
                         MemberAccess #848
                             id: 848
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function (uint256) pure returns (LibWithUDVT_088.UFixed)"
                             vExpression: Identifier #847
                             memberName: "wrap"
@@ -7164,6 +7163,7 @@ SourceUnit #959
                             parent: FunctionCall #855
                             <getter> children: Array(1) [ Identifier #847 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #847
                             <getter> lastChild: Identifier #847
                             <getter> previousSibling: undefined
@@ -7174,7 +7174,6 @@ SourceUnit #959
                             Identifier #847
                                 id: 847
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "type(LibWithUDVT_088.UFixed)"
                                 name: "UFixed"
                                 referencedDeclaration: 805
@@ -7182,6 +7181,7 @@ SourceUnit #959
                                 parent: MemberAccess #848
                                 <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7193,7 +7193,6 @@ SourceUnit #959
                         BinaryOperation #854
                             id: 854
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "uint256"
                             operator: "*"
                             vLeftExpression: FunctionCall #852
@@ -7201,6 +7200,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: FunctionCall #855
                             <getter> children: Array(2) [ FunctionCall #852, Identifier #853 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: FunctionCall #852
                             <getter> lastChild: Identifier #853
                             <getter> previousSibling: MemberAccess #848
@@ -7211,7 +7211,6 @@ SourceUnit #959
                             FunctionCall #852
                                 id: 852
                                 src: "0:0:0"
-                                type: "FunctionCall"
                                 typeString: "uint256"
                                 kind: "functionCall"
                                 fieldNames: undefined
@@ -7226,6 +7225,7 @@ SourceUnit #959
                                 <getter> vReferencedDeclaration: undefined
                                 <getter> vFunctionName: "unwrap"
                                 <getter> vCallee: MemberAccess #850
+                                <getter> type: "FunctionCall"
                                 <getter> firstChild: MemberAccess #850
                                 <getter> lastChild: Identifier #851
                                 <getter> previousSibling: undefined
@@ -7236,7 +7236,6 @@ SourceUnit #959
                                 MemberAccess #850
                                     id: 850
                                     src: "0:0:0"
-                                    type: "MemberAccess"
                                     typeString: "function (LibWithUDVT_088.UFixed) pure returns (uint256)"
                                     vExpression: Identifier #849
                                     memberName: "unwrap"
@@ -7245,6 +7244,7 @@ SourceUnit #959
                                     parent: FunctionCall #852
                                     <getter> children: Array(1) [ Identifier #849 ]
                                     <getter> vReferencedDeclaration: undefined
+                                    <getter> type: "MemberAccess"
                                     <getter> firstChild: Identifier #849
                                     <getter> lastChild: Identifier #849
                                     <getter> previousSibling: undefined
@@ -7255,7 +7255,6 @@ SourceUnit #959
                                     Identifier #849
                                         id: 849
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "type(LibWithUDVT_088.UFixed)"
                                         name: "UFixed"
                                         referencedDeclaration: 805
@@ -7263,6 +7262,7 @@ SourceUnit #959
                                         parent: MemberAccess #850
                                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -7274,7 +7274,6 @@ SourceUnit #959
                                 Identifier #851
                                     id: 851
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "LibWithUDVT_088.UFixed"
                                     name: "a"
                                     referencedDeclaration: 839
@@ -7282,6 +7281,7 @@ SourceUnit #959
                                     parent: FunctionCall #852
                                     <getter> vReferencedDeclaration: VariableDeclaration #839
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -7293,7 +7293,6 @@ SourceUnit #959
                             Identifier #853
                                 id: 853
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "b"
                                 referencedDeclaration: 841
@@ -7301,6 +7300,7 @@ SourceUnit #959
                                 parent: BinaryOperation #854
                                 <getter> vReferencedDeclaration: VariableDeclaration #841
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7312,7 +7312,6 @@ SourceUnit #959
         FunctionDefinition #874
             id: 874
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 891
@@ -7332,6 +7331,7 @@ SourceUnit #959
             parent: ContractDefinition #891
             <getter> children: Array(3) [ ParameterList #862, ParameterList #865, Block #873 ]
             <getter> vScope: ContractDefinition #891
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #862
             <getter> lastChild: Block #873
             <getter> previousSibling: FunctionDefinition #858
@@ -7342,11 +7342,11 @@ SourceUnit #959
             ParameterList #862
                 id: 862
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #874
                 <getter> vParameters: Array(1) [ VariableDeclaration #861 ]
                 <getter> children: Array(1) [ VariableDeclaration #861 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #861
                 <getter> lastChild: VariableDeclaration #861
                 <getter> previousSibling: undefined
@@ -7357,7 +7357,6 @@ SourceUnit #959
                 VariableDeclaration #861
                     id: 861
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -7376,6 +7375,7 @@ SourceUnit #959
                     parent: ParameterList #862
                     <getter> children: Array(1) [ UserDefinedTypeName #860 ]
                     <getter> vScope: FunctionDefinition #874
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #860
                     <getter> lastChild: UserDefinedTypeName #860
                     <getter> previousSibling: undefined
@@ -7386,7 +7386,6 @@ SourceUnit #959
                     UserDefinedTypeName #860
                         id: 860
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -7395,6 +7394,7 @@ SourceUnit #959
                         parent: VariableDeclaration #861
                         <getter> children: Array(1) [ IdentifierPath #859 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #859
                         <getter> lastChild: IdentifierPath #859
                         <getter> previousSibling: undefined
@@ -7405,12 +7405,12 @@ SourceUnit #959
                         IdentifierPath #859
                             id: 859
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #860
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -7422,11 +7422,11 @@ SourceUnit #959
             ParameterList #865
                 id: 865
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #874
                 <getter> vParameters: Array(1) [ VariableDeclaration #864 ]
                 <getter> children: Array(1) [ VariableDeclaration #864 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #864
                 <getter> lastChild: VariableDeclaration #864
                 <getter> previousSibling: ParameterList #862
@@ -7437,7 +7437,6 @@ SourceUnit #959
                 VariableDeclaration #864
                     id: 864
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -7456,6 +7455,7 @@ SourceUnit #959
                     parent: ParameterList #865
                     <getter> children: Array(1) [ ElementaryTypeName #863 ]
                     <getter> vScope: FunctionDefinition #874
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #863
                     <getter> lastChild: ElementaryTypeName #863
                     <getter> previousSibling: undefined
@@ -7466,12 +7466,12 @@ SourceUnit #959
                     ElementaryTypeName #863
                         id: 863
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint256"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #864
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -7483,12 +7483,12 @@ SourceUnit #959
             Block #873
                 id: 873
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #874
                 <getter> vStatements: Array(1) [ Return #872 ]
                 <getter> children: Array(1) [ Return #872 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #872
                 <getter> lastChild: Return #872
                 <getter> previousSibling: ParameterList #865
@@ -7499,7 +7499,6 @@ SourceUnit #959
                 Return #872
                     id: 872
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 380
                     vExpression: BinaryOperation #871
@@ -7507,6 +7506,7 @@ SourceUnit #959
                     parent: Block #873
                     <getter> children: Array(1) [ BinaryOperation #871 ]
                     <getter> vFunctionReturnParameters: ParameterList #380
+                    <getter> type: "Return"
                     <getter> firstChild: BinaryOperation #871
                     <getter> lastChild: BinaryOperation #871
                     <getter> previousSibling: undefined
@@ -7517,7 +7517,6 @@ SourceUnit #959
                     BinaryOperation #871
                         id: 871
                         src: "0:0:0"
-                        type: "BinaryOperation"
                         typeString: "uint256"
                         operator: "/"
                         vLeftExpression: FunctionCall #869
@@ -7525,6 +7524,7 @@ SourceUnit #959
                         context: ASTContext #1000
                         parent: Return #872
                         <getter> children: Array(2) [ FunctionCall #869, Identifier #870 ]
+                        <getter> type: "BinaryOperation"
                         <getter> firstChild: FunctionCall #869
                         <getter> lastChild: Identifier #870
                         <getter> previousSibling: undefined
@@ -7535,7 +7535,6 @@ SourceUnit #959
                         FunctionCall #869
                             id: 869
                             src: "0:0:0"
-                            type: "FunctionCall"
                             typeString: "uint256"
                             kind: "functionCall"
                             fieldNames: undefined
@@ -7550,6 +7549,7 @@ SourceUnit #959
                             <getter> vReferencedDeclaration: undefined
                             <getter> vFunctionName: "unwrap"
                             <getter> vCallee: MemberAccess #867
+                            <getter> type: "FunctionCall"
                             <getter> firstChild: MemberAccess #867
                             <getter> lastChild: Identifier #868
                             <getter> previousSibling: undefined
@@ -7560,7 +7560,6 @@ SourceUnit #959
                             MemberAccess #867
                                 id: 867
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "function (LibWithUDVT_088.UFixed) pure returns (uint256)"
                                 vExpression: Identifier #866
                                 memberName: "unwrap"
@@ -7569,6 +7568,7 @@ SourceUnit #959
                                 parent: FunctionCall #869
                                 <getter> children: Array(1) [ Identifier #866 ]
                                 <getter> vReferencedDeclaration: undefined
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: Identifier #866
                                 <getter> lastChild: Identifier #866
                                 <getter> previousSibling: undefined
@@ -7579,7 +7579,6 @@ SourceUnit #959
                                 Identifier #866
                                     id: 866
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "type(LibWithUDVT_088.UFixed)"
                                     name: "UFixed"
                                     referencedDeclaration: 805
@@ -7587,6 +7586,7 @@ SourceUnit #959
                                     parent: MemberAccess #867
                                     <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -7598,7 +7598,6 @@ SourceUnit #959
                             Identifier #868
                                 id: 868
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "LibWithUDVT_088.UFixed"
                                 name: "a"
                                 referencedDeclaration: 861
@@ -7606,6 +7605,7 @@ SourceUnit #959
                                 parent: FunctionCall #869
                                 <getter> vReferencedDeclaration: VariableDeclaration #861
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7617,7 +7617,6 @@ SourceUnit #959
                         Identifier #870
                             id: 870
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "uint256"
                             name: "multiplier"
                             referencedDeclaration: 810
@@ -7625,6 +7624,7 @@ SourceUnit #959
                             parent: BinaryOperation #871
                             <getter> vReferencedDeclaration: VariableDeclaration #810
                             <getter> vIdentifierType: "userDefined"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -7636,7 +7636,6 @@ SourceUnit #959
         FunctionDefinition #890
             id: 890
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 891
@@ -7656,6 +7655,7 @@ SourceUnit #959
             parent: ContractDefinition #891
             <getter> children: Array(3) [ ParameterList #877, ParameterList #881, Block #889 ]
             <getter> vScope: ContractDefinition #891
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #877
             <getter> lastChild: Block #889
             <getter> previousSibling: FunctionDefinition #874
@@ -7666,11 +7666,11 @@ SourceUnit #959
             ParameterList #877
                 id: 877
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #890
                 <getter> vParameters: Array(1) [ VariableDeclaration #876 ]
                 <getter> children: Array(1) [ VariableDeclaration #876 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #876
                 <getter> lastChild: VariableDeclaration #876
                 <getter> previousSibling: undefined
@@ -7681,7 +7681,6 @@ SourceUnit #959
                 VariableDeclaration #876
                     id: 876
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "a"
@@ -7700,6 +7699,7 @@ SourceUnit #959
                     parent: ParameterList #877
                     <getter> children: Array(1) [ ElementaryTypeName #875 ]
                     <getter> vScope: FunctionDefinition #890
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #875
                     <getter> lastChild: ElementaryTypeName #875
                     <getter> previousSibling: undefined
@@ -7710,12 +7710,12 @@ SourceUnit #959
                     ElementaryTypeName #875
                         id: 875
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint256"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #876
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -7727,11 +7727,11 @@ SourceUnit #959
             ParameterList #881
                 id: 881
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #890
                 <getter> vParameters: Array(1) [ VariableDeclaration #880 ]
                 <getter> children: Array(1) [ VariableDeclaration #880 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #880
                 <getter> lastChild: VariableDeclaration #880
                 <getter> previousSibling: ParameterList #877
@@ -7742,7 +7742,6 @@ SourceUnit #959
                 VariableDeclaration #880
                     id: 880
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -7761,6 +7760,7 @@ SourceUnit #959
                     parent: ParameterList #881
                     <getter> children: Array(1) [ UserDefinedTypeName #879 ]
                     <getter> vScope: FunctionDefinition #890
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #879
                     <getter> lastChild: UserDefinedTypeName #879
                     <getter> previousSibling: undefined
@@ -7771,7 +7771,6 @@ SourceUnit #959
                     UserDefinedTypeName #879
                         id: 879
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "LibWithUDVT_088.UFixed"
                         name: undefined
                         referencedDeclaration: 805
@@ -7780,6 +7779,7 @@ SourceUnit #959
                         parent: VariableDeclaration #880
                         <getter> children: Array(1) [ IdentifierPath #878 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #878
                         <getter> lastChild: IdentifierPath #878
                         <getter> previousSibling: undefined
@@ -7790,12 +7790,12 @@ SourceUnit #959
                         IdentifierPath #878
                             id: 878
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "UFixed"
                             referencedDeclaration: 320
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #879
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #320
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -7807,12 +7807,12 @@ SourceUnit #959
             Block #889
                 id: 889
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #890
                 <getter> vStatements: Array(1) [ Return #888 ]
                 <getter> children: Array(1) [ Return #888 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #888
                 <getter> lastChild: Return #888
                 <getter> previousSibling: ParameterList #881
@@ -7823,7 +7823,6 @@ SourceUnit #959
                 Return #888
                     id: 888
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 396
                     vExpression: FunctionCall #887
@@ -7831,6 +7830,7 @@ SourceUnit #959
                     parent: Block #889
                     <getter> children: Array(1) [ FunctionCall #887 ]
                     <getter> vFunctionReturnParameters: ParameterList #396
+                    <getter> type: "Return"
                     <getter> firstChild: FunctionCall #887
                     <getter> lastChild: FunctionCall #887
                     <getter> previousSibling: undefined
@@ -7841,7 +7841,6 @@ SourceUnit #959
                     FunctionCall #887
                         id: 887
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "LibWithUDVT_088.UFixed"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -7856,6 +7855,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "wrap"
                         <getter> vCallee: MemberAccess #883
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: MemberAccess #883
                         <getter> lastChild: BinaryOperation #886
                         <getter> previousSibling: undefined
@@ -7866,7 +7866,6 @@ SourceUnit #959
                         MemberAccess #883
                             id: 883
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "function (uint256) pure returns (LibWithUDVT_088.UFixed)"
                             vExpression: Identifier #882
                             memberName: "wrap"
@@ -7875,6 +7874,7 @@ SourceUnit #959
                             parent: FunctionCall #887
                             <getter> children: Array(1) [ Identifier #882 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #882
                             <getter> lastChild: Identifier #882
                             <getter> previousSibling: undefined
@@ -7885,7 +7885,6 @@ SourceUnit #959
                             Identifier #882
                                 id: 882
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "type(LibWithUDVT_088.UFixed)"
                                 name: "UFixed"
                                 referencedDeclaration: 805
@@ -7893,6 +7892,7 @@ SourceUnit #959
                                 parent: MemberAccess #883
                                 <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #805
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7904,7 +7904,6 @@ SourceUnit #959
                         BinaryOperation #886
                             id: 886
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "uint256"
                             operator: "*"
                             vLeftExpression: Identifier #884
@@ -7912,6 +7911,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: FunctionCall #887
                             <getter> children: Array(2) [ Identifier #884, Identifier #885 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: Identifier #884
                             <getter> lastChild: Identifier #885
                             <getter> previousSibling: MemberAccess #883
@@ -7922,7 +7922,6 @@ SourceUnit #959
                             Identifier #884
                                 id: 884
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "a"
                                 referencedDeclaration: 876
@@ -7930,6 +7929,7 @@ SourceUnit #959
                                 parent: BinaryOperation #886
                                 <getter> vReferencedDeclaration: VariableDeclaration #876
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7941,7 +7941,6 @@ SourceUnit #959
                             Identifier #885
                                 id: 885
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "uint256"
                                 name: "multiplier"
                                 referencedDeclaration: 810
@@ -7949,6 +7948,7 @@ SourceUnit #959
                                 parent: BinaryOperation #886
                                 <getter> vReferencedDeclaration: VariableDeclaration #810
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -7960,7 +7960,6 @@ SourceUnit #959
     ContractDefinition #902
         id: 902
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "InterfaceWithUDTV_088"
         scope: 959
         kind: "interface"
@@ -7988,6 +7987,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(1) [ UserDefinedValueTypeDefinition #893 ]
         <getter> vConstructor: undefined
         <getter> children: Array(2) [ UserDefinedValueTypeDefinition #893, FunctionDefinition #901 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: UserDefinedValueTypeDefinition #893
         <getter> lastChild: FunctionDefinition #901
         <getter> previousSibling: ContractDefinition #891
@@ -7998,7 +7998,6 @@ SourceUnit #959
         UserDefinedValueTypeDefinition #893
             id: 893
             src: "0:0:0"
-            type: "UserDefinedValueTypeDefinition"
             name: "EntityReference"
             underlyingType: ElementaryTypeName #892
             nameLocation: "5483:15:0"
@@ -8007,6 +8006,7 @@ SourceUnit #959
             <getter> children: Array(1) [ ElementaryTypeName #892 ]
             <getter> canonicalName: "InterfaceWithUDTV_088.EntityReference"
             <getter> vScope: ContractDefinition #902
+            <getter> type: "UserDefinedValueTypeDefinition"
             <getter> firstChild: ElementaryTypeName #892
             <getter> lastChild: ElementaryTypeName #892
             <getter> previousSibling: undefined
@@ -8017,12 +8017,12 @@ SourceUnit #959
             ElementaryTypeName #892
                 id: 892
                 src: "0:0:0"
-                type: "ElementaryTypeName"
                 typeString: "address payable"
                 name: "address"
                 stateMutability: "payable"
                 context: ASTContext #1000
                 parent: UserDefinedValueTypeDefinition #893
+                <getter> type: "ElementaryTypeName"
                 <getter> children: Array(0)
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
@@ -8034,7 +8034,6 @@ SourceUnit #959
         FunctionDefinition #901
             id: 901
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: false
             virtual: false
             scope: 902
@@ -8054,6 +8053,7 @@ SourceUnit #959
             parent: ContractDefinition #902
             <getter> children: Array(2) [ ParameterList #897, ParameterList #900 ]
             <getter> vScope: ContractDefinition #902
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #897
             <getter> lastChild: ParameterList #900
             <getter> previousSibling: UserDefinedValueTypeDefinition #893
@@ -8064,11 +8064,11 @@ SourceUnit #959
             ParameterList #897
                 id: 897
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #901
                 <getter> vParameters: Array(1) [ VariableDeclaration #896 ]
                 <getter> children: Array(1) [ VariableDeclaration #896 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #896
                 <getter> lastChild: VariableDeclaration #896
                 <getter> previousSibling: undefined
@@ -8079,7 +8079,6 @@ SourceUnit #959
                 VariableDeclaration #896
                     id: 896
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "er"
@@ -8098,6 +8097,7 @@ SourceUnit #959
                     parent: ParameterList #897
                     <getter> children: Array(1) [ UserDefinedTypeName #895 ]
                     <getter> vScope: FunctionDefinition #901
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: UserDefinedTypeName #895
                     <getter> lastChild: UserDefinedTypeName #895
                     <getter> previousSibling: undefined
@@ -8108,7 +8108,6 @@ SourceUnit #959
                     UserDefinedTypeName #895
                         id: 895
                         src: "0:0:0"
-                        type: "UserDefinedTypeName"
                         typeString: "InterfaceWithUDTV_088.EntityReference"
                         name: undefined
                         referencedDeclaration: 893
@@ -8117,6 +8116,7 @@ SourceUnit #959
                         parent: VariableDeclaration #896
                         <getter> children: Array(1) [ IdentifierPath #894 ]
                         <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #893
+                        <getter> type: "UserDefinedTypeName"
                         <getter> firstChild: IdentifierPath #894
                         <getter> lastChild: IdentifierPath #894
                         <getter> previousSibling: undefined
@@ -8127,12 +8127,12 @@ SourceUnit #959
                         IdentifierPath #894
                             id: 894
                             src: "0:0:0"
-                            type: "IdentifierPath"
                             name: "EntityReference"
                             referencedDeclaration: 408
                             context: ASTContext #1000
                             parent: UserDefinedTypeName #895
                             <getter> vReferencedDeclaration: UserDefinedValueTypeDefinition #408
+                            <getter> type: "IdentifierPath"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -8144,11 +8144,11 @@ SourceUnit #959
             ParameterList #900
                 id: 900
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #901
                 <getter> vParameters: Array(1) [ VariableDeclaration #899 ]
                 <getter> children: Array(1) [ VariableDeclaration #899 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #899
                 <getter> lastChild: VariableDeclaration #899
                 <getter> previousSibling: ParameterList #897
@@ -8159,7 +8159,6 @@ SourceUnit #959
                 VariableDeclaration #899
                     id: 899
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -8178,6 +8177,7 @@ SourceUnit #959
                     parent: ParameterList #900
                     <getter> children: Array(1) [ ElementaryTypeName #898 ]
                     <getter> vScope: FunctionDefinition #901
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #898
                     <getter> lastChild: ElementaryTypeName #898
                     <getter> previousSibling: undefined
@@ -8188,12 +8188,12 @@ SourceUnit #959
                     ElementaryTypeName #898
                         id: 898
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #899
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -8205,7 +8205,6 @@ SourceUnit #959
     ContractDefinition #927
         id: 927
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "EnumTypeMinMax_088"
         scope: 959
         kind: "contract"
@@ -8233,6 +8232,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(1) [ FunctionDefinition #926 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #926
         <getter> lastChild: FunctionDefinition #926
         <getter> previousSibling: ContractDefinition #902
@@ -8243,7 +8243,6 @@ SourceUnit #959
         FunctionDefinition #926
             id: 926
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 927
@@ -8263,6 +8262,7 @@ SourceUnit #959
             parent: ContractDefinition #927
             <getter> children: Array(3) [ ParameterList #903, ParameterList #904, Block #925 ]
             <getter> vScope: ContractDefinition #927
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #903
             <getter> lastChild: Block #925
             <getter> previousSibling: undefined
@@ -8273,11 +8273,11 @@ SourceUnit #959
             ParameterList #903
                 id: 903
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #926
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -8288,11 +8288,11 @@ SourceUnit #959
             ParameterList #904
                 id: 904
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #926
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #903
@@ -8303,12 +8303,12 @@ SourceUnit #959
             Block #925
                 id: 925
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #926
                 <getter> vStatements: Array(2) [ ExpressionStatement #914, ExpressionStatement #924 ]
                 <getter> children: Array(2) [ ExpressionStatement #914, ExpressionStatement #924 ]
+                <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #914
                 <getter> lastChild: ExpressionStatement #924
                 <getter> previousSibling: ParameterList #904
@@ -8319,12 +8319,12 @@ SourceUnit #959
                 ExpressionStatement #914
                     id: 914
                     src: "0:0:0"
-                    type: "ExpressionStatement"
                     documentation: undefined
                     vExpression: FunctionCall #913
                     context: ASTContext #1000
                     parent: Block #925
                     <getter> children: Array(1) [ FunctionCall #913 ]
+                    <getter> type: "ExpressionStatement"
                     <getter> firstChild: FunctionCall #913
                     <getter> lastChild: FunctionCall #913
                     <getter> previousSibling: undefined
@@ -8335,7 +8335,6 @@ SourceUnit #959
                     FunctionCall #913
                         id: 913
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -8350,6 +8349,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "assert"
                         <getter> vCallee: Identifier #905
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: Identifier #905
                         <getter> lastChild: BinaryOperation #912
                         <getter> previousSibling: undefined
@@ -8360,7 +8360,6 @@ SourceUnit #959
                         Identifier #905
                             id: 905
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "function (bool) pure"
                             name: "assert"
                             referencedDeclaration: -1
@@ -8368,6 +8367,7 @@ SourceUnit #959
                             parent: FunctionCall #913
                             <getter> vReferencedDeclaration: undefined
                             <getter> vIdentifierType: "builtin"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -8379,7 +8379,6 @@ SourceUnit #959
                         BinaryOperation #912
                             id: 912
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "bool"
                             operator: "=="
                             vLeftExpression: MemberAccess #909
@@ -8387,6 +8386,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: FunctionCall #913
                             <getter> children: Array(2) [ MemberAccess #909, MemberAccess #911 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: MemberAccess #909
                             <getter> lastChild: MemberAccess #911
                             <getter> previousSibling: Identifier #905
@@ -8397,7 +8397,6 @@ SourceUnit #959
                             MemberAccess #909
                                 id: 909
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "enum EnumABC"
                                 vExpression: FunctionCall #908
                                 memberName: "min"
@@ -8406,6 +8405,7 @@ SourceUnit #959
                                 parent: BinaryOperation #912
                                 <getter> children: Array(1) [ FunctionCall #908 ]
                                 <getter> vReferencedDeclaration: undefined
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: FunctionCall #908
                                 <getter> lastChild: FunctionCall #908
                                 <getter> previousSibling: undefined
@@ -8416,7 +8416,6 @@ SourceUnit #959
                                 FunctionCall #908
                                     id: 908
                                     src: "0:0:0"
-                                    type: "FunctionCall"
                                     typeString: "type(enum EnumABC)"
                                     kind: "functionCall"
                                     fieldNames: undefined
@@ -8431,6 +8430,7 @@ SourceUnit #959
                                     <getter> vReferencedDeclaration: undefined
                                     <getter> vFunctionName: "type"
                                     <getter> vCallee: Identifier #906
+                                    <getter> type: "FunctionCall"
                                     <getter> firstChild: Identifier #906
                                     <getter> lastChild: Identifier #907
                                     <getter> previousSibling: undefined
@@ -8441,7 +8441,6 @@ SourceUnit #959
                                     Identifier #906
                                         id: 906
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "function () pure"
                                         name: "type"
                                         referencedDeclaration: -1
@@ -8449,6 +8448,7 @@ SourceUnit #959
                                         parent: FunctionCall #908
                                         <getter> vReferencedDeclaration: undefined
                                         <getter> vIdentifierType: "builtin"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -8460,7 +8460,6 @@ SourceUnit #959
                                     Identifier #907
                                         id: 907
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "type(enum EnumABC)"
                                         name: "EnumABC"
                                         referencedDeclaration: 497
@@ -8468,6 +8467,7 @@ SourceUnit #959
                                         parent: FunctionCall #908
                                         <getter> vReferencedDeclaration: EnumDefinition #497
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -8479,7 +8479,6 @@ SourceUnit #959
                             MemberAccess #911
                                 id: 911
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "enum EnumABC"
                                 vExpression: Identifier #910
                                 memberName: "A"
@@ -8488,6 +8487,7 @@ SourceUnit #959
                                 parent: BinaryOperation #912
                                 <getter> children: Array(1) [ Identifier #910 ]
                                 <getter> vReferencedDeclaration: EnumValue #494
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: Identifier #910
                                 <getter> lastChild: Identifier #910
                                 <getter> previousSibling: MemberAccess #909
@@ -8498,7 +8498,6 @@ SourceUnit #959
                                 Identifier #910
                                     id: 910
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "type(enum EnumABC)"
                                     name: "EnumABC"
                                     referencedDeclaration: 497
@@ -8506,6 +8505,7 @@ SourceUnit #959
                                     parent: MemberAccess #911
                                     <getter> vReferencedDeclaration: EnumDefinition #497
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -8517,12 +8517,12 @@ SourceUnit #959
                 ExpressionStatement #924
                     id: 924
                     src: "0:0:0"
-                    type: "ExpressionStatement"
                     documentation: undefined
                     vExpression: FunctionCall #923
                     context: ASTContext #1000
                     parent: Block #925
                     <getter> children: Array(1) [ FunctionCall #923 ]
+                    <getter> type: "ExpressionStatement"
                     <getter> firstChild: FunctionCall #923
                     <getter> lastChild: FunctionCall #923
                     <getter> previousSibling: ExpressionStatement #914
@@ -8533,7 +8533,6 @@ SourceUnit #959
                     FunctionCall #923
                         id: 923
                         src: "0:0:0"
-                        type: "FunctionCall"
                         typeString: "tuple()"
                         kind: "functionCall"
                         fieldNames: undefined
@@ -8548,6 +8547,7 @@ SourceUnit #959
                         <getter> vReferencedDeclaration: undefined
                         <getter> vFunctionName: "assert"
                         <getter> vCallee: Identifier #915
+                        <getter> type: "FunctionCall"
                         <getter> firstChild: Identifier #915
                         <getter> lastChild: BinaryOperation #922
                         <getter> previousSibling: undefined
@@ -8558,7 +8558,6 @@ SourceUnit #959
                         Identifier #915
                             id: 915
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "function (bool) pure"
                             name: "assert"
                             referencedDeclaration: -1
@@ -8566,6 +8565,7 @@ SourceUnit #959
                             parent: FunctionCall #923
                             <getter> vReferencedDeclaration: undefined
                             <getter> vIdentifierType: "builtin"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -8577,7 +8577,6 @@ SourceUnit #959
                         BinaryOperation #922
                             id: 922
                             src: "0:0:0"
-                            type: "BinaryOperation"
                             typeString: "bool"
                             operator: "=="
                             vLeftExpression: MemberAccess #919
@@ -8585,6 +8584,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: FunctionCall #923
                             <getter> children: Array(2) [ MemberAccess #919, MemberAccess #921 ]
+                            <getter> type: "BinaryOperation"
                             <getter> firstChild: MemberAccess #919
                             <getter> lastChild: MemberAccess #921
                             <getter> previousSibling: Identifier #915
@@ -8595,7 +8595,6 @@ SourceUnit #959
                             MemberAccess #919
                                 id: 919
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "enum EnumABC"
                                 vExpression: FunctionCall #918
                                 memberName: "max"
@@ -8604,6 +8603,7 @@ SourceUnit #959
                                 parent: BinaryOperation #922
                                 <getter> children: Array(1) [ FunctionCall #918 ]
                                 <getter> vReferencedDeclaration: undefined
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: FunctionCall #918
                                 <getter> lastChild: FunctionCall #918
                                 <getter> previousSibling: undefined
@@ -8614,7 +8614,6 @@ SourceUnit #959
                                 FunctionCall #918
                                     id: 918
                                     src: "0:0:0"
-                                    type: "FunctionCall"
                                     typeString: "type(enum EnumABC)"
                                     kind: "functionCall"
                                     fieldNames: undefined
@@ -8629,6 +8628,7 @@ SourceUnit #959
                                     <getter> vReferencedDeclaration: undefined
                                     <getter> vFunctionName: "type"
                                     <getter> vCallee: Identifier #916
+                                    <getter> type: "FunctionCall"
                                     <getter> firstChild: Identifier #916
                                     <getter> lastChild: Identifier #917
                                     <getter> previousSibling: undefined
@@ -8639,7 +8639,6 @@ SourceUnit #959
                                     Identifier #916
                                         id: 916
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "function () pure"
                                         name: "type"
                                         referencedDeclaration: -1
@@ -8647,6 +8646,7 @@ SourceUnit #959
                                         parent: FunctionCall #918
                                         <getter> vReferencedDeclaration: undefined
                                         <getter> vIdentifierType: "builtin"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -8658,7 +8658,6 @@ SourceUnit #959
                                     Identifier #917
                                         id: 917
                                         src: "0:0:0"
-                                        type: "Identifier"
                                         typeString: "type(enum EnumABC)"
                                         name: "EnumABC"
                                         referencedDeclaration: 497
@@ -8666,6 +8665,7 @@ SourceUnit #959
                                         parent: FunctionCall #918
                                         <getter> vReferencedDeclaration: EnumDefinition #497
                                         <getter> vIdentifierType: "userDefined"
+                                        <getter> type: "Identifier"
                                         <getter> children: Array(0)
                                         <getter> firstChild: undefined
                                         <getter> lastChild: undefined
@@ -8677,7 +8677,6 @@ SourceUnit #959
                             MemberAccess #921
                                 id: 921
                                 src: "0:0:0"
-                                type: "MemberAccess"
                                 typeString: "enum EnumABC"
                                 vExpression: Identifier #920
                                 memberName: "C"
@@ -8686,6 +8685,7 @@ SourceUnit #959
                                 parent: BinaryOperation #922
                                 <getter> children: Array(1) [ Identifier #920 ]
                                 <getter> vReferencedDeclaration: EnumValue #496
+                                <getter> type: "MemberAccess"
                                 <getter> firstChild: Identifier #920
                                 <getter> lastChild: Identifier #920
                                 <getter> previousSibling: MemberAccess #919
@@ -8696,7 +8696,6 @@ SourceUnit #959
                                 Identifier #920
                                     id: 920
                                     src: "0:0:0"
-                                    type: "Identifier"
                                     typeString: "type(enum EnumABC)"
                                     name: "EnumABC"
                                     referencedDeclaration: 497
@@ -8704,6 +8703,7 @@ SourceUnit #959
                                     parent: MemberAccess #921
                                     <getter> vReferencedDeclaration: EnumDefinition #497
                                     <getter> vIdentifierType: "userDefined"
+                                    <getter> type: "Identifier"
                                     <getter> children: Array(0)
                                     <getter> firstChild: undefined
                                     <getter> lastChild: undefined
@@ -8715,7 +8715,6 @@ SourceUnit #959
     ContractDefinition #958
         id: 958
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "ExternalFnSelectorAndAddress_0810"
         scope: 959
         kind: "contract"
@@ -8743,6 +8742,7 @@ SourceUnit #959
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(2) [ FunctionDefinition #931, FunctionDefinition #957 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: FunctionDefinition #931
         <getter> lastChild: FunctionDefinition #957
         <getter> previousSibling: ContractDefinition #927
@@ -8753,7 +8753,6 @@ SourceUnit #959
         FunctionDefinition #931
             id: 931
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 958
@@ -8773,6 +8772,7 @@ SourceUnit #959
             parent: ContractDefinition #958
             <getter> children: Array(3) [ ParameterList #928, ParameterList #929, Block #930 ]
             <getter> vScope: ContractDefinition #958
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #928
             <getter> lastChild: Block #930
             <getter> previousSibling: undefined
@@ -8783,11 +8783,11 @@ SourceUnit #959
             ParameterList #928
                 id: 928
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #931
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -8798,11 +8798,11 @@ SourceUnit #959
             ParameterList #929
                 id: 929
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #931
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #928
@@ -8813,12 +8813,12 @@ SourceUnit #959
             Block #930
                 id: 930
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #931
                 <getter> vStatements: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "Block"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: ParameterList #929
@@ -8829,7 +8829,6 @@ SourceUnit #959
         FunctionDefinition #957
             id: 957
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: false
             scope: 958
@@ -8849,6 +8848,7 @@ SourceUnit #959
             parent: ContractDefinition #958
             <getter> children: Array(3) [ ParameterList #936, ParameterList #941, Block #956 ]
             <getter> vScope: ContractDefinition #958
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #936
             <getter> lastChild: Block #956
             <getter> previousSibling: FunctionDefinition #931
@@ -8859,11 +8859,11 @@ SourceUnit #959
             ParameterList #936
                 id: 936
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #957
                 <getter> vParameters: Array(2) [ VariableDeclaration #933, VariableDeclaration #935 ]
                 <getter> children: Array(2) [ VariableDeclaration #933, VariableDeclaration #935 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #933
                 <getter> lastChild: VariableDeclaration #935
                 <getter> previousSibling: undefined
@@ -8874,7 +8874,6 @@ SourceUnit #959
                 VariableDeclaration #933
                     id: 933
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "newAddress"
@@ -8893,6 +8892,7 @@ SourceUnit #959
                     parent: ParameterList #936
                     <getter> children: Array(1) [ ElementaryTypeName #932 ]
                     <getter> vScope: FunctionDefinition #957
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #932
                     <getter> lastChild: ElementaryTypeName #932
                     <getter> previousSibling: undefined
@@ -8903,12 +8903,12 @@ SourceUnit #959
                     ElementaryTypeName #932
                         id: 932
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "address"
                         name: "address"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #933
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -8920,7 +8920,6 @@ SourceUnit #959
                 VariableDeclaration #935
                     id: 935
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "newSelector"
@@ -8939,6 +8938,7 @@ SourceUnit #959
                     parent: ParameterList #936
                     <getter> children: Array(1) [ ElementaryTypeName #934 ]
                     <getter> vScope: FunctionDefinition #957
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #934
                     <getter> lastChild: ElementaryTypeName #934
                     <getter> previousSibling: VariableDeclaration #933
@@ -8949,12 +8949,12 @@ SourceUnit #959
                     ElementaryTypeName #934
                         id: 934
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint32"
                         name: "uint32"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #935
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -8966,11 +8966,11 @@ SourceUnit #959
             ParameterList #941
                 id: 941
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #957
                 <getter> vParameters: Array(2) [ VariableDeclaration #938, VariableDeclaration #940 ]
                 <getter> children: Array(2) [ VariableDeclaration #938, VariableDeclaration #940 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #938
                 <getter> lastChild: VariableDeclaration #940
                 <getter> previousSibling: ParameterList #936
@@ -8981,7 +8981,6 @@ SourceUnit #959
                 VariableDeclaration #938
                     id: 938
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "adr"
@@ -9000,6 +8999,7 @@ SourceUnit #959
                     parent: ParameterList #941
                     <getter> children: Array(1) [ ElementaryTypeName #937 ]
                     <getter> vScope: FunctionDefinition #957
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #937
                     <getter> lastChild: ElementaryTypeName #937
                     <getter> previousSibling: undefined
@@ -9010,12 +9010,12 @@ SourceUnit #959
                     ElementaryTypeName #937
                         id: 937
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "address"
                         name: "address"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #938
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -9027,7 +9027,6 @@ SourceUnit #959
                 VariableDeclaration #940
                     id: 940
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: "sel"
@@ -9046,6 +9045,7 @@ SourceUnit #959
                     parent: ParameterList #941
                     <getter> children: Array(1) [ ElementaryTypeName #939 ]
                     <getter> vScope: FunctionDefinition #957
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #939
                     <getter> lastChild: ElementaryTypeName #939
                     <getter> previousSibling: VariableDeclaration #938
@@ -9056,12 +9056,12 @@ SourceUnit #959
                     ElementaryTypeName #939
                         id: 939
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "bytes4"
                         name: "bytes4"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #940
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -9073,12 +9073,12 @@ SourceUnit #959
             Block #956
                 id: 956
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #957
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #948, InlineAssembly #949, Return #955 ]
                 <getter> children: Array(3) [ VariableDeclarationStatement #948, InlineAssembly #949, Return #955 ]
+                <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #948
                 <getter> lastChild: Return #955
                 <getter> previousSibling: ParameterList #941
@@ -9089,7 +9089,6 @@ SourceUnit #959
                 VariableDeclarationStatement #948
                     id: 948
                     src: "0:0:0"
-                    type: "VariableDeclarationStatement"
                     documentation: undefined
                     assignments: Array(1) [ 945 ]
                     vDeclarations: Array(1) [ VariableDeclaration #945 ]
@@ -9097,6 +9096,7 @@ SourceUnit #959
                     context: ASTContext #1000
                     parent: Block #956
                     <getter> children: Array(2) [ VariableDeclaration #945, MemberAccess #947 ]
+                    <getter> type: "VariableDeclarationStatement"
                     <getter> firstChild: VariableDeclaration #945
                     <getter> lastChild: MemberAccess #947
                     <getter> previousSibling: undefined
@@ -9107,7 +9107,6 @@ SourceUnit #959
                     VariableDeclaration #945
                         id: 945
                         src: "0:0:0"
-                        type: "VariableDeclaration"
                         constant: false
                         indexed: false
                         name: "fp"
@@ -9126,6 +9125,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #948
                         <getter> children: Array(1) [ FunctionTypeName #944 ]
                         <getter> vScope: Block #956
+                        <getter> type: "VariableDeclaration"
                         <getter> firstChild: FunctionTypeName #944
                         <getter> lastChild: FunctionTypeName #944
                         <getter> previousSibling: undefined
@@ -9136,7 +9136,6 @@ SourceUnit #959
                         FunctionTypeName #944
                             id: 944
                             src: "0:0:0"
-                            type: "FunctionTypeName"
                             typeString: "function () external"
                             visibility: "external"
                             stateMutability: "nonpayable"
@@ -9145,6 +9144,7 @@ SourceUnit #959
                             context: ASTContext #1000
                             parent: VariableDeclaration #945
                             <getter> children: Array(2) [ ParameterList #942, ParameterList #943 ]
+                            <getter> type: "FunctionTypeName"
                             <getter> firstChild: ParameterList #942
                             <getter> lastChild: ParameterList #943
                             <getter> previousSibling: undefined
@@ -9155,11 +9155,11 @@ SourceUnit #959
                             ParameterList #942
                                 id: 942
                                 src: "0:0:0"
-                                type: "ParameterList"
                                 context: ASTContext #1000
                                 parent: FunctionTypeName #944
                                 <getter> vParameters: Array(0)
                                 <getter> children: Array(0)
+                                <getter> type: "ParameterList"
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
                                 <getter> previousSibling: undefined
@@ -9170,11 +9170,11 @@ SourceUnit #959
                             ParameterList #943
                                 id: 943
                                 src: "0:0:0"
-                                type: "ParameterList"
                                 context: ASTContext #1000
                                 parent: FunctionTypeName #944
                                 <getter> vParameters: Array(0)
                                 <getter> children: Array(0)
+                                <getter> type: "ParameterList"
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
                                 <getter> previousSibling: ParameterList #942
@@ -9185,7 +9185,6 @@ SourceUnit #959
                     MemberAccess #947
                         id: 947
                         src: "0:0:0"
-                        type: "MemberAccess"
                         typeString: "function () external"
                         vExpression: Identifier #946
                         memberName: "testFunction"
@@ -9194,6 +9193,7 @@ SourceUnit #959
                         parent: VariableDeclarationStatement #948
                         <getter> children: Array(1) [ Identifier #946 ]
                         <getter> vReferencedDeclaration: FunctionDefinition #931
+                        <getter> type: "MemberAccess"
                         <getter> firstChild: Identifier #946
                         <getter> lastChild: Identifier #946
                         <getter> previousSibling: VariableDeclaration #945
@@ -9204,7 +9204,6 @@ SourceUnit #959
                         Identifier #946
                             id: 946
                             src: "0:0:0"
-                            type: "Identifier"
                             typeString: "contract ExternalFnSelectorAndAddress_0810"
                             name: "this"
                             referencedDeclaration: -1
@@ -9212,6 +9211,7 @@ SourceUnit #959
                             parent: MemberAccess #947
                             <getter> vReferencedDeclaration: undefined
                             <getter> vIdentifierType: "builtin"
+                            <getter> type: "Identifier"
                             <getter> children: Array(0)
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
@@ -9223,13 +9223,13 @@ SourceUnit #959
                 InlineAssembly #949
                     id: 949
                     src: "0:0:0"
-                    type: "InlineAssembly"
                     documentation: undefined
                     externalReferences: Array(6) [ Object { declaration: 460, isOffset: false, isSlot: false, src: "6057:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6114:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6089:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6151:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 448, isOffset: false, isSlot: false, src: "6128:10:0", valueSize: 1 }, Object { declaration: 450, isOffset: false, isSlot: false, src: "6166:11:0", valueSize: 1 } ]
                     operations: undefined
                     yul: Object { nodeType: "YulBlock", src: "6034:153:0", statements: Array(4) [ Object { nodeType: "YulVariableDeclaration", src: "6048:19:0", value: Object { name: "fp.address", nodeType: "YulIdentifier", src: "6057:10:0" }, variables: Array(1) [ Object { name: "o", nodeType: "YulTypedName", src: "6052:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "6080:20:0", value: Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6089:11:0" }, variables: Array(1) [ Object { name: "s", nodeType: "YulTypedName", src: "6084:1:0", type: "" } ] }, Object { nodeType: "YulAssignment", src: "6114:24:0", value: Object { name: "newAddress", nodeType: "YulIdentifier", src: "6128:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nodeType: "YulIdentifier", src: "6114:10:0" } ] }, Object { nodeType: "YulAssignment", src: "6151:26:0", value: Object { name: "newSelector", nodeType: "YulIdentifier", src: "6166:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6151:11:0" } ] } ] }
                     context: ASTContext #1000
                     parent: Block #956
+                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -9241,7 +9241,6 @@ SourceUnit #959
                 Return #955
                     id: 955
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 456
                     vExpression: TupleExpression #954
@@ -9249,6 +9248,7 @@ SourceUnit #959
                     parent: Block #956
                     <getter> children: Array(1) [ TupleExpression #954 ]
                     <getter> vFunctionReturnParameters: ParameterList #456
+                    <getter> type: "Return"
                     <getter> firstChild: TupleExpression #954
                     <getter> lastChild: TupleExpression #954
                     <getter> previousSibling: InlineAssembly #949
@@ -9259,7 +9259,6 @@ SourceUnit #959
                     TupleExpression #954
                         id: 954
                         src: "0:0:0"
-                        type: "TupleExpression"
                         typeString: "tuple(address,bytes4)"
                         isInlineArray: false
                         vOriginalComponents: Array(2) [ MemberAccess #951, MemberAccess #953 ]
@@ -9268,6 +9267,7 @@ SourceUnit #959
                         <getter> children: Array(2) [ MemberAccess #951, MemberAccess #953 ]
                         <getter> components: Array(2) [ 951, 953 ]
                         <getter> vComponents: Array(2) [ MemberAccess #951, MemberAccess #953 ]
+                        <getter> type: "TupleExpression"
                         <getter> firstChild: MemberAccess #951
                         <getter> lastChild: MemberAccess #953
                         <getter> previousSibling: undefined
@@ -9278,7 +9278,6 @@ SourceUnit #959
                         MemberAccess #951
                             id: 951
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "address"
                             vExpression: Identifier #950
                             memberName: "address"
@@ -9287,6 +9286,7 @@ SourceUnit #959
                             parent: TupleExpression #954
                             <getter> children: Array(1) [ Identifier #950 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #950
                             <getter> lastChild: Identifier #950
                             <getter> previousSibling: undefined
@@ -9297,7 +9297,6 @@ SourceUnit #959
                             Identifier #950
                                 id: 950
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "function () external"
                                 name: "fp"
                                 referencedDeclaration: 945
@@ -9305,6 +9304,7 @@ SourceUnit #959
                                 parent: MemberAccess #951
                                 <getter> vReferencedDeclaration: VariableDeclaration #945
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -9316,7 +9316,6 @@ SourceUnit #959
                         MemberAccess #953
                             id: 953
                             src: "0:0:0"
-                            type: "MemberAccess"
                             typeString: "bytes4"
                             vExpression: Identifier #952
                             memberName: "selector"
@@ -9325,6 +9324,7 @@ SourceUnit #959
                             parent: TupleExpression #954
                             <getter> children: Array(1) [ Identifier #952 ]
                             <getter> vReferencedDeclaration: undefined
+                            <getter> type: "MemberAccess"
                             <getter> firstChild: Identifier #952
                             <getter> lastChild: Identifier #952
                             <getter> previousSibling: MemberAccess #951
@@ -9335,7 +9335,6 @@ SourceUnit #959
                             Identifier #952
                                 id: 952
                                 src: "0:0:0"
-                                type: "Identifier"
                                 typeString: "function () external"
                                 name: "fp"
                                 referencedDeclaration: 945
@@ -9343,6 +9342,7 @@ SourceUnit #959
                                 parent: MemberAccess #953
                                 <getter> vReferencedDeclaration: VariableDeclaration #945
                                 <getter> vIdentifierType: "userDefined"
+                                <getter> type: "Identifier"
                                 <getter> children: Array(0)
                                 <getter> firstChild: undefined
                                 <getter> lastChild: undefined
@@ -9354,7 +9354,6 @@ SourceUnit #959
 SourceUnit #975
     id: 975
     src: "0:0:0"
-    type: "SourceUnit"
     sourceEntryKey: "./test/samples/solidity/latest_imports_08.sol"
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/latest_imports_08.sol"
@@ -9371,6 +9370,7 @@ SourceUnit #975
     <getter> vUserDefinedValueTypes: Array(0)
     <getter> vExportedSymbols: Map(2) { "SomeContract" -> ContractDefinition #973, "SomeLib" -> ContractDefinition #974 }
     <getter> children: Array(4) [ PragmaDirective #960, PragmaDirective #961, ContractDefinition #973, ContractDefinition #974 ]
+    <getter> type: "SourceUnit"
     <getter> firstChild: PragmaDirective #960
     <getter> lastChild: ContractDefinition #974
     <getter> previousSibling: undefined
@@ -9381,12 +9381,12 @@ SourceUnit #975
     PragmaDirective #960
         id: 960
         src: "0:0:0"
-        type: "PragmaDirective"
         literals: Array(4) [ "solidity", "^", "0.8", ".0" ]
         context: ASTContext #1000
         parent: SourceUnit #975
         <getter> vIdentifier: "solidity"
         <getter> vValue: "^0.8.0"
+        <getter> type: "PragmaDirective"
         <getter> children: Array(0)
         <getter> firstChild: undefined
         <getter> lastChild: undefined
@@ -9398,12 +9398,12 @@ SourceUnit #975
     PragmaDirective #961
         id: 961
         src: "0:0:0"
-        type: "PragmaDirective"
         literals: Array(2) [ "abicoder", "v2" ]
         context: ASTContext #1000
         parent: SourceUnit #975
         <getter> vIdentifier: "abicoder"
         <getter> vValue: "v2"
+        <getter> type: "PragmaDirective"
         <getter> children: Array(0)
         <getter> firstChild: undefined
         <getter> lastChild: undefined
@@ -9415,7 +9415,6 @@ SourceUnit #975
     ContractDefinition #973
         id: 973
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "SomeContract"
         scope: 975
         kind: "contract"
@@ -9443,6 +9442,7 @@ SourceUnit #975
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(2) [ StructDefinition #964, FunctionDefinition #972 ]
+        <getter> type: "ContractDefinition"
         <getter> firstChild: StructDefinition #964
         <getter> lastChild: FunctionDefinition #972
         <getter> previousSibling: PragmaDirective #961
@@ -9453,7 +9453,6 @@ SourceUnit #975
         StructDefinition #964
             id: 964
             src: "0:0:0"
-            type: "StructDefinition"
             name: "SomeStruct"
             scope: 973
             visibility: "public"
@@ -9464,6 +9463,7 @@ SourceUnit #975
             <getter> vMembers: Array(1) [ VariableDeclaration #963 ]
             <getter> vScope: ContractDefinition #973
             <getter> children: Array(1) [ VariableDeclaration #963 ]
+            <getter> type: "StructDefinition"
             <getter> firstChild: VariableDeclaration #963
             <getter> lastChild: VariableDeclaration #963
             <getter> previousSibling: undefined
@@ -9474,7 +9474,6 @@ SourceUnit #975
             VariableDeclaration #963
                 id: 963
                 src: "0:0:0"
-                type: "VariableDeclaration"
                 constant: false
                 indexed: false
                 name: "n"
@@ -9493,6 +9492,7 @@ SourceUnit #975
                 parent: StructDefinition #964
                 <getter> children: Array(1) [ ElementaryTypeName #962 ]
                 <getter> vScope: StructDefinition #964
+                <getter> type: "VariableDeclaration"
                 <getter> firstChild: ElementaryTypeName #962
                 <getter> lastChild: ElementaryTypeName #962
                 <getter> previousSibling: undefined
@@ -9503,12 +9503,12 @@ SourceUnit #975
                 ElementaryTypeName #962
                     id: 962
                     src: "0:0:0"
-                    type: "ElementaryTypeName"
                     typeString: "uint256"
                     name: "uint"
                     stateMutability: "nonpayable"
                     context: ASTContext #1000
                     parent: VariableDeclaration #963
+                    <getter> type: "ElementaryTypeName"
                     <getter> children: Array(0)
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
@@ -9520,7 +9520,6 @@ SourceUnit #975
         FunctionDefinition #972
             id: 972
             src: "0:0:0"
-            type: "FunctionDefinition"
             implemented: true
             virtual: true
             scope: 973
@@ -9540,6 +9539,7 @@ SourceUnit #975
             parent: ContractDefinition #973
             <getter> children: Array(3) [ ParameterList #965, ParameterList #968, Block #971 ]
             <getter> vScope: ContractDefinition #973
+            <getter> type: "FunctionDefinition"
             <getter> firstChild: ParameterList #965
             <getter> lastChild: Block #971
             <getter> previousSibling: StructDefinition #964
@@ -9550,11 +9550,11 @@ SourceUnit #975
             ParameterList #965
                 id: 965
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #972
                 <getter> vParameters: Array(0)
                 <getter> children: Array(0)
+                <getter> type: "ParameterList"
                 <getter> firstChild: undefined
                 <getter> lastChild: undefined
                 <getter> previousSibling: undefined
@@ -9565,11 +9565,11 @@ SourceUnit #975
             ParameterList #968
                 id: 968
                 src: "0:0:0"
-                type: "ParameterList"
                 context: ASTContext #1000
                 parent: FunctionDefinition #972
                 <getter> vParameters: Array(1) [ VariableDeclaration #967 ]
                 <getter> children: Array(1) [ VariableDeclaration #967 ]
+                <getter> type: "ParameterList"
                 <getter> firstChild: VariableDeclaration #967
                 <getter> lastChild: VariableDeclaration #967
                 <getter> previousSibling: ParameterList #965
@@ -9580,7 +9580,6 @@ SourceUnit #975
                 VariableDeclaration #967
                     id: 967
                     src: "0:0:0"
-                    type: "VariableDeclaration"
                     constant: false
                     indexed: false
                     name: ""
@@ -9599,6 +9598,7 @@ SourceUnit #975
                     parent: ParameterList #968
                     <getter> children: Array(1) [ ElementaryTypeName #966 ]
                     <getter> vScope: FunctionDefinition #972
+                    <getter> type: "VariableDeclaration"
                     <getter> firstChild: ElementaryTypeName #966
                     <getter> lastChild: ElementaryTypeName #966
                     <getter> previousSibling: undefined
@@ -9609,12 +9609,12 @@ SourceUnit #975
                     ElementaryTypeName #966
                         id: 966
                         src: "0:0:0"
-                        type: "ElementaryTypeName"
                         typeString: "uint256"
                         name: "uint"
                         stateMutability: "nonpayable"
                         context: ASTContext #1000
                         parent: VariableDeclaration #967
+                        <getter> type: "ElementaryTypeName"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -9626,12 +9626,12 @@ SourceUnit #975
             Block #971
                 id: 971
                 src: "0:0:0"
-                type: "Block"
                 documentation: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #972
                 <getter> vStatements: Array(1) [ Return #970 ]
                 <getter> children: Array(1) [ Return #970 ]
+                <getter> type: "Block"
                 <getter> firstChild: Return #970
                 <getter> lastChild: Return #970
                 <getter> previousSibling: ParameterList #968
@@ -9642,7 +9642,6 @@ SourceUnit #975
                 Return #970
                     id: 970
                     src: "0:0:0"
-                    type: "Return"
                     documentation: undefined
                     functionReturnParameters: 483
                     vExpression: Literal #969
@@ -9650,6 +9649,7 @@ SourceUnit #975
                     parent: Block #971
                     <getter> children: Array(1) [ Literal #969 ]
                     <getter> vFunctionReturnParameters: ParameterList #483
+                    <getter> type: "Return"
                     <getter> firstChild: Literal #969
                     <getter> lastChild: Literal #969
                     <getter> previousSibling: undefined
@@ -9660,7 +9660,6 @@ SourceUnit #975
                     Literal #969
                         id: 969
                         src: "0:0:0"
-                        type: "Literal"
                         typeString: "int_const 1"
                         kind: "number"
                         hexValue: "31"
@@ -9668,6 +9667,7 @@ SourceUnit #975
                         subdenomination: undefined
                         context: ASTContext #1000
                         parent: Return #970
+                        <getter> type: "Literal"
                         <getter> children: Array(0)
                         <getter> firstChild: undefined
                         <getter> lastChild: undefined
@@ -9679,7 +9679,6 @@ SourceUnit #975
     ContractDefinition #974
         id: 974
         src: "0:0:0"
-        type: "ContractDefinition"
         name: "SomeLib"
         scope: 975
         kind: "library"
@@ -9707,6 +9706,7 @@ SourceUnit #975
         <getter> vUserDefinedValueTypes: Array(0)
         <getter> vConstructor: undefined
         <getter> children: Array(0)
+        <getter> type: "ContractDefinition"
         <getter> firstChild: undefined
         <getter> lastChild: undefined
         <getter> previousSibling: ContractDefinition #973

--- a/test/unit/ast/ast_node_formatter.spec.ts
+++ b/test/unit/ast/ast_node_formatter.spec.ts
@@ -5,7 +5,7 @@ describe("ASTNodeFormatter", () => {
     const formatter = new ASTNodeFormatter();
 
     const context = new ASTContext();
-    const node = new ASTNode(1, "1:2:3", "SourceUnit", undefined);
+    const node = new ASTNode(1, "1:2:3", undefined);
 
     context.register(node);
 
@@ -37,17 +37,17 @@ describe("ASTNodeFormatter", () => {
             "Correctly handles generic ASTNode",
             [node, 0],
             [
-                "ASTNode #1 = SourceUnit",
+                "ASTNode #1",
                 "    id: 1",
                 '    src: "1:2:3"',
-                '    type: "SourceUnit"',
                 "    context: ASTContext #1",
+                '    <getter> type: "ASTNode"',
                 "    <getter> children: Array(0)",
                 "    <getter> firstChild: undefined",
                 "    <getter> lastChild: undefined",
                 "    <getter> previousSibling: undefined",
                 "    <getter> nextSibling: undefined",
-                "    <getter> root: ASTNode #1 = SourceUnit",
+                "    <getter> root: ASTNode #1",
                 "    <getter> sourceInfo: Object { offset: 1, length: 2, sourceIndex: 3 }",
                 ""
             ].join("\n")

--- a/test/unit/ast/nodes/block.spec.ts
+++ b/test/unit/ast/nodes/block.spec.ts
@@ -4,24 +4,10 @@ import { Block, ExpressionStatement, Literal, LiteralKind } from "../../../../sr
 describe("Block", () => {
     describe("removeChild()", () => {
         it("Single child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
-
-            const block = new Block(3, "0:0:0", "Block", [myExprStmt1]);
+            const block = new Block(3, "0:0:0", [myExprStmt1]);
 
             const statement = block.removeChild(myExprStmt1);
 
@@ -38,41 +24,13 @@ describe("Block", () => {
         });
 
         it("First child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1, myExprStmt2]);
+            const block = new Block(5, "0:0:0", [myExprStmt1, myExprStmt2]);
 
             const statement = block.removeChild(myExprStmt1);
 
@@ -92,41 +50,13 @@ describe("Block", () => {
         });
 
         it("Last child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1, myExprStmt2]);
+            const block = new Block(5, "0:0:0", [myExprStmt1, myExprStmt2]);
 
             const statement = block.removeChild(myExprStmt2);
 
@@ -146,58 +76,16 @@ describe("Block", () => {
         });
 
         it("Middle child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
+            const myLiteral3 = new Literal(5, "0:0:0", "uint256", LiteralKind.Number, "", "3");
+            const myExprStmt3 = new ExpressionStatement(6, "0:0:0", myLiteral3);
 
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const myLiteral3 = new Literal(
-                5,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "3"
-            );
-
-            const myExprStmt3 = new ExpressionStatement(
-                6,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral3
-            );
-
-            const block = new Block(7, "0:0:0", "Block", [myExprStmt1, myExprStmt2, myExprStmt3]);
+            const block = new Block(7, "0:0:0", [myExprStmt1, myExprStmt2, myExprStmt3]);
 
             const statement = block.removeChild(myExprStmt2);
 
@@ -219,41 +107,13 @@ describe("Block", () => {
 
     describe("insertBefore()", () => {
         it("First child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1]);
+            const block = new Block(5, "0:0:0", [myExprStmt1]);
 
             const statement = block.insertBefore(myExprStmt2, myExprStmt1);
 
@@ -272,58 +132,16 @@ describe("Block", () => {
         });
 
         it("Last child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
+            const myLiteral3 = new Literal(5, "0:0:0", "uint256", LiteralKind.Number, "", "3");
+            const myExprStmt3 = new ExpressionStatement(6, "0:0:0", myLiteral3);
 
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const myLiteral3 = new Literal(
-                5,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "3"
-            );
-
-            const myExprStmt3 = new ExpressionStatement(
-                6,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral3
-            );
-
-            const block = new Block(7, "0:0:0", "Block", [myExprStmt1, myExprStmt2]);
+            const block = new Block(7, "0:0:0", [myExprStmt1, myExprStmt2]);
 
             const statement = block.insertBefore(myExprStmt3, myExprStmt2);
 
@@ -345,24 +163,10 @@ describe("Block", () => {
 
     describe("insertAtBeginning()", () => {
         it("Without children", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
-
-            const block = new Block(3, "0:0:0", "Block", []);
+            const block = new Block(3, "0:0:0", []);
 
             const statement = block.insertAtBeginning(myExprStmt1);
 
@@ -379,41 +183,13 @@ describe("Block", () => {
         });
 
         it("With children", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1]);
+            const block = new Block(5, "0:0:0", [myExprStmt1]);
 
             const statement = block.insertAtBeginning(myExprStmt2);
 
@@ -437,41 +213,13 @@ describe("Block", () => {
 
     describe("insertAfter()", () => {
         it("Last child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1]);
+            const block = new Block(5, "0:0:0", [myExprStmt1]);
 
             const statement = block.insertAfter(myExprStmt2, myExprStmt1);
 
@@ -490,58 +238,16 @@ describe("Block", () => {
         });
 
         it("First child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
+            const myLiteral3 = new Literal(5, "0:0:0", "uint256", LiteralKind.Number, "", "3");
+            const myExprStmt3 = new ExpressionStatement(6, "0:0:0", myLiteral3);
 
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const myLiteral3 = new Literal(
-                5,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "3"
-            );
-
-            const myExprStmt3 = new ExpressionStatement(
-                6,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral3
-            );
-
-            const block = new Block(7, "0:0:0", "Block", [myExprStmt1, myExprStmt2]);
+            const block = new Block(7, "0:0:0", [myExprStmt1, myExprStmt2]);
 
             const statement = block.insertAfter(myExprStmt3, myExprStmt1);
 
@@ -560,41 +266,13 @@ describe("Block", () => {
 
     describe("replaceChild()", () => {
         it("Single child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
-
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
-
-            const block = new Block(5, "0:0:0", "Block", [myExprStmt1]);
+            const block = new Block(5, "0:0:0", [myExprStmt1]);
 
             const statement = block.replaceChild(myExprStmt2, myExprStmt1);
 
@@ -611,75 +289,19 @@ describe("Block", () => {
         });
 
         it("Middle child", () => {
-            const myLiteral1 = new Literal(
-                1,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "1"
-            );
+            const myLiteral1 = new Literal(1, "0:0:0", "uint256", LiteralKind.Number, "", "1");
+            const myExprStmt1 = new ExpressionStatement(2, "0:0:0", myLiteral1);
 
-            const myExprStmt1 = new ExpressionStatement(
-                2,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral1
-            );
+            const myLiteral2 = new Literal(3, "0:0:0", "uint256", LiteralKind.Number, "", "2");
+            const myExprStmt2 = new ExpressionStatement(4, "0:0:0", myLiteral2);
 
-            const myLiteral2 = new Literal(
-                3,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "2"
-            );
+            const myLiteral3 = new Literal(5, "0:0:0", "uint256", LiteralKind.Number, "", "3");
+            const myExprStmt3 = new ExpressionStatement(6, "0:0:0", myLiteral3);
 
-            const myExprStmt2 = new ExpressionStatement(
-                4,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral2
-            );
+            const myLiteral4 = new Literal(7, "0:0:0", "uint256", LiteralKind.Number, "", "4");
+            const myExprStmt4 = new ExpressionStatement(8, "0:0:0", myLiteral4);
 
-            const myLiteral3 = new Literal(
-                5,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "3"
-            );
-
-            const myExprStmt3 = new ExpressionStatement(
-                6,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral3
-            );
-
-            const myLiteral4 = new Literal(
-                7,
-                "0:0:0",
-                "Literal",
-                "uint256",
-                LiteralKind.Number,
-                "",
-                "4"
-            );
-
-            const myExprStmt4 = new ExpressionStatement(
-                8,
-                "0:0:0",
-                "ExpressionStatement",
-                myLiteral4
-            );
-
-            const block = new Block(9, "0:0:0", "Block", [myExprStmt1, myExprStmt2, myExprStmt3]);
+            const block = new Block(9, "0:0:0", [myExprStmt1, myExprStmt2, myExprStmt3]);
 
             const statement = block.replaceChild(myExprStmt4, myExprStmt2);
 

--- a/test/unit/ast/nodes/contract_definition.spec.ts
+++ b/test/unit/ast/nodes/contract_definition.spec.ts
@@ -10,30 +10,12 @@ import {
 describe("ContractDefinition", () => {
     it("set vScope", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
-
-        const otherUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const otherUnit = new SourceUnit(2, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
         const contract = new ContractDefinition(
             3,
             "0:0:0",
-            "ContractDefinition",
             "MyContract",
             0,
             ContractKind.Contract,
@@ -59,12 +41,11 @@ describe("ContractDefinition", () => {
 
     describe("removeChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
 
             const contract = new ContractDefinition(
                 2,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -91,13 +72,12 @@ describe("ContractDefinition", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -127,13 +107,12 @@ describe("ContractDefinition", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -163,14 +142,13 @@ describe("ContractDefinition", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -202,13 +180,12 @@ describe("ContractDefinition", () => {
 
     describe("insertBefore()", () => {
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -237,14 +214,13 @@ describe("ContractDefinition", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -276,13 +252,12 @@ describe("ContractDefinition", () => {
 
     describe("insertAfter()", () => {
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -311,14 +286,13 @@ describe("ContractDefinition", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const contract = new ContractDefinition(
                 4,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -347,13 +321,12 @@ describe("ContractDefinition", () => {
 
     describe("replaceChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const contract = new ContractDefinition(
                 3,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,
@@ -380,15 +353,14 @@ describe("ContractDefinition", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
-            const myEnum4 = new EnumDefinition(4, "0:0:0", "EnumDefinition", "MyEnum4", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
+            const myEnum4 = new EnumDefinition(4, "0:0:0", "MyEnum4", []);
 
             const contract = new ContractDefinition(
                 5,
                 "0:0:0",
-                "ContractDefinition",
                 "MyContract",
                 0,
                 ContractKind.Contract,

--- a/test/unit/ast/nodes/function_definition.spec.ts
+++ b/test/unit/ast/nodes/function_definition.spec.ts
@@ -13,33 +13,15 @@ import {
 describe("FunctionDefinition", () => {
     it("set vScope", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const otherUnit = new SourceUnit(2, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
-        const otherUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
-
-        const body = new Block(3, "0:0:0", "Block", []);
-        const args = new ParameterList(4, "0:0:0", "ParameterList", []);
-        const rets = new ParameterList(5, "0:0:0", "ParameterList", []);
+        const body = new Block(3, "0:0:0", []);
+        const args = new ParameterList(4, "0:0:0", []);
+        const rets = new ParameterList(5, "0:0:0", []);
         const fn = new FunctionDefinition(
             6,
             "0:0:0",
-            "FunctionDefinition",
             0,
             FunctionKind.Free,
             "myFunc",

--- a/test/unit/ast/nodes/identifier.spec.ts
+++ b/test/unit/ast/nodes/identifier.spec.ts
@@ -13,18 +13,11 @@ describe("Identifier", () => {
     it("set vReferencedDeclaration", () => {
         const context = new ASTContext();
 
-        const myType = new ElementaryTypeName(
-            1,
-            "0:0:0",
-            "ElementaryTypeName",
-            "uint256",
-            "uint256"
-        );
+        const myType = new ElementaryTypeName(1, "0:0:0", "uint256", "uint256");
 
         const myVar = new VariableDeclaration(
             2,
             "0:0:0",
-            "VariableDeclaration",
             true,
             false,
             "myVar",
@@ -38,18 +31,11 @@ describe("Identifier", () => {
             myType
         );
 
-        const otherType = new ElementaryTypeName(
-            3,
-            "0:0:0",
-            "ElementaryTypeName",
-            "uint256",
-            "uint256"
-        );
+        const otherType = new ElementaryTypeName(3, "0:0:0", "uint256", "uint256");
 
         const otherVar = new VariableDeclaration(
             4,
             "0:0:0",
-            "VariableDeclaration",
             true,
             false,
             "otherVar",
@@ -63,7 +49,7 @@ describe("Identifier", () => {
             otherType
         );
 
-        const identifier = new Identifier(5, "0:0:0", "Identifier", myType.typeString, "myVar", 0);
+        const identifier = new Identifier(5, "0:0:0", myType.typeString, "myVar", 0);
 
         context.register(myVar, myType, identifier);
 

--- a/test/unit/ast/nodes/import_directive.spec.ts
+++ b/test/unit/ast/nodes/import_directive.spec.ts
@@ -4,47 +4,11 @@ import { ASTContext, ImportDirective, SourceUnit } from "../../../../src";
 describe("ImportDirective", () => {
     it("set vScope", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const someUnit = new SourceUnit(2, "0:0:0", "some.sol", 1, "some.sol", new Map());
+        const otherUnit = new SourceUnit(3, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
-        const someUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "some.sol",
-            1,
-            "some.sol",
-            new Map()
-        );
-
-        const otherUnit = new SourceUnit(
-            3,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
-
-        const directive = new ImportDirective(
-            4,
-            "0:0:0",
-            "ImportDirective",
-            "some.sol",
-            "some.sol",
-            "",
-            [],
-            0,
-            0
-        );
+        const directive = new ImportDirective(4, "0:0:0", "some.sol", "some.sol", "", [], 0, 0);
 
         context.register(unit, someUnit, directive);
 
@@ -60,47 +24,11 @@ describe("ImportDirective", () => {
 
     it("set vSourceUnit", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const someUnit = new SourceUnit(2, "0:0:0", "some.sol", 1, "some.sol", new Map());
+        const otherUnit = new SourceUnit(3, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
-        const someUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "some.sol",
-            1,
-            "some.sol",
-            new Map()
-        );
-
-        const otherUnit = new SourceUnit(
-            3,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
-
-        const directive = new ImportDirective(
-            4,
-            "0:0:0",
-            "ImportDirective",
-            "some.sol",
-            "some.sol",
-            "",
-            [],
-            0,
-            0
-        );
+        const directive = new ImportDirective(4, "0:0:0", "some.sol", "some.sol", "", [], 0, 0);
 
         context.register(unit, someUnit, directive);
 

--- a/test/unit/ast/nodes/member_access.spec.ts
+++ b/test/unit/ast/nodes/member_access.spec.ts
@@ -16,26 +16,13 @@ describe("MemberAccess", () => {
     it("set vReferencedDeclaration", () => {
         const context = new ASTContext();
 
-        const arrayBaseType = new ElementaryTypeName(
-            1,
-            "0:0:0",
-            "ElementaryTypeName",
-            "uint256",
-            "uint256"
-        );
+        const arrayBaseType = new ElementaryTypeName(1, "0:0:0", "uint256", "uint256");
 
-        const arrayType = new ArrayTypeName(
-            2,
-            "0:0:0",
-            "ArrayTypeName",
-            "uint256[] memory",
-            arrayBaseType
-        );
+        const arrayType = new ArrayTypeName(2, "0:0:0", "uint256[] memory", arrayBaseType);
 
         const variable = new VariableDeclaration(
             3,
             "0:0:0",
-            "VariableDeclaration",
             true,
             false,
             "myArr",
@@ -49,24 +36,9 @@ describe("MemberAccess", () => {
             arrayType
         );
 
-        const identifier = new Identifier(
-            4,
-            "0:0:0",
-            "Identifier",
-            arrayBaseType.typeString,
-            "myArr",
-            0
-        );
+        const identifier = new Identifier(4, "0:0:0", arrayBaseType.typeString, "myArr", 0);
 
-        const memberAccess = new MemberAccess(
-            5,
-            "0:0:0",
-            "MemberAccess",
-            "uint256",
-            identifier,
-            "length",
-            -1
-        );
+        const memberAccess = new MemberAccess(5, "0:0:0", "uint256", identifier, "length", -1);
 
         const other = new ASTNode(6, "0:0:0", "Custom");
 

--- a/test/unit/ast/nodes/return.spec.ts
+++ b/test/unit/ast/nodes/return.spec.ts
@@ -5,9 +5,9 @@ describe("Return", () => {
     it("set vFunctionReturnParameters", () => {
         const context = new ASTContext();
 
-        const rets = new ParameterList(1, "0:0:0", "ParameterList", []);
-        const otherRets = new ParameterList(2, "0:0:0", "ParameterList", []);
-        const ret = new Return(3, "0:0:0", "Return", 0);
+        const rets = new ParameterList(1, "0:0:0", []);
+        const otherRets = new ParameterList(2, "0:0:0", []);
+        const ret = new Return(3, "0:0:0", 0);
 
         context.register(rets, ret);
 

--- a/test/unit/ast/nodes/source_unit.spec.ts
+++ b/test/unit/ast/nodes/source_unit.spec.ts
@@ -4,12 +4,11 @@ import { EnumDefinition, SourceUnit } from "../../../../src";
 describe("SourceUnit", () => {
     describe("removeChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
 
             const unit = new SourceUnit(
                 2,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -32,13 +31,12 @@ describe("SourceUnit", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -64,13 +62,12 @@ describe("SourceUnit", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -96,14 +93,13 @@ describe("SourceUnit", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -131,13 +127,12 @@ describe("SourceUnit", () => {
 
     describe("insertBefore()", () => {
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -162,14 +157,13 @@ describe("SourceUnit", () => {
         });
 
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -197,13 +191,12 @@ describe("SourceUnit", () => {
 
     describe("insertAfter()", () => {
         it("Last child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -228,14 +221,13 @@ describe("SourceUnit", () => {
         });
 
         it("First child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
 
             const unit = new SourceUnit(
                 4,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -260,13 +252,12 @@ describe("SourceUnit", () => {
 
     describe("replaceChild()", () => {
         it("Single child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
 
             const unit = new SourceUnit(
                 3,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",
@@ -289,15 +280,14 @@ describe("SourceUnit", () => {
         });
 
         it("Middle child", () => {
-            const myEnum1 = new EnumDefinition(1, "0:0:0", "EnumDefinition", "MyEnum1", []);
-            const myEnum2 = new EnumDefinition(2, "0:0:0", "EnumDefinition", "MyEnum2", []);
-            const myEnum3 = new EnumDefinition(3, "0:0:0", "EnumDefinition", "MyEnum3", []);
-            const myEnum4 = new EnumDefinition(4, "0:0:0", "EnumDefinition", "MyEnum4", []);
+            const myEnum1 = new EnumDefinition(1, "0:0:0", "MyEnum1", []);
+            const myEnum2 = new EnumDefinition(2, "0:0:0", "MyEnum2", []);
+            const myEnum3 = new EnumDefinition(3, "0:0:0", "MyEnum3", []);
+            const myEnum4 = new EnumDefinition(4, "0:0:0", "MyEnum4", []);
 
             const unit = new SourceUnit(
                 5,
                 "0:0:0",
-                "SourceUnit",
                 "../sample.sol",
                 0,
                 "path/to/sample.sol",

--- a/test/unit/ast/nodes/struct_definition.spec.ts
+++ b/test/unit/ast/nodes/struct_definition.spec.ts
@@ -4,35 +4,10 @@ import { ASTContext, SourceUnit, StructDefinition } from "../../../../src";
 describe("StructDefinition", () => {
     it("set vScope", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const otherUnit = new SourceUnit(2, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
-        const otherUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
-
-        const struct = new StructDefinition(
-            3,
-            "0:0:0",
-            "StructDefinition",
-            "MyStruct",
-            0,
-            "internal",
-            []
-        );
+        const struct = new StructDefinition(3, "0:0:0", "MyStruct", 0, "internal", []);
 
         context.register(unit, struct);
 

--- a/test/unit/ast/nodes/user_defined_type_name.spec.ts
+++ b/test/unit/ast/nodes/user_defined_type_name.spec.ts
@@ -5,34 +5,10 @@ describe("UserDefinedTypeName", () => {
     it("set vReferencedDeclaration", () => {
         const context = new ASTContext();
 
-        const struct = new StructDefinition(
-            1,
-            "0:0:0",
-            "StructDefinition",
-            "MyStruct",
-            0,
-            "internal",
-            []
-        );
+        const struct = new StructDefinition(1, "0:0:0", "MyStruct", 0, "internal", []);
+        const otherStruct = new StructDefinition(2, "0:0:0", "OtherStruct", 0, "internal", []);
 
-        const otherStruct = new StructDefinition(
-            2,
-            "0:0:0",
-            "StructDefinition",
-            "OtherStruct",
-            0,
-            "internal",
-            []
-        );
-
-        const type = new UserDefinedTypeName(
-            3,
-            "0:0:0",
-            "UserDefinedTypeName",
-            "struct MyStruct",
-            "MyStruct",
-            0
-        );
+        const type = new UserDefinedTypeName(3, "0:0:0", "struct MyStruct", "MyStruct", 0);
 
         context.register(struct, type);
 

--- a/test/unit/ast/nodes/variable_declaration.spec.ts
+++ b/test/unit/ast/nodes/variable_declaration.spec.ts
@@ -12,31 +12,13 @@ import {
 describe("VariableDeclaration", () => {
     it("set vScope", () => {
         const context = new ASTContext();
-        const unit = new SourceUnit(
-            1,
-            "0:0:0",
-            "SourceUnit",
-            "entry.sol",
-            0,
-            "entry.sol",
-            new Map()
-        );
+        const unit = new SourceUnit(1, "0:0:0", "entry.sol", 0, "entry.sol", new Map());
+        const otherUnit = new SourceUnit(2, "0:0:0", "other.sol", 1, "other.sol", new Map());
 
-        const otherUnit = new SourceUnit(
-            2,
-            "0:0:0",
-            "SourceUnit",
-            "other.sol",
-            1,
-            "other.sol",
-            new Map()
-        );
-
-        const type = new ElementaryTypeName(3, "0:0:0", "ElementaryTypeName", "uint256", "uint256");
+        const type = new ElementaryTypeName(3, "0:0:0", "uint256", "uint256");
         const variable = new VariableDeclaration(
             4,
             "0:0:0",
-            "VariableDeclaration",
             true,
             false,
             "myVar",

--- a/test/unit/ast/writing/writer.spec.ts
+++ b/test/unit/ast/writing/writer.spec.ts
@@ -16,7 +16,7 @@ describe("ASTWriter", () => {
                 LatestCompilerVersion
             );
 
-            const node = new ASTNode(0, "0:0:0", "CustomNode");
+            const node = new ASTNode(0, "0:0:0");
 
             expect(() => writer.write(node)).toThrow();
         });

--- a/test/unit/misc/pretty_printing.spec.ts
+++ b/test/unit/misc/pretty_printing.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../src";
 
 const ctx = new ASTContext();
-const astNode = new ElementaryTypeName(777, "0:0:0", "ElementaryTypeName", "uint8", "uint8");
+const astNode = new ElementaryTypeName(777, "0:0:0", "uint8", "uint8");
 const customPPAble = {
     name: "test",
     pp: () => "PPAble object"

--- a/test/unit/misc/utils/assert.spec.ts
+++ b/test/unit/misc/utils/assert.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../src";
 
 const typeNode = new IntType(256, false);
-const astNode = new ElementaryTypeName(1, "0:0:0", "ElementaryTypeName", "uint8", "uint8");
+const astNode = new ElementaryTypeName(1, "0:0:0", "uint8", "uint8");
 const ctx = new ASTContext();
 
 ctx.register(astNode);


### PR DESCRIPTION
## Changes
- [x] Reintroduced property `ASTNode.type` as getter and removed field.
- [x] Removed `type` argument from constructors of `ASTNode` and it's descendants.
- [x] Tweaked tests.

## Notes
This PR changes a lot of constructor signatures, so it's merge would require bumping **major** version.

Regards.