### PR TITLE
Predownload native compilers in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,10 @@ steps:
       environment:
           CODECOV_TOKEN:
               from_secret: CODECOV_TOKEN
+          SOL_AST_COMPILER_CACHE: /.compiler_cache
       commands:
+          - apt-get -qq update && apt-get -qq install jq
+          - ./docker/download.sh 'linux-amd64'
           - npm install --unsafe-perm
           - npm link --unsafe-perm
           - npm run lint

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,13 @@ steps:
               from_secret: CODECOV_TOKEN
           SOL_AST_COMPILER_CACHE: /.compiler_cache
       commands:
+          # pre-download native compilers
           - apt-get -qq update && apt-get -qq install jq
           - ./docker/download.sh 'linux-amd64'
+          # remove list and one rarely used compiler to still test downloading on-demand
+          - rm /.compiler_cache/linux-amd64/list.json
+          - rm /.compiler_cache/linux-amd64/solc-linux-amd64-v0.5.17+commit.d19bba13
+          # perform testing
           - npm install --unsafe-perm
           - npm link --unsafe-perm
           - npm run lint


### PR DESCRIPTION
## Preface
This PR tweaks CI to use compiler downloading script prior to executing tests. It will help us to avoid `ETXTBSY` exit codes, probably caused by attempts to access compilers that are still downloading. We can reconfigure to use docker image later, when we decide where to publish it.

## Changes
- [x] Added CI commands to predownload native compilers and set ENV to use them instead of downloading on-demand.

## Notes
Part of the code, that is responsible for downloading on-demand will not be covered by the tests as the result of predownloading. Other option is to create a test that downloads only one compiler that is not used by other tests (or remove one rarely used compiler).

Regards.