### PR TITLE
Fix off by one error in enumToIntType

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -284,7 +284,7 @@ export function enumToIntType(decl: EnumDefinition): IntType {
     let size: number | undefined;
 
     for (let n = 8; n <= 32; n += 8) {
-        if (length < 2 ** n) {
+        if (length <= 2 ** n) {
             size = n;
 
             break;


### PR DESCRIPTION
The bug can be reproduced with this file https://github.com/ethereum/solidity/blob/develop/test/libsolidity/semanticTests/enums/enum_with_256_members.sol

Since the enum definition has 256 members it should fit in a uint8 but before the patch `enumToIntType` would return uint16