### PR TITLE
Support function types in ABI-related logic

### DIFF
--- a/src/types/abi.ts
+++ b/src/types/abi.ts
@@ -12,6 +12,7 @@ import {
     BoolType,
     BytesType,
     FixedBytesType,
+    FunctionType,
     IntType,
     MappingType,
     StringType,
@@ -37,7 +38,9 @@ export const ABIEncoderVersions = new Set<string>([ABIEncoderVersion.V1, ABIEnco
  * 1. Contract definitions turned to address.
  * 2. Enum definitions turned to uint of minimal fitting size.
  * 3. Any storage pointer types are converted to memory pointer types.
- * 4. Throw an error on any nested mapping types
+ * 4. Throw an error on any nested mapping types.
+ *
+ * @see https://docs.soliditylang.org/en/latest/abi-spec.html
  */
 export function toABIEncodedType(
     type: TypeNode,
@@ -126,6 +129,10 @@ export function abiTypeToCanonicalName(t: TypeNode): string {
         return abiTypeToCanonicalName(t.to);
     }
 
+    if (t instanceof FunctionType) {
+        return "function";
+    }
+
     assert(false, "Unexpected ABI Type: {0}", t);
 }
 
@@ -177,6 +184,10 @@ export function abiTypeToLibraryCanonicalName(t: TypeNode): string {
         const valueName = abiTypeToLibraryCanonicalName(t.valueType);
 
         return `mapping(${keyName} => ${valueName})`;
+    }
+
+    if (t instanceof FunctionType) {
+        return "function";
     }
 
     assert(false, "Unexpected ABI Type: {0}", t);

--- a/test/samples/solidity/library_signatures.sol
+++ b/test/samples/solidity/library_signatures.sol
@@ -9,6 +9,7 @@ library Lib {
         struct S1 {
                 S s;
                 mapping(uint=>uint) m;
+                function () external f;
         }
 
         function f1(uint[] storage x) public {}
@@ -19,4 +20,5 @@ library Lib {
         function f5(S storage s) external {}
         function f6(S calldata s) external {}
         function f7(address payable a) public {}
+        function f8(function (address) external returns (bool) fn) external returns (bool) {}
 }

--- a/test/samples/solidity/signatures.sol
+++ b/test/samples/solidity/signatures.sol
@@ -22,3 +22,21 @@ library Lib {
         function f7(address payable a) public {}
         function f8(function (address) external returns (bool) fn) external returns (bool) {}
 }
+
+library L {
+    function f(address caller, function (address) external returns (bool) funcName) internal returns (bool) {
+        return funcName(caller);
+    }
+}
+
+contract C {
+    function (address) external returns (bool) public v;
+    
+    function cf(address caller, function (address) external returns (bool) funcName) external returns (bool) {
+        return funcName(caller);
+    }
+
+    function lf(address caller) external {
+        L.f(caller, v);
+    }
+}

--- a/test/unit/types/signatures.spec.ts
+++ b/test/unit/types/signatures.spec.ts
@@ -43,7 +43,7 @@ const samples: Array<[string, string, ABIEncoderVersion]> = [
     ["test/samples/solidity/compile_04.sol", "0.4.26", ABIEncoderVersion.V1],
     ["test/samples/solidity/compile_05.sol", "0.5.17", ABIEncoderVersion.V1],
     ["test/samples/solidity/compile_06.sol", "0.6.12", ABIEncoderVersion.V1],
-    ["test/samples/solidity/library_signatures.sol", "0.8.7", ABIEncoderVersion.V2]
+    ["test/samples/solidity/signatures.sol", "0.8.7", ABIEncoderVersion.V2]
 ];
 
 function resolveOne(


### PR DESCRIPTION
## Tasks
- Fixes #103

## Changes
- [x] Add support for function types when converting to ABI canonical names.

## Notes
- For ABI encoding the `function` type is replaced with `bytes24` - first 20 bytes for address of contract and 4 bytes for function selector. This happends for `external`/`public` functions with arguments of function type. See last entry of [the section for ABI Types in manual](https://docs.soliditylang.org/en/latest/abi-spec.html#types).
  - However, we are unable to just convert it to `bytes24` on-fly as word `function` is **used for function selector computation**. The replacement causes selector bytes mismatch.
- I'm not yet sure how this may affect resolution or overloading, especially for internal functions with such arguments. Compiler actually figures the difference of the function arg modifiers, so user can not pass just any function there. I'm wondering if there any edge-cases are involved and not yet figured out how to test this properly (for internal library functions in `abiTypeToLibraryCanonicalName()`).

Regards.