### PR TITLE
Redownload compiler metadata file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "prepare": "npm run build"
     },
     "dependencies": {
-        "axios": "^0.26.0",
+        "axios": "^0.26.1",
         "findup-sync": "^5.0.0",
         "fs-extra": "^10.0.1",
         "jsel": "^1.1.6",
@@ -36,29 +36,29 @@
         "semver": "^7.3.5",
         "solc": "^0.8.12",
         "src-location": "^1.1.0",
-        "web3-eth-abi": "^1.7.0"
+        "web3-eth-abi": "^1.7.1"
     },
     "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/minimist": "^1.2.2",
         "@types/mocha": "^9.1.0",
-        "@types/node": "^16.11.25",
+        "@types/node": "^16.11.26",
         "@types/semver": "^7.3.9",
-        "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "@typescript-eslint/parser": "^5.12.1",
+        "@typescript-eslint/eslint-plugin": "^5.14.0",
+        "@typescript-eslint/parser": "^5.14.0",
         "codecov": "^3.8.3",
-        "eslint": "^8.9.0",
-        "eslint-config-prettier": "^8.4.0",
+        "eslint": "^8.10.0",
+        "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "expect": "^27.5.1",
         "mocha": "^9.2.1",
         "nyc": "^15.1.0",
         "peggy": "^1.2.0",
         "prettier": "2.5.1",
-        "ts-node": "^10.5.0",
+        "ts-node": "^10.7.0",
         "ts-pegjs": "^1.2.1",
-        "typedoc": "^0.22.12",
-        "typescript": "^4.5.5"
+        "typedoc": "^0.22.13",
+        "typescript": "^4.6.2"
     },
     "homepage": "https://consensys.github.io/solc-typed-ast",
     "bugs": "https://github.com/ConsenSys/solc-typed-ast/issues",

--- a/src/compile/kinds/compiler.ts
+++ b/src/compile/kinds/compiler.ts
@@ -79,6 +79,17 @@ export class WasmCompiler extends Compiler {
 
 type CompilerMapping = [CompilerKind.Native, NativeCompiler] | [CompilerKind.WASM, WasmCompiler];
 
+export function getCompilerLocalPath(prefix: string, compilerFileName: string): string {
+    const compilerLocalPath = path.join(CACHE_DIR, prefix, compilerFileName);
+
+    assert(
+        isSubDir(compilerLocalPath, CACHE_DIR),
+        `Path ${compilerLocalPath} escapes from cache dir ${CACHE_DIR}`
+    );
+
+    return compilerLocalPath;
+}
+
 export async function getCompilerForVersion<T extends CompilerMapping>(
     version: string,
     kind: T[0]
@@ -104,19 +115,14 @@ export async function getCompilerForVersion<T extends CompilerMapping>(
         return undefined;
     }
 
-    const md = await getCompilerMDForPlatform(prefix);
+    const md = await getCompilerMDForPlatform(prefix, version);
     const compilerFileName = md.releases[version];
 
     if (compilerFileName === undefined) {
         return undefined;
     }
 
-    const compilerLocalPath = path.join(CACHE_DIR, prefix, compilerFileName);
-
-    assert(
-        isSubDir(compilerLocalPath, CACHE_DIR),
-        `Path ${compilerLocalPath} escapes from cache dir ${CACHE_DIR}`
-    );
+    const compilerLocalPath = getCompilerLocalPath(prefix, compilerFileName);
 
     if (!fse.existsSync(compilerLocalPath)) {
         const build = md.builds.find((b) => b.version === version);

--- a/src/types/ast/rational_literal.ts
+++ b/src/types/ast/rational_literal.ts
@@ -2,12 +2,12 @@ import { Range } from "../../misc";
 import { TypeNode } from "./type";
 
 interface Rational {
-  numerator: bigint;
-  denominator: bigint;
+    numerator: bigint;
+    denominator: bigint;
 }
 
 export class RationalLiteralType extends TypeNode {
-    public readonly literal: Rational;
+    readonly literal: Rational;
 
     constructor(literal: Rational, src?: Range) {
         super(src);
@@ -16,14 +16,12 @@ export class RationalLiteralType extends TypeNode {
     }
 
     pp(): string {
-        return `rational_const ${ppRational(this.literal)}`;
+        const { numerator, denominator } = this.literal;
+
+        return `rational_const ${numerator.toString()} / ${denominator.toString()}`;
     }
 
     getFields(): any[] {
         return [this.literal];
     }
-}
-
-function ppRational(literal: Rational): string {
-  return `${literal.numerator.toString()} / ${literal.denominator.toString()}`;
 }


### PR DESCRIPTION
## Changes
- [x] Updated dependencies.
- [x] Try re-downloading the JSON compiler metadata file automatically (once) if compiler version is not found in cached file.
- [x] Linting and slight improvements in `RationalLiteralType`.

Regards.