### PR TITLE
Return remappings inferred by the `LocalNpmResolver` in the `CompileResult`

### DIFF
--- a/test/unit/compile/import_resolver.spec.ts
+++ b/test/unit/compile/import_resolver.spec.ts
@@ -1,6 +1,6 @@
 import expect from "expect";
 import path from "path";
-import { FileSystemResolver, LocalNpmResolver } from "../../../src";
+import { FileSystemResolver, LocalNpmResolver, Remapping } from "../../../src";
 
 describe("FileSystemResolver", () => {
     describe("resolve()", () => {
@@ -20,17 +20,26 @@ describe("FileSystemResolver", () => {
 
 describe("LocalNpmResolver", () => {
     describe("resolve()", () => {
-        const resolver = new LocalNpmResolver("test/");
+        const inferredRemappings = new Map<string, Remapping>();
+        const resolver = new LocalNpmResolver("test/", inferredRemappings);
 
         const cases: Array<[string, string | undefined]> = [
             [".bin/tsc", path.resolve("node_modules/.bin/tsc")],
             [".bin/missing", undefined]
         ];
 
+        const expectedInferredRemapping = new Map<string, Remapping>([
+            [".bin/tsc", ["", ".bin", path.resolve("node_modules/.bin")]]
+        ]);
+
         for (const [fileName, result] of cases) {
             it(`Returns ${JSON.stringify(result)} for "${fileName}"`, () => {
                 expect(resolver.resolve(fileName)).toEqual(result);
             });
         }
+
+        it("Inferred path remappings map is valid", () => {
+            expect(inferredRemappings).toEqual(expectedInferredRemapping);
+        });
     });
 });


### PR DESCRIPTION
The `compileSol` and `compileSourceString()` use the `LocalNpmResolver` class to infer any missing remappings to packages located under a node_modules directory in a parent directory of the current compiled artifact.

It would be useful to callers (especially scribble) if those entry points also reported in their `CompileResult` any additional rempapings that they inferred, on top of the remappings passed in by the user.