### PR TITLE
Support multiple file inputs to `compileSol()`

### DIFF
--- a/src/compile/import_resolver.ts
+++ b/src/compile/import_resolver.ts
@@ -1,5 +1,6 @@
 import fse from "fs-extra";
 import path from "path";
+import { assert } from "../misc";
 
 const findUpSync = require("findup-sync");
 
@@ -16,13 +17,15 @@ export class FileSystemResolver implements ImportResolver {
 export type Remapping = [string, string, string];
 
 export class LocalNpmResolver implements ImportResolver {
-    private baseDir: string;
+    baseDir?: string;
 
-    constructor(baseDir: string) {
+    constructor(baseDir?: string) {
         this.baseDir = baseDir;
     }
 
     resolve(fileName: string): string | undefined {
+        assert(this.baseDir !== undefined, "LocalNpmResolver: base directory is not set");
+
         let currentDir = this.baseDir;
 
         while (true) {

--- a/src/compile/input.ts
+++ b/src/compile/input.ts
@@ -2,16 +2,22 @@ import { CompilationOutput } from "./constants";
 
 export interface PartialSolcInput {
     language: "Solidity";
+
     settings: {
         outputSelection: any;
         remappings: string[];
         [otherKeys: string]: any;
     };
+
     [otherKeys: string]: any;
 }
 
 export interface SolcInput extends PartialSolcInput {
-    sources: { [fileName: string]: { content: string } };
+    sources: {
+        [fileName: string]: {
+            content: string;
+        };
+    };
 }
 
 function mergeCompilerSettings<T extends SolcInput>(input: T, settings: any): T {

--- a/test/integration/sol-ast-compile/mode/valid.spec.ts
+++ b/test/integration/sol-ast-compile/mode/valid.spec.ts
@@ -2,7 +2,7 @@ import expect from "expect";
 import { PossibleCompilerKinds } from "../../../../src";
 import { SolAstCompileCommand, SolAstCompileExec } from "../common";
 
-const error = "Error: Unable to auto-detect mode for the file name";
+const error = "Unable to auto-detect mode by the file name";
 const output = ["SourceUnit #2", "ContractDefinition #1", 'name: "Test"', 'kind: "contract"'];
 
 const cases: Array<[string, string, number, string, string[]]> = [

--- a/test/integration/sol-ast-compile/tree.spec.ts
+++ b/test/integration/sol-ast-compile/tree.spec.ts
@@ -3,22 +3,38 @@ import fse from "fs-extra";
 import { PossibleCompilerKinds } from "../../../src";
 import { SolAstCompileCommand, SolAstCompileExec } from "./common";
 
-const cases = [
+const cases: Array<[string[], string]> = [
     [
-        "test/samples/solidity/declarations/interface_060.sol",
+        ["test/samples/solidity/declarations/interface_060.sol"],
         "test/samples/solidity/declarations/interface_060.tree.txt"
     ],
-    ["test/samples/solidity/interface_id.sol", "test/samples/solidity/interface_id.tree.txt"],
+    [["test/samples/solidity/interface_id.sol"], "test/samples/solidity/interface_id.tree.txt"],
     [
-        "test/samples/solidity/library_fun_overloads.sol",
+        ["test/samples/solidity/library_fun_overloads.sol"],
         "test/samples/solidity/library_fun_overloads.tree.txt"
     ],
-    ["test/samples/solidity/fun_selectors.sol", "test/samples/solidity/fun_selectors.tree.txt"]
+    [["test/samples/solidity/fun_selectors.sol"], "test/samples/solidity/fun_selectors.tree.txt"],
+    [
+        ["test/samples/solidity/multifile/A.sol", "test/samples/solidity/multifile/B.sol"],
+        "test/samples/solidity/multifile/A_B.tree.txt"
+    ],
+    [
+        ["test/samples/solidity/multifile/A.sol", "test/samples/solidity/multifile/C.sol"],
+        "test/samples/solidity/multifile/A_C.tree.txt"
+    ],
+    [
+        [
+            "test/samples/solidity/multifile/A.sol",
+            "test/samples/solidity/multifile/B.sol",
+            "test/samples/solidity/multifile/C.sol"
+        ],
+        "test/samples/solidity/multifile/A_B_C.tree.txt"
+    ]
 ];
 
-for (const [sample, snapshot] of cases) {
+for (const [samples, snapshot] of cases) {
     for (const kind of PossibleCompilerKinds) {
-        const args = [sample, "--compiler-kind", kind, "--tree"];
+        const args = [...samples, "--compiler-kind", kind, "--tree"];
         const command = SolAstCompileCommand(...args);
 
         describe(command, () => {
@@ -44,8 +60,12 @@ for (const [sample, snapshot] of cases) {
 
             it("STDOUT is correct", () => {
                 const snapshotData = fse.readFileSync(snapshot, { encoding: "utf8" });
+                const result = outData.replace(new RegExp(process.cwd(), "g"), "");
 
-                expect(outData.replace(process.cwd(), "")).toContain(snapshotData);
+                // Uncomment next line to update snapshots
+                // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+
+                expect(result).toContain(snapshotData);
             });
         });
     }

--- a/test/samples/solidity/multifile/A.sol
+++ b/test/samples/solidity/multifile/A.sol
@@ -1,0 +1,3 @@
+import "package-x/contracts/X.sol";
+
+contract A {}

--- a/test/samples/solidity/multifile/A_B.tree.txt
+++ b/test/samples/solidity/multifile/A_B.tree.txt
@@ -1,0 +1,14 @@
+SourceUnit #3 -> /test/samples/solidity/multifile/A.sol
+|   ImportDirective #1
+|   ContractDefinition #2 -> contract A
+
+SourceUnit #6 -> /test/samples/solidity/multifile/B.sol
+|   ImportDirective #4
+|   ContractDefinition #5 -> contract B
+
+SourceUnit #8 -> package-x/contracts/X.sol
+|   ContractDefinition #7 -> contract X
+
+SourceUnit #10 -> package-y/contracts/Y.sol
+|   ContractDefinition #9 -> contract Y
+

--- a/test/samples/solidity/multifile/A_B_C.tree.txt
+++ b/test/samples/solidity/multifile/A_B_C.tree.txt
@@ -1,0 +1,18 @@
+SourceUnit #3 -> /test/samples/solidity/multifile/A.sol
+|   ImportDirective #1
+|   ContractDefinition #2 -> contract A
+
+SourceUnit #6 -> /test/samples/solidity/multifile/B.sol
+|   ImportDirective #4
+|   ContractDefinition #5 -> contract B
+
+SourceUnit #9 -> /test/samples/solidity/multifile/C.sol
+|   ImportDirective #7
+|   ContractDefinition #8 -> contract C
+
+SourceUnit #11 -> package-x/contracts/X.sol
+|   ContractDefinition #10 -> contract X
+
+SourceUnit #13 -> package-y/contracts/Y.sol
+|   ContractDefinition #12 -> contract Y
+

--- a/test/samples/solidity/multifile/A_C.tree.txt
+++ b/test/samples/solidity/multifile/A_C.tree.txt
@@ -1,0 +1,11 @@
+SourceUnit #3 -> /test/samples/solidity/multifile/A.sol
+|   ImportDirective #1
+|   ContractDefinition #2 -> contract A
+
+SourceUnit #6 -> /test/samples/solidity/multifile/C.sol
+|   ImportDirective #4
+|   ContractDefinition #5 -> contract C
+
+SourceUnit #8 -> package-x/contracts/X.sol
+|   ContractDefinition #7 -> contract X
+

--- a/test/samples/solidity/multifile/B.sol
+++ b/test/samples/solidity/multifile/B.sol
@@ -1,0 +1,3 @@
+import "package-y/contracts/Y.sol";
+
+contract B {}

--- a/test/samples/solidity/multifile/C.sol
+++ b/test/samples/solidity/multifile/C.sol
@@ -1,0 +1,3 @@
+import "package-x/contracts/X.sol";
+
+contract C {}

--- a/test/samples/solidity/multifile/node_modules/package-x/contracts/X.sol
+++ b/test/samples/solidity/multifile/node_modules/package-x/contracts/X.sol
@@ -1,0 +1,1 @@
+contract X {}

--- a/test/samples/solidity/multifile/node_modules/package-y/contracts/Y.sol
+++ b/test/samples/solidity/multifile/node_modules/package-y/contracts/Y.sol
@@ -1,0 +1,1 @@
+contract Y {}

--- a/test/unit/compile/inference/findAllFiles.spec.ts
+++ b/test/unit/compile/inference/findAllFiles.spec.ts
@@ -48,17 +48,19 @@ const samples: Array<[string, string[]]> = [
 
 describe("findAllFiles() find all needed imports", () => {
     for (const [fileName, expectedAllFiles] of samples) {
-        it(`All imports for ${fileName} should be ${expectedAllFiles.join(", ")}`, () => {
+        it(`All imports for ${fileName} should be ${expectedAllFiles.join(", ")}`, async () => {
             const contents = fse.readFileSync(fileName).toString();
             const files = new Map<string, string>([[fileName, contents]]);
-            findAllFiles(files, [], [new FileSystemResolver()]);
+
+            await findAllFiles(files, [], [new FileSystemResolver()]);
+
             expect(new Set(files.keys())).toEqual(new Set(expectedAllFiles));
         });
     }
 });
 
 describe("findAllFiles() throws proper errors", () => {
-    it("Parsing error", () => {
+    it("Parsing error", async () => {
         const files = new Map<string, string>([
             [
                 "foo.sol",
@@ -69,12 +71,10 @@ contract Foo {
             ]
         ]);
 
-        expect(() => findAllFiles(files, [], [new FileSystemResolver()])).toThrow(
-            /Failed parsing imports/
-        );
+        await expect(findAllFiles(files, [], [])).rejects.toThrow(/Failed parsing imports/);
     });
 
-    it("Missing file error", () => {
+    it("Missing file error", async () => {
         const files = new Map<string, string>([
             [
                 "foo.sol",
@@ -85,6 +85,6 @@ contract Foo {
             ]
         ]);
 
-        expect(() => findAllFiles(files, [], [])).toThrow(/Couldn't find a.sol/);
+        await expect(findAllFiles(files, [], [])).rejects.toThrow(/Couldn't find a.sol/);
     });
 });


### PR DESCRIPTION
## Changes
- [x] Add overloads of `compileSol()` to enable support of compiling array of files via single compiler invocation. Added related tests.
- [x] Removed `resolveFiles()` as it more logical to use `findAllFiles()` and `parsePathRemapping()` separately. There is no real need to reparse remappings before each call to `findAllFiles()`.
- [x] The function `findAllFiles()` is now `async`. 
- [x] Minor smaller codebase improvements.

Regards.