### PR TITLE
Detection of dangling documentation

### DIFF
--- a/src/ast/documentation.ts
+++ b/src/ast/documentation.ts
@@ -3,11 +3,21 @@ import { StructuredDocumentation } from "./implementation/meta";
 
 export interface WithPrecedingDocs {
     documentation?: string | StructuredDocumentation;
+
+    /**
+     * This field is used as a storage field for string,
+     * if string is set as value for `documentation`.
+     */
     docString?: string;
 }
 
 export interface WithDanglingDocs {
     danglingDocumentation?: string | StructuredDocumentation;
+
+    /**
+     * This field is used as a storage field for string,
+     * if string is set as value for `danglingDocumentation`.
+     */
     danglingDocString?: string;
 }
 
@@ -27,6 +37,10 @@ export function getDocumentation(
         if (child instanceof StructuredDocumentation) {
             const childLoc = child.sourceInfo;
 
+            /**
+             * Note that preceding documentation nodes are
+             * EXCLUDED from source range of parent node.
+             */
             if (childLoc.offset <= ownLoc.offset) {
                 return child;
             }
@@ -77,6 +91,10 @@ export function getDanglingDocumentation(
         if (child instanceof StructuredDocumentation) {
             const childLoc = child.sourceInfo;
 
+            /**
+             * Note that preceding documentation nodes are
+             * INCLUDED from source range of parent node.
+             */
             if (childLoc.offset > ownLoc.offset) {
                 return child;
             }

--- a/src/ast/documentation.ts
+++ b/src/ast/documentation.ts
@@ -1,7 +1,7 @@
 import { ASTNode, ASTNodeWithChildren } from "./ast_node";
 import { StructuredDocumentation } from "./implementation/meta";
 
-export interface WithPreceedingDocs {
+export interface WithPrecedingDocs {
     documentation?: string | StructuredDocumentation;
     docString?: string;
 }
@@ -12,7 +12,7 @@ export interface WithDanglingDocs {
 }
 
 export function getDocumentation(
-    node: WithPreceedingDocs & ASTNodeWithChildren<ASTNode>
+    node: WithPrecedingDocs & ASTNodeWithChildren<ASTNode>
 ): string | StructuredDocumentation | undefined {
     if (node.docString !== undefined) {
         return node.docString;
@@ -37,7 +37,7 @@ export function getDocumentation(
 }
 
 export function setDocumentation(
-    node: WithPreceedingDocs & ASTNodeWithChildren<ASTNode>,
+    node: WithPrecedingDocs & ASTNodeWithChildren<ASTNode>,
     value: string | StructuredDocumentation | undefined
 ): void {
     const old = node.documentation;

--- a/src/ast/documentation.ts
+++ b/src/ast/documentation.ts
@@ -1,0 +1,112 @@
+import { ASTNode, ASTNodeWithChildren } from "./ast_node";
+import { StructuredDocumentation } from "./implementation/meta";
+
+export interface WithPreceedingDocs {
+    documentation?: string | StructuredDocumentation;
+    docString?: string;
+}
+
+export interface WithDanglingDocs {
+    danglingDocumentation?: string | StructuredDocumentation;
+    danglingDocString?: string;
+}
+
+export function getDocumentation(
+    node: WithPreceedingDocs & ASTNodeWithChildren<ASTNode>
+): string | StructuredDocumentation | undefined {
+    if (node.docString !== undefined) {
+        return node.docString;
+    }
+
+    const ownLoc = node.sourceInfo;
+    const children = node.children;
+
+    for (let c = 0; c < children.length; c++) {
+        const child = children[c];
+
+        if (child instanceof StructuredDocumentation) {
+            const childLoc = child.sourceInfo;
+
+            if (childLoc.offset <= ownLoc.offset) {
+                return child;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+export function setDocumentation(
+    node: WithPreceedingDocs & ASTNodeWithChildren<ASTNode>,
+    value: string | StructuredDocumentation | undefined
+): void {
+    const old = node.documentation;
+
+    if (value instanceof StructuredDocumentation) {
+        node.docString = undefined;
+
+        if (old instanceof StructuredDocumentation) {
+            if (value !== old) {
+                node.replaceChild(value, old);
+            }
+        } else {
+            node.insertAtBeginning(value);
+        }
+    } else {
+        if (old instanceof StructuredDocumentation) {
+            node.removeChild(old);
+        }
+
+        node.docString = value;
+    }
+}
+
+export function getDanglingDocumentation(
+    node: WithDanglingDocs & ASTNodeWithChildren<ASTNode>
+): string | StructuredDocumentation | undefined {
+    if (node.danglingDocString !== undefined) {
+        return node.danglingDocString;
+    }
+
+    const ownLoc = node.sourceInfo;
+    const children = node.children;
+
+    for (let c = children.length - 1; c >= 0; c--) {
+        const child = children[c];
+
+        if (child instanceof StructuredDocumentation) {
+            const childLoc = child.sourceInfo;
+
+            if (childLoc.offset > ownLoc.offset) {
+                return child;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+export function setDanglingDocumentation(
+    node: WithDanglingDocs & ASTNodeWithChildren<ASTNode>,
+    value: string | StructuredDocumentation | undefined
+): void {
+    const old = node.danglingDocumentation;
+
+    if (value instanceof StructuredDocumentation) {
+        node.danglingDocString = undefined;
+
+        if (old instanceof StructuredDocumentation) {
+            if (value !== old) {
+                node.replaceChild<any, any>(value, old);
+            }
+        } else {
+            node.appendChild(value as any);
+        }
+    } else {
+        if (old instanceof StructuredDocumentation) {
+            node.removeChild(old as any);
+        }
+
+        node.danglingDocString = value;
+    }
+}

--- a/src/ast/implementation/declaration/contract_definition.ts
+++ b/src/ast/implementation/declaration/contract_definition.ts
@@ -1,6 +1,14 @@
 import { ABIEncoderVersion } from "../../../types/abi";
 import { ASTNode, ASTNodeWithChildren } from "../../ast_node";
 import { ContractKind, StateVariableVisibility } from "../../constants";
+import {
+    getDanglingDocumentation,
+    getDocumentation,
+    setDanglingDocumentation,
+    setDocumentation,
+    WithDanglingDocs,
+    WithPreceedingDocs
+} from "../../documentation";
 import { InheritanceSpecifier } from "../meta/inheritance_specifier";
 import { SourceUnit } from "../meta/source_unit";
 import { StructuredDocumentation } from "../meta/structured_documentation";
@@ -14,9 +22,12 @@ import { StructDefinition } from "./struct_definition";
 import { UserDefinedValueTypeDefinition } from "./user_defined_value_type_definition";
 import { VariableDeclaration } from "./variable_declaration";
 
-export class ContractDefinition extends ASTNodeWithChildren<ASTNode> {
-    private docString?: string;
-    private danglingDocString?: string;
+export class ContractDefinition
+    extends ASTNodeWithChildren<ASTNode>
+    implements WithPreceedingDocs, WithDanglingDocs
+{
+    docString?: string;
+    danglingDocString?: string;
 
     /**
      * The contract name
@@ -105,48 +116,13 @@ export class ContractDefinition extends ASTNodeWithChildren<ASTNode> {
      * - Is instance of `StructuredDocumentation` when specified and compiler version is `0.6.3` or newer.
      */
     get documentation(): string | StructuredDocumentation | undefined {
-        if (this.docString !== undefined) {
-            return this.docString;
-        }
-
-        const ownLoc = this.sourceInfo;
-
-        for (let c = 0; c < this.ownChildren.length; c++) {
-            const child = this.ownChildren[c];
-
-            if (child instanceof StructuredDocumentation) {
-                const childLoc = child.sourceInfo;
-
-                if (childLoc.offset <= ownLoc.offset) {
-                    return child;
-                }
-            }
-        }
-
-        return undefined;
+        return getDocumentation(this);
     }
 
     set documentation(value: string | StructuredDocumentation | undefined) {
-        const old = this.documentation;
-
-        if (value instanceof StructuredDocumentation) {
-            this.docString = undefined;
-
-            if (old instanceof StructuredDocumentation) {
-                if (value !== old) {
-                    this.replaceChild(value, old);
-                }
-            } else {
-                this.insertAtBeginning(value);
-            }
-        } else {
-            if (old instanceof StructuredDocumentation) {
-                this.removeChild(old);
-            }
-
-            this.docString = value;
-        }
+        setDocumentation(this, value);
     }
+
     /**
      * Optional documentation that is dangling in the source fragment,
      * that is after end of last child and before the end of the current node.
@@ -156,47 +132,11 @@ export class ContractDefinition extends ASTNodeWithChildren<ASTNode> {
      * - Is type of `string` for compatibility reasons.
      */
     get danglingDocumentation(): string | StructuredDocumentation | undefined {
-        if (this.danglingDocString !== undefined) {
-            return this.danglingDocString;
-        }
-
-        const ownLoc = this.sourceInfo;
-
-        for (let c = this.ownChildren.length - 1; c >= 0; c--) {
-            const child = this.ownChildren[c];
-
-            if (child instanceof StructuredDocumentation) {
-                const childLoc = child.sourceInfo;
-
-                if (childLoc.offset > ownLoc.offset) {
-                    return child;
-                }
-            }
-        }
-
-        return undefined;
+        return getDanglingDocumentation(this);
     }
 
     set danglingDocumentation(value: string | StructuredDocumentation | undefined) {
-        const old = this.danglingDocumentation;
-
-        if (value instanceof StructuredDocumentation) {
-            this.danglingDocString = undefined;
-
-            if (old instanceof StructuredDocumentation) {
-                if (value !== old) {
-                    this.replaceChild<any, any>(value, old);
-                }
-            } else {
-                this.appendChild(value as any);
-            }
-        } else {
-            if (old instanceof StructuredDocumentation) {
-                this.removeChild(old as any);
-            }
-
-            this.danglingDocString = value;
-        }
+        setDanglingDocumentation(this, value);
     }
 
     /**

--- a/src/ast/implementation/declaration/contract_definition.ts
+++ b/src/ast/implementation/declaration/contract_definition.ts
@@ -7,7 +7,7 @@ import {
     setDanglingDocumentation,
     setDocumentation,
     WithDanglingDocs,
-    WithPreceedingDocs
+    WithPrecedingDocs
 } from "../../documentation";
 import { InheritanceSpecifier } from "../meta/inheritance_specifier";
 import { SourceUnit } from "../meta/source_unit";
@@ -24,7 +24,7 @@ import { VariableDeclaration } from "./variable_declaration";
 
 export class ContractDefinition
     extends ASTNodeWithChildren<ASTNode>
-    implements WithPreceedingDocs, WithDanglingDocs
+    implements WithPrecedingDocs, WithDanglingDocs
 {
     docString?: string;
     danglingDocString?: string;

--- a/src/ast/implementation/statement/block.ts
+++ b/src/ast/implementation/statement/block.ts
@@ -1,10 +1,13 @@
+import { ASTNode } from "../../ast_node";
 import { StructuredDocumentation } from "../meta";
 import { Statement, StatementWithChildren } from "./statement";
 
 /**
  * Block is a compound statement and it can hold other statements
  */
-export class Block extends StatementWithChildren<Statement> {
+export class Block extends StatementWithChildren<
+    Statement | StatementWithChildren<ASTNode> | StructuredDocumentation
+> {
     constructor(
         id: number,
         src: string,
@@ -22,7 +25,9 @@ export class Block extends StatementWithChildren<Statement> {
     /**
      * An array of the member statements
      */
-    get vStatements(): Statement[] {
-        return this.ownChildren as Statement[];
+    get vStatements(): Array<Statement | StatementWithChildren<ASTNode>> {
+        return this.ownChildren.filter(
+            (node) => node instanceof Statement || node instanceof StatementWithChildren
+        );
     }
 }

--- a/src/ast/implementation/statement/do_while_statement.ts
+++ b/src/ast/implementation/statement/do_while_statement.ts
@@ -31,6 +31,6 @@ export class DoWhileStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vCondition, this.vBody);
+        return this.pickNodes(this.documentation, this.vCondition, this.vBody);
     }
 }

--- a/src/ast/implementation/statement/emit_statement.ts
+++ b/src/ast/implementation/statement/emit_statement.ts
@@ -24,6 +24,6 @@ export class EmitStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vEventCall);
+        return this.pickNodes(this.documentation, this.vEventCall);
     }
 }

--- a/src/ast/implementation/statement/expression_statement.ts
+++ b/src/ast/implementation/statement/expression_statement.ts
@@ -27,6 +27,6 @@ export class ExpressionStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vExpression);
+        return this.pickNodes(this.documentation, this.vExpression);
     }
 }

--- a/src/ast/implementation/statement/for_statement.ts
+++ b/src/ast/implementation/statement/for_statement.ts
@@ -49,6 +49,7 @@ export class ForStatement extends Statement {
 
     get children(): readonly ASTNode[] {
         return this.pickNodes(
+            this.documentation,
             this.vInitializationExpression,
             this.vCondition,
             this.vLoopExpression,

--- a/src/ast/implementation/statement/if_statement.ts
+++ b/src/ast/implementation/statement/if_statement.ts
@@ -38,6 +38,6 @@ export class IfStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vCondition, this.vTrueBody, this.vFalseBody);
+        return this.pickNodes(this.documentation, this.vCondition, this.vTrueBody, this.vFalseBody);
     }
 }

--- a/src/ast/implementation/statement/return.ts
+++ b/src/ast/implementation/statement/return.ts
@@ -33,7 +33,7 @@ export class Return extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vExpression);
+        return this.pickNodes(this.documentation, this.vExpression);
     }
 
     /**

--- a/src/ast/implementation/statement/revert_statement.ts
+++ b/src/ast/implementation/statement/revert_statement.ts
@@ -24,6 +24,6 @@ export class RevertStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.errorCall);
+        return this.pickNodes(this.documentation, this.errorCall);
     }
 }

--- a/src/ast/implementation/statement/statement.ts
+++ b/src/ast/implementation/statement/statement.ts
@@ -5,7 +5,7 @@ import {
     setDanglingDocumentation,
     setDocumentation,
     WithDanglingDocs,
-    WithPreceedingDocs
+    WithPrecedingDocs
 } from "../../documentation";
 import { StructuredDocumentation } from "../meta";
 
@@ -35,7 +35,7 @@ export class Statement extends ASTNode {
 
 export class StatementWithChildren<T extends ASTNode>
     extends ASTNodeWithChildren<T>
-    implements WithPreceedingDocs, WithDanglingDocs
+    implements WithPrecedingDocs, WithDanglingDocs
 {
     docString?: string;
     danglingDocString?: string;

--- a/src/ast/implementation/statement/statement.ts
+++ b/src/ast/implementation/statement/statement.ts
@@ -19,15 +19,15 @@ export class Statement extends ASTNode {
 
         this.documentation = documentation;
     }
+
+    get children(): readonly ASTNode[] {
+        return this.pickNodes(this.documentation);
+    }
 }
 
 export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildren<T> {
-    /**
-     * Optional documentation appearing above the statement:
-     * - Is `undefined` when not specified.
-     * - Is type of `string` for compatibility reasons.
-     */
-    documentation?: string | StructuredDocumentation;
+    private docString?: string;
+    private danglingDocString?: string;
 
     constructor(
         id: number,
@@ -38,5 +38,107 @@ export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildre
         super(id, src, raw);
 
         this.documentation = documentation;
+    }
+
+    /**
+     * Optional documentation appearing above the contract definition:
+     * - Is `undefined` when not specified.
+     * - Is type of `string` when specified and compiler version is older than `0.6.3`.
+     * - Is instance of `StructuredDocumentation` when specified and compiler version is `0.6.3` or newer.
+     */
+    get documentation(): string | StructuredDocumentation | undefined {
+        if (this.docString !== undefined) {
+            return this.docString;
+        }
+
+        const ownLoc = this.sourceInfo;
+
+        for (let c = 0; c < this.ownChildren.length; c++) {
+            const child = this.ownChildren[c];
+
+            if (child instanceof StructuredDocumentation) {
+                const childLoc = child.sourceInfo;
+
+                if (childLoc.offset <= ownLoc.offset) {
+                    return child;
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    set documentation(value: string | StructuredDocumentation | undefined) {
+        const old = this.documentation;
+
+        if (value instanceof StructuredDocumentation) {
+            this.docString = undefined;
+
+            if (old instanceof StructuredDocumentation) {
+                if (value !== old) {
+                    this.replaceChild<any, any>(value, old);
+                }
+            } else {
+                this.insertAtBeginning(value as any);
+            }
+        } else {
+            if (old instanceof StructuredDocumentation) {
+                this.removeChild(old as any);
+            }
+
+            this.docString = value;
+        }
+    }
+
+    /**
+     * Optional documentation that is dangling in the source fragment,
+     * that is after end of last child and before the end of the current node.
+     *
+     * It is:
+     * - Is `undefined` when not detected.
+     * - Is type of `string` for compatibility reasons.
+     */
+    get danglingDocumentation(): string | StructuredDocumentation | undefined {
+        if (this.danglingDocString !== undefined) {
+            return this.danglingDocString;
+        }
+
+        const ownLoc = this.sourceInfo;
+
+        for (let c = this.ownChildren.length - 1; c >= 0; c--) {
+            const child = this.ownChildren[c];
+
+            if (child instanceof StructuredDocumentation) {
+                const childLoc = child.sourceInfo;
+
+                if (childLoc.offset > ownLoc.offset) {
+                    return child;
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    set danglingDocumentation(value: string | StructuredDocumentation | undefined) {
+        const old = this.danglingDocumentation;
+
+        if (value instanceof StructuredDocumentation) {
+            this.danglingDocString = undefined;
+
+            if (old instanceof StructuredDocumentation) {
+                if (value !== old) {
+                    this.replaceChild<any, any>(value, old);
+                }
+            } else {
+                this.appendChild(value as any);
+            }
+        } else {
+            if (old instanceof StructuredDocumentation) {
+                this.removeChild(old as any);
+            }
+
+            this.danglingDocString = value;
+        }
     }
 }

--- a/src/ast/implementation/statement/statement.ts
+++ b/src/ast/implementation/statement/statement.ts
@@ -1,4 +1,12 @@
 import { ASTNode, ASTNodeWithChildren } from "../../ast_node";
+import {
+    getDanglingDocumentation,
+    getDocumentation,
+    setDanglingDocumentation,
+    setDocumentation,
+    WithDanglingDocs,
+    WithPreceedingDocs
+} from "../../documentation";
 import { StructuredDocumentation } from "../meta";
 
 export class Statement extends ASTNode {
@@ -25,9 +33,12 @@ export class Statement extends ASTNode {
     }
 }
 
-export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildren<T> {
-    private docString?: string;
-    private danglingDocString?: string;
+export class StatementWithChildren<T extends ASTNode>
+    extends ASTNodeWithChildren<T>
+    implements WithPreceedingDocs, WithDanglingDocs
+{
+    docString?: string;
+    danglingDocString?: string;
 
     constructor(
         id: number,
@@ -47,47 +58,11 @@ export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildre
      * - Is instance of `StructuredDocumentation` when specified and compiler version is `0.6.3` or newer.
      */
     get documentation(): string | StructuredDocumentation | undefined {
-        if (this.docString !== undefined) {
-            return this.docString;
-        }
-
-        const ownLoc = this.sourceInfo;
-
-        for (let c = 0; c < this.ownChildren.length; c++) {
-            const child = this.ownChildren[c];
-
-            if (child instanceof StructuredDocumentation) {
-                const childLoc = child.sourceInfo;
-
-                if (childLoc.offset <= ownLoc.offset) {
-                    return child;
-                }
-            }
-        }
-
-        return undefined;
+        return getDocumentation(this);
     }
 
     set documentation(value: string | StructuredDocumentation | undefined) {
-        const old = this.documentation;
-
-        if (value instanceof StructuredDocumentation) {
-            this.docString = undefined;
-
-            if (old instanceof StructuredDocumentation) {
-                if (value !== old) {
-                    this.replaceChild<any, any>(value, old);
-                }
-            } else {
-                this.insertAtBeginning(value as any);
-            }
-        } else {
-            if (old instanceof StructuredDocumentation) {
-                this.removeChild(old as any);
-            }
-
-            this.docString = value;
-        }
+        setDocumentation(this, value);
     }
 
     /**
@@ -99,46 +74,10 @@ export class StatementWithChildren<T extends ASTNode> extends ASTNodeWithChildre
      * - Is type of `string` for compatibility reasons.
      */
     get danglingDocumentation(): string | StructuredDocumentation | undefined {
-        if (this.danglingDocString !== undefined) {
-            return this.danglingDocString;
-        }
-
-        const ownLoc = this.sourceInfo;
-
-        for (let c = this.ownChildren.length - 1; c >= 0; c--) {
-            const child = this.ownChildren[c];
-
-            if (child instanceof StructuredDocumentation) {
-                const childLoc = child.sourceInfo;
-
-                if (childLoc.offset > ownLoc.offset) {
-                    return child;
-                }
-            }
-        }
-
-        return undefined;
+        return getDanglingDocumentation(this);
     }
 
     set danglingDocumentation(value: string | StructuredDocumentation | undefined) {
-        const old = this.danglingDocumentation;
-
-        if (value instanceof StructuredDocumentation) {
-            this.danglingDocString = undefined;
-
-            if (old instanceof StructuredDocumentation) {
-                if (value !== old) {
-                    this.replaceChild<any, any>(value, old);
-                }
-            } else {
-                this.appendChild(value as any);
-            }
-        } else {
-            if (old instanceof StructuredDocumentation) {
-                this.removeChild(old as any);
-            }
-
-            this.danglingDocString = value;
-        }
+        setDanglingDocumentation(this, value);
     }
 }

--- a/src/ast/implementation/statement/try_catch_clause.ts
+++ b/src/ast/implementation/statement/try_catch_clause.ts
@@ -39,6 +39,6 @@ export class TryCatchClause extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vParameters, this.vBlock);
+        return this.pickNodes(this.documentation, this.vParameters, this.vBlock);
     }
 }

--- a/src/ast/implementation/statement/try_statement.ts
+++ b/src/ast/implementation/statement/try_statement.ts
@@ -32,6 +32,6 @@ export class TryStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vExternalCall, this.vClauses);
+        return this.pickNodes(this.documentation, this.vExternalCall, this.vClauses);
     }
 }

--- a/src/ast/implementation/statement/unchecked_block.ts
+++ b/src/ast/implementation/statement/unchecked_block.ts
@@ -1,3 +1,4 @@
+import { ASTNode } from "../../ast_node";
 import { StructuredDocumentation } from "../meta";
 import { Statement, StatementWithChildren } from "./statement";
 
@@ -5,7 +6,9 @@ import { Statement, StatementWithChildren } from "./statement";
  * UncheckedBlock is a compound statement that indicates
  * the underflow and overflow effects are permitted in math expressions.
  */
-export class UncheckedBlock extends StatementWithChildren<Statement> {
+export class UncheckedBlock extends StatementWithChildren<
+    Statement | StatementWithChildren<ASTNode> | StructuredDocumentation
+> {
     constructor(
         id: number,
         src: string,
@@ -23,7 +26,9 @@ export class UncheckedBlock extends StatementWithChildren<Statement> {
     /**
      * An array of the member statements
      */
-    get vStatements(): Statement[] {
-        return this.ownChildren as Statement[];
+    get vStatements(): Array<Statement | StatementWithChildren<ASTNode>> {
+        return this.ownChildren.filter(
+            (node) => node instanceof Statement || node instanceof StatementWithChildren
+        );
     }
 }

--- a/src/ast/implementation/statement/variable_declaration_statement.ts
+++ b/src/ast/implementation/statement/variable_declaration_statement.ts
@@ -41,6 +41,6 @@ export class VariableDeclarationStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vDeclarations, this.vInitialValue);
+        return this.pickNodes(this.documentation, this.vDeclarations, this.vInitialValue);
     }
 }

--- a/src/ast/implementation/statement/while_statement.ts
+++ b/src/ast/implementation/statement/while_statement.ts
@@ -31,6 +31,6 @@ export class WhileStatement extends Statement {
     }
 
     get children(): readonly ASTNode[] {
-        return this.pickNodes(this.vCondition, this.vBody);
+        return this.pickNodes(this.documentation, this.vCondition, this.vBody);
     }
 }

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -8,6 +8,7 @@ export * from "./ast_node_formatter";
 export * from "./ast_node";
 export * from "./ast_reader";
 export * from "./constants";
+export * from "./documentation";
 export * from "./postprocessing";
 export * from "./writing";
 export * from "./dispatch";

--- a/src/ast/postprocessing/structured_documentation_reconstruction.ts
+++ b/src/ast/postprocessing/structured_documentation_reconstruction.ts
@@ -93,7 +93,7 @@ export class StructuredDocumentationReconstructor {
     }
 
     private extractComments(fragment: string): string[] {
-        const rx = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|([^\n\r]*\/\/.*[\n\r]+)/g;
+        const rx = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|([^\n\r]*\/\/.*[\n\r]+)|[\n\r]/g;
         const result: string[] = [];
 
         let match = rx.exec(fragment);
@@ -153,7 +153,6 @@ export class StructuredDocumentationReconstructor {
         const result: string[] = [];
 
         const replacers = docBlock.startsWith("///") ? ["/// ", "///"] : ["/**", "*/", "* ", "*"];
-
         const lines = docBlock.split("\n");
 
         for (let line of lines) {

--- a/src/ast/writing/ast_mapping.ts
+++ b/src/ast/writing/ast_mapping.ts
@@ -212,7 +212,7 @@ function wrapWithParens(
     return desc;
 }
 
-function writePreceedingDocs(
+function writePrecedingDocs(
     documentation: string | StructuredDocumentation | undefined,
     writer: ASTWriter
 ): SrcDesc {
@@ -530,7 +530,7 @@ abstract class SimpleStatementWriter<T extends Statement> extends ASTNodeWriter 
     writeWhole(node: T, writer: ASTWriter): SrcDesc {
         const stmtDesc = super.writeWhole(node, writer);
 
-        stmtDesc.unshift(...writePreceedingDocs(node.documentation, writer));
+        stmtDesc.unshift(...writePrecedingDocs(node.documentation, writer));
         stmtDesc.push(";");
 
         return stmtDesc;
@@ -549,7 +549,7 @@ class ExpressionStatementWriter extends SimpleStatementWriter<ExpressionStatemen
     writeWhole(node: ExpressionStatement, writer: ASTWriter): SrcDesc {
         const stmtDesc: SrcDesc = [[node, this.writeInner(node, writer)]];
 
-        stmtDesc.unshift(...writePreceedingDocs(node.documentation, writer));
+        stmtDesc.unshift(...writePrecedingDocs(node.documentation, writer));
 
         if (!(node.parent instanceof ForStatement && node.parent.vLoopExpression === node)) {
             stmtDesc.push(";");
@@ -625,7 +625,7 @@ abstract class CompoundStatementWriter<
 
         pushSemicolonsDown(stmtDesc);
 
-        return writePreceedingDocs(node.documentation, writer).concat(
+        return writePrecedingDocs(node.documentation, writer).concat(
             wrapCompoundStatement(node, stmtDesc)
         );
     }
@@ -747,7 +747,7 @@ class InlineAssemblyWriter extends ASTNodeWriter {
 
     writeWhole(node: InlineAssembly, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -779,7 +779,7 @@ class TryCatchClauseWriter extends ASTNodeWriter {
 
     writeWhole(node: TryCatchClause, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -792,7 +792,7 @@ class TryStatementWriter extends ASTNodeWriter {
 
     writeWhole(node: TryStatement, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -811,7 +811,7 @@ class VariableDeclarationWriter extends ASTNodeWriter {
 
     writeWhole(node: VariableDeclaration, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -925,7 +925,7 @@ class BlockWriter extends ASTNodeWriter {
 
     writeWhole(node: Block, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -968,7 +968,7 @@ class UncheckedBlockWriter extends ASTNodeWriter {
 
     writeWhole(node: UncheckedBlock, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -981,7 +981,7 @@ class ErrorDefinitionWriter extends ASTNodeWriter {
 
     writeWhole(node: ErrorDefinition, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -1000,7 +1000,7 @@ class EventDefinitionWriter extends ASTNodeWriter {
 
     writeWhole(node: EventDefinition, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -1065,7 +1065,7 @@ class ModifierDefinitionWriter extends ASTNodeWriter {
 
     writeWhole(node: ModifierDefinition, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -1104,7 +1104,7 @@ class FunctionDefinitionWriter extends ASTNodeWriter {
 
     writeWhole(node: FunctionDefinition, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }
@@ -1233,7 +1233,7 @@ class ContractDefinitionWriter extends ASTNodeWriter {
 
     writeWhole(node: ContractDefinition, writer: ASTWriter): SrcDesc {
         return [
-            ...writePreceedingDocs(node.documentation, writer),
+            ...writePrecedingDocs(node.documentation, writer),
             [node, this.writeInner(node, writer)]
         ];
     }

--- a/src/compile/version.ts
+++ b/src/compile/version.ts
@@ -50,7 +50,7 @@ export function normalizeSpecifier(specifier: string): string {
         .replace(rx.space, "")
         .replace(rx.operator, " $1")
         .replace(rx.spaceDash, "$1 ")
-        .trimLeft();
+        .trimStart();
 }
 
 export function extractSpecifiersFromSource(source: string): string[] {

--- a/test/integration/sourcemap/snapshot.spec.ts
+++ b/test/integration/sourcemap/snapshot.spec.ts
@@ -77,6 +77,10 @@ describe("Source map snapshot tests", () => {
                     }
 
                     const result = parts.join("\n") + "\n";
+
+                    // Uncomment next line to update snapshots
+                    // fse.writeFileSync(sample, result, { encoding: "utf-8" });
+
                     const expectation = fse.readFileSync(sample, { encoding: "utf-8" });
 
                     expect(result).toEqual(expectation);

--- a/test/samples/solidity/declarations/contract_050.nodes.native.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.native.txt
@@ -41,6 +41,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #90 ]
         <getter> vUsedErrors: Array(0)
@@ -265,10 +266,12 @@ SourceUnit #146
             Block #88
                 id: 88
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #89
                 <getter> vStatements: Array(1) [ ExpressionStatement #87 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #87 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #87
@@ -402,6 +405,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #100 ]
         <getter> vUsedErrors: Array(0)
@@ -638,6 +642,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(2) [ ContractDefinition #145, ContractDefinition #100 ]
         <getter> vUsedErrors: Array(0)
@@ -1073,10 +1078,12 @@ SourceUnit #146
             Block #128
                 id: 128
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #129
                 <getter> vStatements: Array(1) [ ExpressionStatement #127 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #127 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #127
@@ -1422,10 +1429,12 @@ SourceUnit #146
             Block #143
                 id: 143
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #144
                 <getter> vStatements: Array(1) [ Return #142 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #142 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #142

--- a/test/samples/solidity/declarations/contract_050.nodes.wasm.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.wasm.txt
@@ -41,6 +41,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #90 ]
         <getter> vUsedErrors: Array(0)
@@ -265,10 +266,12 @@ SourceUnit #146
             Block #88
                 id: 88
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #89
                 <getter> vStatements: Array(1) [ ExpressionStatement #87 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #87 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #87
@@ -402,6 +405,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #100 ]
         <getter> vUsedErrors: Array(0)
@@ -638,6 +642,7 @@ SourceUnit #146
         context: ASTContext #1000
         parent: SourceUnit #146
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #146
         <getter> vLinearizedBaseContracts: Array(2) [ ContractDefinition #145, ContractDefinition #100 ]
         <getter> vUsedErrors: Array(0)
@@ -1073,10 +1078,12 @@ SourceUnit #146
             Block #128
                 id: 128
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #129
                 <getter> vStatements: Array(1) [ ExpressionStatement #127 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #127 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #127
@@ -1422,10 +1429,12 @@ SourceUnit #146
             Block #143
                 id: 143
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #144
                 <getter> vStatements: Array(1) [ Return #142 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #142 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #142

--- a/test/samples/solidity/latest_06.sourced.sm.sol
+++ b/test/samples/solidity/latest_06.sourced.sm.sol
@@ -214,7 +214,7 @@ contract PublicVarOverride is SomeInterface {
 // Mapping#23 (409:22:0) -> 241:22:0
 // VariableDeclaration#24 (409:24:0) -> 241:24:0
 // StructDefinition#25 (288:148:0) -> 120:148:0
-// StructuredDocumentation#26 (438:65:0) -> 270:65:0
+// StructuredDocumentation#26 (438:65:0) -> 270:64:0
 // ElementaryTypeName#27 (569:3:0) -> 401:3:0
 // VariableDeclaration#28 (569:8:0) -> 401:8:0
 // ElementaryTypeName#29 (579:4:0) -> 411:4:0
@@ -231,7 +231,7 @@ contract PublicVarOverride is SomeInterface {
 // Block#40 (610:37:0) -> 442:37:0
 // FunctionDefinition#41 (531:116:0) -> 363:116:0
 // ContractDefinition#42 (503:146:0) -> 335:146:0
-// StructuredDocumentation#43 (651:74:0) -> 483:74:0
+// StructuredDocumentation#43 (651:74:0) -> 483:73:0
 // ElementaryTypeName#44 (774:6:0) -> 606:6:0
 // VariableDeclaration#45 (774:17:0) -> 606:17:0
 // ParameterList#46 (773:19:0) -> 605:19:0
@@ -242,7 +242,7 @@ contract PublicVarOverride is SomeInterface {
 // ContractDefinition#51 (725:102:0) -> 557:102:0
 // ElementaryTypeName#52 (868:3:0) -> 700:3:0
 // VariableDeclaration#53 (868:17:0) -> 700:17:0
-// StructuredDocumentation#54 (892:36:0) -> 724:40:0
+// StructuredDocumentation#54 (892:36:0) -> 724:35:0
 // ElementaryTypeName#55 (954:3:0) -> 785:3:0
 // VariableDeclaration#56 (954:5:0) -> 785:5:0
 // ParameterList#57 (953:7:0) -> 784:7:0
@@ -264,7 +264,7 @@ contract PublicVarOverride is SomeInterface {
 // ParameterList#74 (1090:17:0) -> 921:17:0
 // FunctionDefinition#75 (1032:76:0) -> 863:76:0
 // ContractDefinition#76 (829:281:0) -> 661:280:0
-// StructuredDocumentation#77 (1112:36:0) -> 943:37:0
+// StructuredDocumentation#77 (1112:36:0) -> 943:36:0
 // ContractDefinition#78 (1148:17:0) -> 980:17:0
 // ParameterList#79 (1206:2:0) -> 1038:2:0
 // Block#81 (1224:2:0) -> 1056:2:0
@@ -273,7 +273,7 @@ contract PublicVarOverride is SomeInterface {
 // UserDefinedTypeName#84 (1253:14:0) -> 1085:14:0
 // Literal#85 (1268:1:0) -> 1100:1:0
 // InheritanceSpecifier#86 (1253:17:0) -> 1085:17:0
-// StructuredDocumentation#87 (1277:38:0) -> 1109:43:0
+// StructuredDocumentation#87 (1277:38:0) -> 1109:38:0
 // ElementaryTypeName#88 (1332:7:0) -> 1164:7:0
 // VariableDeclaration#89 (1332:14:0) -> 1164:14:0
 // ElementaryTypeName#90 (1348:6:0) -> 1180:6:0
@@ -291,7 +291,7 @@ contract PublicVarOverride is SomeInterface {
 // ElementaryTypeName#102 (1499:4:0) -> 1331:4:0
 // ArrayTypeName#103 (1499:6:0) -> 1331:6:0
 // VariableDeclaration#104 (1499:20:0) -> 1331:20:0
-// StructuredDocumentation#105 (1526:47:0) -> 1358:51:0
+// StructuredDocumentation#105 (1526:47:0) -> 1358:46:0
 // ElementaryTypeName#106 (1599:3:0) -> 1430:3:0
 // VariableDeclaration#107 (1599:5:0) -> 1430:5:0
 // ParameterList#108 (1598:7:0) -> 1429:7:0
@@ -303,7 +303,7 @@ contract PublicVarOverride is SomeInterface {
 // ExpressionStatement#114 (1636:9:0) -> 1467:9:0
 // Block#115 (1615:37:0) -> 1446:37:0
 // ModifierDefinition#116 (1578:74:0) -> 1409:74:0
-// StructuredDocumentation#117 (1658:89:0) -> 1489:94:0
+// StructuredDocumentation#117 (1658:89:0) -> 1489:89:0
 // ParameterList#118 (1783:2:0) -> 1614:2:0
 // Identifier#119 (1796:7:0) -> 1627:7:0
 // Identifier#120 (1804:4:0) -> 1635:4:0
@@ -400,7 +400,7 @@ contract PublicVarOverride is SomeInterface {
 // ExpressionStatement#214 (2504:105:0) -> 2335:105:0
 // Block#215 (2225:391:0) -> 2056:391:0
 // FunctionDefinition#216 (2196:420:0) -> 2027:420:0
-// StructuredDocumentation#217 (2622:26:0) -> 2453:31:0
+// StructuredDocumentation#217 (2622:26:0) -> 2453:26:0
 // ParameterList#218 (2677:2:0) -> 2508:2:0
 // ElementaryTypeName#219 (2701:6:0) -> 2532:6:0
 // VariableDeclaration#220 (2701:6:0) -> 2532:6:0
@@ -412,7 +412,7 @@ contract PublicVarOverride is SomeInterface {
 // Return#226 (2719:40:0) -> 2550:40:0
 // Block#227 (2709:57:0) -> 2540:57:0
 // FunctionDefinition#228 (2653:113:0) -> 2484:113:0
-// StructuredDocumentation#229 (2772:31:0) -> 2603:36:0
+// StructuredDocumentation#229 (2772:31:0) -> 2603:31:0
 // ParameterList#230 (2827:2:0) -> 2658:2:0
 // ElementaryTypeName#232 (2853:4:0) -> 2684:4:0
 // VariableDeclaration#233 (2853:6:0) -> 2684:6:0
@@ -687,7 +687,7 @@ contract PublicVarOverride is SomeInterface {
 // Block#520 (4623:2:0) -> 4454:2:0
 // FunctionDefinition#521 (4603:22:0) -> 4434:22:0
 // ContractDefinition#522 (1230:3397:0) -> 1062:3396:0
-// StructuredDocumentation#523 (4658:29:0) -> 4489:34:0
+// StructuredDocumentation#523 (4658:29:0) -> 4489:29:0
 // ElementaryTypeName#524 (4692:4:0) -> 4523:4:0
 // ArrayTypeName#525 (4692:6:0) -> 4523:6:0
 // VariableDeclaration#526 (4692:22:0) -> 4523:22:0
@@ -813,7 +813,7 @@ contract PublicVarOverride is SomeInterface {
 // ContractDefinition#653 (5496:88:0) -> 5289:88:0
 // UserDefinedTypeName#654 (5616:13:0) -> 5409:13:0
 // InheritanceSpecifier#655 (5616:13:0) -> 5409:13:0
-// StructuredDocumentation#656 (5636:60:0) -> 5429:64:0
+// StructuredDocumentation#656 (5636:60:0) -> 5429:59:0
 // ElementaryTypeName#657 (5701:15:0) -> 5493:15:0
 // OverrideSpecifier#658 (5734:8:0) -> 5526:8:0
 // ElementaryTypeName#659 (5750:7:0) -> 5542:7:0

--- a/test/samples/solidity/latest_08.nodes.native.txt
+++ b/test/samples/solidity/latest_08.nodes.native.txt
@@ -165,6 +165,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #735 ]
         <getter> vUsedErrors: Array(0)
@@ -297,10 +298,12 @@ SourceUnit #1400
             Block #733
                 id: 733
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #734
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #726, UncheckedBlock #730, Return #732 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(3) [ VariableDeclarationStatement #726, UncheckedBlock #730, Return #732 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #726
@@ -396,10 +399,12 @@ SourceUnit #1400
                 UncheckedBlock #730
                     id: 730
                     src: "0:0:0"
-                    documentation: undefined
+                    docString: undefined
                     context: ASTContext #1000
                     parent: Block #733
                     <getter> vStatements: Array(1) [ ExpressionStatement #729 ]
+                    <getter> documentation: undefined
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(1) [ ExpressionStatement #729 ]
                     <getter> type: "UncheckedBlock"
                     <getter> firstChild: ExpressionStatement #729
@@ -514,6 +519,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(2) [ ContractDefinition #771, ContractDefinition #709 ]
         <getter> vUsedErrors: Array(0)
@@ -738,10 +744,12 @@ SourceUnit #1400
             Block #746
                 id: 746
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #747
                 <getter> vStatements: Array(0)
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(0)
                 <getter> type: "Block"
                 <getter> firstChild: undefined
@@ -814,10 +822,12 @@ SourceUnit #1400
             Block #759
                 id: 759
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #760
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #758 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #758 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #758
@@ -1152,10 +1162,12 @@ SourceUnit #1400
             Block #769
                 id: 769
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #770
                 <getter> vStatements: Array(1) [ Return #768 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #768 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #768
@@ -1217,6 +1229,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #792 ]
         <getter> vUsedErrors: Array(0)
@@ -1303,10 +1316,12 @@ SourceUnit #1400
             Block #790
                 id: 790
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #791
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #781, VariableDeclarationStatement #789 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ VariableDeclarationStatement #781, VariableDeclarationStatement #789 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #781
@@ -1651,6 +1666,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #849 ]
         <getter> vUsedErrors: Array(0)
@@ -1737,10 +1753,12 @@ SourceUnit #1400
             Block #847
                 id: 847
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #848
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #802, TryStatement #846 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ VariableDeclarationStatement #802, TryStatement #846 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #802
@@ -2011,10 +2029,12 @@ SourceUnit #1400
                         Block #806
                             id: 806
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #807
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -2106,10 +2126,12 @@ SourceUnit #1400
                         Block #812
                             id: 812
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #816
                             <getter> vStatements: Array(1) [ ExpressionStatement #811 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ ExpressionStatement #811 ]
                             <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #811
@@ -2280,10 +2302,12 @@ SourceUnit #1400
                         Block #835
                             id: 835
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #839
                             <getter> vStatements: Array(1) [ IfStatement #834 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ IfStatement #834 ]
                             <getter> type: "Block"
                             <getter> firstChild: IfStatement #834
@@ -2370,10 +2394,12 @@ SourceUnit #1400
                                 Block #824
                                     id: 824
                                     src: "0:0:0"
-                                    documentation: undefined
+                                    docString: undefined
                                     context: ASTContext #1000
                                     parent: IfStatement #834
                                     <getter> vStatements: Array(1) [ ExpressionStatement #823 ]
+                                    <getter> documentation: undefined
+                                    <getter> danglingDocumentation: undefined
                                     <getter> children: Array(1) [ ExpressionStatement #823 ]
                                     <getter> type: "Block"
                                     <getter> firstChild: ExpressionStatement #823
@@ -2539,10 +2565,12 @@ SourceUnit #1400
                                     Block #832
                                         id: 832
                                         src: "0:0:0"
-                                        documentation: undefined
+                                        docString: undefined
                                         context: ASTContext #1000
                                         parent: IfStatement #833
                                         <getter> vStatements: Array(1) [ ExpressionStatement #831 ]
+                                        <getter> documentation: undefined
+                                        <getter> danglingDocumentation: undefined
                                         <getter> children: Array(1) [ ExpressionStatement #831 ]
                                         <getter> type: "Block"
                                         <getter> firstChild: ExpressionStatement #831
@@ -2652,10 +2680,12 @@ SourceUnit #1400
                         Block #844
                             id: 844
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #845
                             <getter> vStatements: Array(1) [ ExpressionStatement #843 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ ExpressionStatement #843 ]
                             <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #843
@@ -2759,6 +2789,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #934 ]
         <getter> vUsedErrors: Array(0)
@@ -2971,10 +3002,12 @@ SourceUnit #1400
             Block #860
                 id: 860
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: ModifierDefinition #861
                 <getter> vStatements: Array(1) [ PlaceholderStatement #859 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ PlaceholderStatement #859 ]
                 <getter> type: "Block"
                 <getter> firstChild: PlaceholderStatement #859
@@ -2990,8 +3023,8 @@ SourceUnit #1400
                     documentation: "PlaceholderStatement docstring"
                     context: ASTContext #1000
                     parent: Block #860
-                    <getter> type: "PlaceholderStatement"
                     <getter> children: Array(0)
+                    <getter> type: "PlaceholderStatement"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -3097,10 +3130,12 @@ SourceUnit #1400
             Block #932
                 id: 932
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #933
                 <getter> vStatements: Array(13) [ VariableDeclarationStatement #870, ExpressionStatement #872, Block #873, EmitStatement #877, WhileStatement #881, DoWhileStatement #885, ForStatement #898, IfStatement #902, VariableDeclarationStatement #910, TryStatement #928, InlineAssembly #929, UncheckedBlock #930, Return #931 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(13) [ VariableDeclarationStatement #870, ExpressionStatement #872, Block #873, EmitStatement #877, WhileStatement #881, DoWhileStatement #885, ForStatement #898, IfStatement #902, VariableDeclarationStatement #910, TryStatement #928, InlineAssembly #929, UncheckedBlock #930, Return #931 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #870
@@ -3250,10 +3285,12 @@ SourceUnit #1400
                 Block #873
                     id: 873
                     src: "0:0:0"
-                    documentation: "Block docstring"
+                    docString: "Block docstring"
                     context: ASTContext #1000
                     parent: Block #932
                     <getter> vStatements: Array(0)
+                    <getter> documentation: "Block docstring"
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(0)
                     <getter> type: "Block"
                     <getter> firstChild: undefined
@@ -3381,10 +3418,12 @@ SourceUnit #1400
                     Block #880
                         id: 880
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: WhileStatement #881
                         <getter> vStatements: Array(1) [ Continue #879 ]
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(1) [ Continue #879 ]
                         <getter> type: "Block"
                         <getter> firstChild: Continue #879
@@ -3400,8 +3439,8 @@ SourceUnit #1400
                             documentation: "Continue docstring"
                             context: ASTContext #1000
                             parent: Block #880
-                            <getter> type: "Continue"
                             <getter> children: Array(0)
+                            <getter> type: "Continue"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -3448,10 +3487,12 @@ SourceUnit #1400
                     Block #884
                         id: 884
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: DoWhileStatement #885
                         <getter> vStatements: Array(1) [ Break #883 ]
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(1) [ Break #883 ]
                         <getter> type: "Block"
                         <getter> firstChild: Break #883
@@ -3467,8 +3508,8 @@ SourceUnit #1400
                             documentation: "Break docstring"
                             context: ASTContext #1000
                             parent: Block #884
-                            <getter> type: "Break"
                             <getter> children: Array(0)
+                            <getter> type: "Break"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -3709,10 +3750,12 @@ SourceUnit #1400
                     Block #886
                         id: 886
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: ForStatement #898
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -3762,10 +3805,12 @@ SourceUnit #1400
                     Block #900
                         id: 900
                         src: "0:0:0"
-                        documentation: "True body Block docstring"
+                        docString: "True body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #902
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "True body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -3778,10 +3823,12 @@ SourceUnit #1400
                     Block #901
                         id: 901
                         src: "0:0:0"
-                        documentation: "False body Block docstring"
+                        docString: "False body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #902
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "False body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -4052,10 +4099,12 @@ SourceUnit #1400
                         Block #914
                             id: 914
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #915
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4147,10 +4196,12 @@ SourceUnit #1400
                         Block #916
                             id: 916
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #920
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4242,10 +4293,12 @@ SourceUnit #1400
                         Block #921
                             id: 921
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #925
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4276,10 +4329,12 @@ SourceUnit #1400
                         Block #926
                             id: 926
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #927
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4300,8 +4355,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #932
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: TryStatement #928
@@ -4312,10 +4367,12 @@ SourceUnit #1400
                 UncheckedBlock #930
                     id: 930
                     src: "0:0:0"
-                    documentation: "UncheckedBlock docstring"
+                    docString: "UncheckedBlock docstring"
                     context: ASTContext #1000
                     parent: Block #932
                     <getter> vStatements: Array(0)
+                    <getter> documentation: "UncheckedBlock docstring"
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(0)
                     <getter> type: "UncheckedBlock"
                     <getter> firstChild: undefined
@@ -4453,6 +4510,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #945 ]
         <getter> vUsedErrors: Array(1) [ ErrorDefinition #944 ]
@@ -4586,6 +4644,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1003 ]
         <getter> vUsedErrors: Array(3) [ ErrorDefinition #939, ErrorDefinition #944, ErrorDefinition #948 ]
@@ -4721,10 +4780,12 @@ SourceUnit #1400
             Block #952
                 id: 952
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #953
                 <getter> vStatements: Array(1) [ InlineAssembly #951 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ InlineAssembly #951 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #951
@@ -4745,8 +4806,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #952
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -4955,10 +5016,12 @@ SourceUnit #1400
             Block #969
                 id: 969
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #970
                 <getter> vStatements: Array(1) [ Return #968 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #968 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #968
@@ -5164,10 +5227,12 @@ SourceUnit #1400
             Block #977
                 id: 977
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #978
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #976 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #976 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #976
@@ -5323,10 +5388,12 @@ SourceUnit #1400
             Block #986
                 id: 986
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #987
                 <getter> vStatements: Array(1) [ RevertStatement #985 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #985 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #985
@@ -5497,10 +5564,12 @@ SourceUnit #1400
             Block #993
                 id: 993
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #994
                 <getter> vStatements: Array(1) [ RevertStatement #992 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #992 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #992
@@ -5633,10 +5702,12 @@ SourceUnit #1400
             Block #1001
                 id: 1001
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1002
                 <getter> vStatements: Array(1) [ RevertStatement #1000 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #1000 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #1000
@@ -5740,6 +5811,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1020 ]
         <getter> vUsedErrors: Array(0)
@@ -5872,10 +5944,12 @@ SourceUnit #1400
             Block #1011
                 id: 1011
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1012
                 <getter> vStatements: Array(1) [ Return #1010 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1010 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1010
@@ -6050,10 +6124,12 @@ SourceUnit #1400
             Block #1018
                 id: 1018
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1019
                 <getter> vStatements: Array(1) [ InlineAssembly #1017 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ InlineAssembly #1017 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #1017
@@ -6074,8 +6150,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1018
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -6170,6 +6246,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1112 ]
         <getter> vUsedErrors: Array(0)
@@ -6589,10 +6666,12 @@ SourceUnit #1400
             Block #1056
                 id: 1056
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1057
                 <getter> vStatements: Array(1) [ Return #1055 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1055 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1055
@@ -7104,10 +7183,12 @@ SourceUnit #1400
             Block #1078
                 id: 1078
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1079
                 <getter> vStatements: Array(1) [ Return #1077 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1077 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1077
@@ -7491,10 +7572,12 @@ SourceUnit #1400
             Block #1094
                 id: 1094
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1095
                 <getter> vStatements: Array(1) [ Return #1093 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1093 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1093
@@ -7815,10 +7898,12 @@ SourceUnit #1400
             Block #1110
                 id: 1110
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1111
                 <getter> vStatements: Array(1) [ Return #1109 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1109 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1109
@@ -7980,6 +8065,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1123 ]
         <getter> vUsedErrors: Array(0)
@@ -8225,6 +8311,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1148 ]
         <getter> vUsedErrors: Array(0)
@@ -8311,10 +8398,12 @@ SourceUnit #1400
             Block #1146
                 id: 1146
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1147
                 <getter> vStatements: Array(2) [ ExpressionStatement #1135, ExpressionStatement #1145 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ ExpressionStatement #1135, ExpressionStatement #1145 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #1135
@@ -8735,6 +8824,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1179 ]
         <getter> vUsedErrors: Array(0)
@@ -8821,10 +8911,12 @@ SourceUnit #1400
             Block #1151
                 id: 1151
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1152
                 <getter> vStatements: Array(0)
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(0)
                 <getter> type: "Block"
                 <getter> firstChild: undefined
@@ -9081,10 +9173,12 @@ SourceUnit #1400
             Block #1177
                 id: 1177
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1178
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #1169, InlineAssembly #1170, Return #1176 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(3) [ VariableDeclarationStatement #1169, InlineAssembly #1170, Return #1176 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1169
@@ -9239,8 +9333,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1177
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: VariableDeclarationStatement #1169
@@ -9376,6 +9470,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1218 ]
         <getter> vUsedErrors: Array(0)
@@ -9738,10 +9833,12 @@ SourceUnit #1400
             Block #1199
                 id: 1199
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1200
                 <getter> vStatements: Array(1) [ Return #1198 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1198 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1198
@@ -9908,10 +10005,12 @@ SourceUnit #1400
             Block #1216
                 id: 1216
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1217
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #1215 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #1215 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1215
@@ -10195,6 +10294,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1281 ]
         <getter> vUsedErrors: Array(0)
@@ -10359,10 +10459,12 @@ SourceUnit #1400
             Block #1279
                 id: 1279
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1280
                 <getter> vStatements: Array(10) [ VariableDeclarationStatement #1229, VariableDeclarationStatement #1234, ExpressionStatement #1238, ExpressionStatement #1242, ExpressionStatement #1246, ExpressionStatement #1250, ExpressionStatement #1261, VariableDeclarationStatement #1265, VariableDeclarationStatement #1269, VariableDeclarationStatement #1278 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(10) [ VariableDeclarationStatement #1229, VariableDeclarationStatement #1234, ExpressionStatement #1238, ExpressionStatement #1242, ExpressionStatement #1246, ExpressionStatement #1250, ExpressionStatement #1261, VariableDeclarationStatement #1265, VariableDeclarationStatement #1269, VariableDeclarationStatement #1278 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1229
@@ -11811,10 +11913,12 @@ SourceUnit #1400
         Block #1313
             id: 1313
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1314
             <getter> vStatements: Array(1) [ UncheckedBlock #1312 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(1) [ UncheckedBlock #1312 ]
             <getter> type: "Block"
             <getter> firstChild: UncheckedBlock #1312
@@ -11827,10 +11931,12 @@ SourceUnit #1400
             UncheckedBlock #1312
                 id: 1312
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: Block #1313
                 <getter> vStatements: Array(1) [ Return #1311 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1311 ]
                 <getter> type: "UncheckedBlock"
                 <getter> firstChild: Return #1311
@@ -12233,10 +12339,12 @@ SourceUnit #1400
         Block #1334
             id: 1334
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1335
             <getter> vStatements: Array(1) [ UncheckedBlock #1333 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(1) [ UncheckedBlock #1333 ]
             <getter> type: "Block"
             <getter> firstChild: UncheckedBlock #1333
@@ -12249,10 +12357,12 @@ SourceUnit #1400
             UncheckedBlock #1333
                 id: 1333
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: Block #1334
                 <getter> vStatements: Array(1) [ Return #1332 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1332 ]
                 <getter> type: "UncheckedBlock"
                 <getter> firstChild: Return #1332
@@ -12636,10 +12746,12 @@ SourceUnit #1400
         Block #1362
             id: 1362
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1363
             <getter> vStatements: Array(2) [ ExpressionStatement #1356, Return #1361 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(2) [ ExpressionStatement #1356, Return #1361 ]
             <getter> type: "Block"
             <getter> firstChild: ExpressionStatement #1356
@@ -13029,6 +13141,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1392 ]
         <getter> vUsedErrors: Array(0)
@@ -13310,10 +13423,12 @@ SourceUnit #1400
             Block #1390
                 id: 1390
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1391
                 <getter> vStatements: Array(1) [ ExpressionStatement #1389 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #1389 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #1389
@@ -13636,6 +13751,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1399 ]
         <getter> vUsedErrors: Array(0)
@@ -13722,10 +13838,12 @@ SourceUnit #1400
             Block #1397
                 id: 1397
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1398
                 <getter> vStatements: Array(2) [ InlineAssembly #1395, InlineAssembly #1396 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ InlineAssembly #1395, InlineAssembly #1396 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #1395
@@ -13746,8 +13864,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1397
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -13766,8 +13884,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1397
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: InlineAssembly #1395
@@ -13852,6 +13970,7 @@ SourceUnit #1416
         context: ASTContext #1000
         parent: SourceUnit #1416
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1416
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1414 ]
         <getter> vUsedErrors: Array(0)
@@ -14051,10 +14170,12 @@ SourceUnit #1416
             Block #1412
                 id: 1412
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1413
                 <getter> vStatements: Array(1) [ Return #1411 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1411 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1411
@@ -14116,6 +14237,7 @@ SourceUnit #1416
         context: ASTContext #1000
         parent: SourceUnit #1416
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1416
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1415 ]
         <getter> vUsedErrors: Array(0)

--- a/test/samples/solidity/latest_08.nodes.wasm.txt
+++ b/test/samples/solidity/latest_08.nodes.wasm.txt
@@ -165,6 +165,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #735 ]
         <getter> vUsedErrors: Array(0)
@@ -297,10 +298,12 @@ SourceUnit #1400
             Block #733
                 id: 733
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #734
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #726, UncheckedBlock #730, Return #732 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(3) [ VariableDeclarationStatement #726, UncheckedBlock #730, Return #732 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #726
@@ -396,10 +399,12 @@ SourceUnit #1400
                 UncheckedBlock #730
                     id: 730
                     src: "0:0:0"
-                    documentation: undefined
+                    docString: undefined
                     context: ASTContext #1000
                     parent: Block #733
                     <getter> vStatements: Array(1) [ ExpressionStatement #729 ]
+                    <getter> documentation: undefined
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(1) [ ExpressionStatement #729 ]
                     <getter> type: "UncheckedBlock"
                     <getter> firstChild: ExpressionStatement #729
@@ -514,6 +519,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(2) [ ContractDefinition #771, ContractDefinition #709 ]
         <getter> vUsedErrors: Array(0)
@@ -738,10 +744,12 @@ SourceUnit #1400
             Block #746
                 id: 746
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #747
                 <getter> vStatements: Array(0)
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(0)
                 <getter> type: "Block"
                 <getter> firstChild: undefined
@@ -814,10 +822,12 @@ SourceUnit #1400
             Block #759
                 id: 759
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #760
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #758 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #758 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #758
@@ -1152,10 +1162,12 @@ SourceUnit #1400
             Block #769
                 id: 769
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #770
                 <getter> vStatements: Array(1) [ Return #768 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #768 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #768
@@ -1217,6 +1229,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #792 ]
         <getter> vUsedErrors: Array(0)
@@ -1303,10 +1316,12 @@ SourceUnit #1400
             Block #790
                 id: 790
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #791
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #781, VariableDeclarationStatement #789 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ VariableDeclarationStatement #781, VariableDeclarationStatement #789 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #781
@@ -1651,6 +1666,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #849 ]
         <getter> vUsedErrors: Array(0)
@@ -1737,10 +1753,12 @@ SourceUnit #1400
             Block #847
                 id: 847
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #848
                 <getter> vStatements: Array(2) [ VariableDeclarationStatement #802, TryStatement #846 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ VariableDeclarationStatement #802, TryStatement #846 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #802
@@ -2011,10 +2029,12 @@ SourceUnit #1400
                         Block #806
                             id: 806
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #807
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -2106,10 +2126,12 @@ SourceUnit #1400
                         Block #812
                             id: 812
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #816
                             <getter> vStatements: Array(1) [ ExpressionStatement #811 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ ExpressionStatement #811 ]
                             <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #811
@@ -2280,10 +2302,12 @@ SourceUnit #1400
                         Block #835
                             id: 835
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #839
                             <getter> vStatements: Array(1) [ IfStatement #834 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ IfStatement #834 ]
                             <getter> type: "Block"
                             <getter> firstChild: IfStatement #834
@@ -2370,10 +2394,12 @@ SourceUnit #1400
                                 Block #824
                                     id: 824
                                     src: "0:0:0"
-                                    documentation: undefined
+                                    docString: undefined
                                     context: ASTContext #1000
                                     parent: IfStatement #834
                                     <getter> vStatements: Array(1) [ ExpressionStatement #823 ]
+                                    <getter> documentation: undefined
+                                    <getter> danglingDocumentation: undefined
                                     <getter> children: Array(1) [ ExpressionStatement #823 ]
                                     <getter> type: "Block"
                                     <getter> firstChild: ExpressionStatement #823
@@ -2539,10 +2565,12 @@ SourceUnit #1400
                                     Block #832
                                         id: 832
                                         src: "0:0:0"
-                                        documentation: undefined
+                                        docString: undefined
                                         context: ASTContext #1000
                                         parent: IfStatement #833
                                         <getter> vStatements: Array(1) [ ExpressionStatement #831 ]
+                                        <getter> documentation: undefined
+                                        <getter> danglingDocumentation: undefined
                                         <getter> children: Array(1) [ ExpressionStatement #831 ]
                                         <getter> type: "Block"
                                         <getter> firstChild: ExpressionStatement #831
@@ -2652,10 +2680,12 @@ SourceUnit #1400
                         Block #844
                             id: 844
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #845
                             <getter> vStatements: Array(1) [ ExpressionStatement #843 ]
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(1) [ ExpressionStatement #843 ]
                             <getter> type: "Block"
                             <getter> firstChild: ExpressionStatement #843
@@ -2759,6 +2789,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #934 ]
         <getter> vUsedErrors: Array(0)
@@ -2971,10 +3002,12 @@ SourceUnit #1400
             Block #860
                 id: 860
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: ModifierDefinition #861
                 <getter> vStatements: Array(1) [ PlaceholderStatement #859 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ PlaceholderStatement #859 ]
                 <getter> type: "Block"
                 <getter> firstChild: PlaceholderStatement #859
@@ -2990,8 +3023,8 @@ SourceUnit #1400
                     documentation: "PlaceholderStatement docstring"
                     context: ASTContext #1000
                     parent: Block #860
-                    <getter> type: "PlaceholderStatement"
                     <getter> children: Array(0)
+                    <getter> type: "PlaceholderStatement"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -3097,10 +3130,12 @@ SourceUnit #1400
             Block #932
                 id: 932
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #933
                 <getter> vStatements: Array(13) [ VariableDeclarationStatement #870, ExpressionStatement #872, Block #873, EmitStatement #877, WhileStatement #881, DoWhileStatement #885, ForStatement #898, IfStatement #902, VariableDeclarationStatement #910, TryStatement #928, InlineAssembly #929, UncheckedBlock #930, Return #931 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(13) [ VariableDeclarationStatement #870, ExpressionStatement #872, Block #873, EmitStatement #877, WhileStatement #881, DoWhileStatement #885, ForStatement #898, IfStatement #902, VariableDeclarationStatement #910, TryStatement #928, InlineAssembly #929, UncheckedBlock #930, Return #931 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #870
@@ -3250,10 +3285,12 @@ SourceUnit #1400
                 Block #873
                     id: 873
                     src: "0:0:0"
-                    documentation: "Block docstring"
+                    docString: "Block docstring"
                     context: ASTContext #1000
                     parent: Block #932
                     <getter> vStatements: Array(0)
+                    <getter> documentation: "Block docstring"
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(0)
                     <getter> type: "Block"
                     <getter> firstChild: undefined
@@ -3381,10 +3418,12 @@ SourceUnit #1400
                     Block #880
                         id: 880
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: WhileStatement #881
                         <getter> vStatements: Array(1) [ Continue #879 ]
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(1) [ Continue #879 ]
                         <getter> type: "Block"
                         <getter> firstChild: Continue #879
@@ -3400,8 +3439,8 @@ SourceUnit #1400
                             documentation: "Continue docstring"
                             context: ASTContext #1000
                             parent: Block #880
-                            <getter> type: "Continue"
                             <getter> children: Array(0)
+                            <getter> type: "Continue"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -3448,10 +3487,12 @@ SourceUnit #1400
                     Block #884
                         id: 884
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: DoWhileStatement #885
                         <getter> vStatements: Array(1) [ Break #883 ]
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(1) [ Break #883 ]
                         <getter> type: "Block"
                         <getter> firstChild: Break #883
@@ -3467,8 +3508,8 @@ SourceUnit #1400
                             documentation: "Break docstring"
                             context: ASTContext #1000
                             parent: Block #884
-                            <getter> type: "Break"
                             <getter> children: Array(0)
+                            <getter> type: "Break"
                             <getter> firstChild: undefined
                             <getter> lastChild: undefined
                             <getter> previousSibling: undefined
@@ -3709,10 +3750,12 @@ SourceUnit #1400
                     Block #886
                         id: 886
                         src: "0:0:0"
-                        documentation: "Body Block docstring"
+                        docString: "Body Block docstring"
                         context: ASTContext #1000
                         parent: ForStatement #898
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "Body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -3762,10 +3805,12 @@ SourceUnit #1400
                     Block #900
                         id: 900
                         src: "0:0:0"
-                        documentation: "True body Block docstring"
+                        docString: "True body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #902
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "True body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -3778,10 +3823,12 @@ SourceUnit #1400
                     Block #901
                         id: 901
                         src: "0:0:0"
-                        documentation: "False body Block docstring"
+                        docString: "False body Block docstring"
                         context: ASTContext #1000
                         parent: IfStatement #902
                         <getter> vStatements: Array(0)
+                        <getter> documentation: "False body Block docstring"
+                        <getter> danglingDocumentation: undefined
                         <getter> children: Array(0)
                         <getter> type: "Block"
                         <getter> firstChild: undefined
@@ -4052,10 +4099,12 @@ SourceUnit #1400
                         Block #914
                             id: 914
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #915
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4147,10 +4196,12 @@ SourceUnit #1400
                         Block #916
                             id: 916
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #920
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4242,10 +4293,12 @@ SourceUnit #1400
                         Block #921
                             id: 921
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #925
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4276,10 +4329,12 @@ SourceUnit #1400
                         Block #926
                             id: 926
                             src: "0:0:0"
-                            documentation: undefined
+                            docString: undefined
                             context: ASTContext #1000
                             parent: TryCatchClause #927
                             <getter> vStatements: Array(0)
+                            <getter> documentation: undefined
+                            <getter> danglingDocumentation: undefined
                             <getter> children: Array(0)
                             <getter> type: "Block"
                             <getter> firstChild: undefined
@@ -4300,8 +4355,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #932
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: TryStatement #928
@@ -4312,10 +4367,12 @@ SourceUnit #1400
                 UncheckedBlock #930
                     id: 930
                     src: "0:0:0"
-                    documentation: "UncheckedBlock docstring"
+                    docString: "UncheckedBlock docstring"
                     context: ASTContext #1000
                     parent: Block #932
                     <getter> vStatements: Array(0)
+                    <getter> documentation: "UncheckedBlock docstring"
+                    <getter> danglingDocumentation: undefined
                     <getter> children: Array(0)
                     <getter> type: "UncheckedBlock"
                     <getter> firstChild: undefined
@@ -4453,6 +4510,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #945 ]
         <getter> vUsedErrors: Array(1) [ ErrorDefinition #944 ]
@@ -4586,6 +4644,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1003 ]
         <getter> vUsedErrors: Array(3) [ ErrorDefinition #939, ErrorDefinition #944, ErrorDefinition #948 ]
@@ -4721,10 +4780,12 @@ SourceUnit #1400
             Block #952
                 id: 952
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #953
                 <getter> vStatements: Array(1) [ InlineAssembly #951 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ InlineAssembly #951 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #951
@@ -4745,8 +4806,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #952
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -4955,10 +5016,12 @@ SourceUnit #1400
             Block #969
                 id: 969
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #970
                 <getter> vStatements: Array(1) [ Return #968 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #968 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #968
@@ -5164,10 +5227,12 @@ SourceUnit #1400
             Block #977
                 id: 977
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #978
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #976 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #976 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #976
@@ -5323,10 +5388,12 @@ SourceUnit #1400
             Block #986
                 id: 986
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #987
                 <getter> vStatements: Array(1) [ RevertStatement #985 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #985 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #985
@@ -5497,10 +5564,12 @@ SourceUnit #1400
             Block #993
                 id: 993
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #994
                 <getter> vStatements: Array(1) [ RevertStatement #992 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #992 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #992
@@ -5633,10 +5702,12 @@ SourceUnit #1400
             Block #1001
                 id: 1001
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1002
                 <getter> vStatements: Array(1) [ RevertStatement #1000 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ RevertStatement #1000 ]
                 <getter> type: "Block"
                 <getter> firstChild: RevertStatement #1000
@@ -5740,6 +5811,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1020 ]
         <getter> vUsedErrors: Array(0)
@@ -5872,10 +5944,12 @@ SourceUnit #1400
             Block #1011
                 id: 1011
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1012
                 <getter> vStatements: Array(1) [ Return #1010 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1010 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1010
@@ -6050,10 +6124,12 @@ SourceUnit #1400
             Block #1018
                 id: 1018
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1019
                 <getter> vStatements: Array(1) [ InlineAssembly #1017 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ InlineAssembly #1017 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #1017
@@ -6074,8 +6150,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1018
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -6170,6 +6246,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1112 ]
         <getter> vUsedErrors: Array(0)
@@ -6589,10 +6666,12 @@ SourceUnit #1400
             Block #1056
                 id: 1056
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1057
                 <getter> vStatements: Array(1) [ Return #1055 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1055 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1055
@@ -7104,10 +7183,12 @@ SourceUnit #1400
             Block #1078
                 id: 1078
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1079
                 <getter> vStatements: Array(1) [ Return #1077 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1077 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1077
@@ -7491,10 +7572,12 @@ SourceUnit #1400
             Block #1094
                 id: 1094
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1095
                 <getter> vStatements: Array(1) [ Return #1093 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1093 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1093
@@ -7815,10 +7898,12 @@ SourceUnit #1400
             Block #1110
                 id: 1110
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1111
                 <getter> vStatements: Array(1) [ Return #1109 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1109 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1109
@@ -7980,6 +8065,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1123 ]
         <getter> vUsedErrors: Array(0)
@@ -8225,6 +8311,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1148 ]
         <getter> vUsedErrors: Array(0)
@@ -8311,10 +8398,12 @@ SourceUnit #1400
             Block #1146
                 id: 1146
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1147
                 <getter> vStatements: Array(2) [ ExpressionStatement #1135, ExpressionStatement #1145 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ ExpressionStatement #1135, ExpressionStatement #1145 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #1135
@@ -8735,6 +8824,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1179 ]
         <getter> vUsedErrors: Array(0)
@@ -8821,10 +8911,12 @@ SourceUnit #1400
             Block #1151
                 id: 1151
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1152
                 <getter> vStatements: Array(0)
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(0)
                 <getter> type: "Block"
                 <getter> firstChild: undefined
@@ -9081,10 +9173,12 @@ SourceUnit #1400
             Block #1177
                 id: 1177
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1178
                 <getter> vStatements: Array(3) [ VariableDeclarationStatement #1169, InlineAssembly #1170, Return #1176 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(3) [ VariableDeclarationStatement #1169, InlineAssembly #1170, Return #1176 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1169
@@ -9239,8 +9333,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1177
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: VariableDeclarationStatement #1169
@@ -9376,6 +9470,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1218 ]
         <getter> vUsedErrors: Array(0)
@@ -9738,10 +9833,12 @@ SourceUnit #1400
             Block #1199
                 id: 1199
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1200
                 <getter> vStatements: Array(1) [ Return #1198 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1198 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1198
@@ -9908,10 +10005,12 @@ SourceUnit #1400
             Block #1216
                 id: 1216
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1217
                 <getter> vStatements: Array(1) [ VariableDeclarationStatement #1215 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ VariableDeclarationStatement #1215 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1215
@@ -10195,6 +10294,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1281 ]
         <getter> vUsedErrors: Array(0)
@@ -10359,10 +10459,12 @@ SourceUnit #1400
             Block #1279
                 id: 1279
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1280
                 <getter> vStatements: Array(10) [ VariableDeclarationStatement #1229, VariableDeclarationStatement #1234, ExpressionStatement #1238, ExpressionStatement #1242, ExpressionStatement #1246, ExpressionStatement #1250, ExpressionStatement #1261, VariableDeclarationStatement #1265, VariableDeclarationStatement #1269, VariableDeclarationStatement #1278 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(10) [ VariableDeclarationStatement #1229, VariableDeclarationStatement #1234, ExpressionStatement #1238, ExpressionStatement #1242, ExpressionStatement #1246, ExpressionStatement #1250, ExpressionStatement #1261, VariableDeclarationStatement #1265, VariableDeclarationStatement #1269, VariableDeclarationStatement #1278 ]
                 <getter> type: "Block"
                 <getter> firstChild: VariableDeclarationStatement #1229
@@ -11811,10 +11913,12 @@ SourceUnit #1400
         Block #1313
             id: 1313
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1314
             <getter> vStatements: Array(1) [ UncheckedBlock #1312 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(1) [ UncheckedBlock #1312 ]
             <getter> type: "Block"
             <getter> firstChild: UncheckedBlock #1312
@@ -11827,10 +11931,12 @@ SourceUnit #1400
             UncheckedBlock #1312
                 id: 1312
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: Block #1313
                 <getter> vStatements: Array(1) [ Return #1311 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1311 ]
                 <getter> type: "UncheckedBlock"
                 <getter> firstChild: Return #1311
@@ -12233,10 +12339,12 @@ SourceUnit #1400
         Block #1334
             id: 1334
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1335
             <getter> vStatements: Array(1) [ UncheckedBlock #1333 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(1) [ UncheckedBlock #1333 ]
             <getter> type: "Block"
             <getter> firstChild: UncheckedBlock #1333
@@ -12249,10 +12357,12 @@ SourceUnit #1400
             UncheckedBlock #1333
                 id: 1333
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: Block #1334
                 <getter> vStatements: Array(1) [ Return #1332 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1332 ]
                 <getter> type: "UncheckedBlock"
                 <getter> firstChild: Return #1332
@@ -12636,10 +12746,12 @@ SourceUnit #1400
         Block #1362
             id: 1362
             src: "0:0:0"
-            documentation: undefined
+            docString: undefined
             context: ASTContext #1000
             parent: FunctionDefinition #1363
             <getter> vStatements: Array(2) [ ExpressionStatement #1356, Return #1361 ]
+            <getter> documentation: undefined
+            <getter> danglingDocumentation: undefined
             <getter> children: Array(2) [ ExpressionStatement #1356, Return #1361 ]
             <getter> type: "Block"
             <getter> firstChild: ExpressionStatement #1356
@@ -13029,6 +13141,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1392 ]
         <getter> vUsedErrors: Array(0)
@@ -13310,10 +13423,12 @@ SourceUnit #1400
             Block #1390
                 id: 1390
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1391
                 <getter> vStatements: Array(1) [ ExpressionStatement #1389 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ ExpressionStatement #1389 ]
                 <getter> type: "Block"
                 <getter> firstChild: ExpressionStatement #1389
@@ -13636,6 +13751,7 @@ SourceUnit #1400
         context: ASTContext #1000
         parent: SourceUnit #1400
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1400
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1399 ]
         <getter> vUsedErrors: Array(0)
@@ -13722,10 +13838,12 @@ SourceUnit #1400
             Block #1397
                 id: 1397
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1398
                 <getter> vStatements: Array(2) [ InlineAssembly #1395, InlineAssembly #1396 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(2) [ InlineAssembly #1395, InlineAssembly #1396 ]
                 <getter> type: "Block"
                 <getter> firstChild: InlineAssembly #1395
@@ -13746,8 +13864,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1397
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: undefined
@@ -13766,8 +13884,8 @@ SourceUnit #1400
                     evmVersion: "london"
                     context: ASTContext #1000
                     parent: Block #1397
-                    <getter> type: "InlineAssembly"
                     <getter> children: Array(0)
+                    <getter> type: "InlineAssembly"
                     <getter> firstChild: undefined
                     <getter> lastChild: undefined
                     <getter> previousSibling: InlineAssembly #1395
@@ -13852,6 +13970,7 @@ SourceUnit #1416
         context: ASTContext #1000
         parent: SourceUnit #1416
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1416
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1414 ]
         <getter> vUsedErrors: Array(0)
@@ -14051,10 +14170,12 @@ SourceUnit #1416
             Block #1412
                 id: 1412
                 src: "0:0:0"
-                documentation: undefined
+                docString: undefined
                 context: ASTContext #1000
                 parent: FunctionDefinition #1413
                 <getter> vStatements: Array(1) [ Return #1411 ]
+                <getter> documentation: undefined
+                <getter> danglingDocumentation: undefined
                 <getter> children: Array(1) [ Return #1411 ]
                 <getter> type: "Block"
                 <getter> firstChild: Return #1411
@@ -14116,6 +14237,7 @@ SourceUnit #1416
         context: ASTContext #1000
         parent: SourceUnit #1416
         <getter> documentation: undefined
+        <getter> danglingDocumentation: undefined
         <getter> vScope: SourceUnit #1416
         <getter> vLinearizedBaseContracts: Array(1) [ ContractDefinition #1415 ]
         <getter> vUsedErrors: Array(0)

--- a/test/samples/solidity/struct_docs_05.sol
+++ b/test/samples/solidity/struct_docs_05.sol
@@ -9,7 +9,7 @@ contract StmtDocs04 {
 
     modifier modStructDocs() {
         /// PlaceholderStatement docstring
-        _;
+        _; /// Modifier dangling docstring
     }
 
     function stmtStructDocs() modStructDocs() public {
@@ -20,7 +20,9 @@ contract StmtDocs04 {
         1;
 
         /// Block docstring
-        {}
+        {
+            /// Block dangling docstring
+        }
 
         /// EmitStatement docstring
         emit Ev(1);
@@ -39,6 +41,10 @@ contract StmtDocs04 {
         {
             /// Break docstring
             break;
+
+            /// Do-While
+            ///  Dangling
+            ///   Docstring
         }
         while(true);
 
@@ -57,17 +63,25 @@ contract StmtDocs04 {
         /// IfStatement docstring
         if (false)
         /// True body Block docstring
-        {}
+        { /// True body dangling docstring
+        }
         else
         /// False body Block docstring
-        {}
+        { /**False body dangling docstring*/ }
 
         /// InlineAssembly docstring
         assembly {}
 
-
         /// Return docstring
         return;
-    }
-}
 
+        /**
+         * Function body docstring
+         */
+    }
+
+    /// Contract
+
+    /// Dangling
+    /// Docstring
+}

--- a/test/samples/solidity/struct_docs_05.sourced.sol
+++ b/test/samples/solidity/struct_docs_05.sourced.sol
@@ -11,6 +11,7 @@ contract StmtDocs04 {
     modifier modStructDocs() {
         /// PlaceholderStatement docstring
         _;
+        /// Modifier dangling docstring
     }
 
     function stmtStructDocs() public modStructDocs() {
@@ -19,7 +20,9 @@ contract StmtDocs04 {
         /// ExpressionStatement docstring
         1;
         /// Block docstring
-        {}
+        {
+            /// Block dangling docstring
+        }
         /// EmitStatement docstring
         emit Ev(1);
         /// WhileStatement docstring
@@ -32,6 +35,9 @@ contract StmtDocs04 {
         do {
             /// Break docstring
             break;
+            /// Do-While
+            ///  Dangling
+            ///   Docstring
         } while(true);
         /// ForStatement docstring
         for (/// Init VariableDeclarationStatement docstring
@@ -40,11 +46,20 @@ contract StmtDocs04 {
         {}
         /// IfStatement docstring
         if (false) /// True body Block docstring
-        {} else /// False body Block docstring
-        {}
+        {
+            /// True body dangling docstring
+        } else /// False body Block docstring
+        {
+            /// False body dangling docstring
+        }
         /// InlineAssembly docstring
         assembly { }
         /// Return docstring
         return;
+        /// Function body docstring
     }
+    /// Contract
+    /// 
+    /// Dangling
+    /// Docstring
 }


### PR DESCRIPTION
## Tasks
This PR resolves #114

## Changes
- [x] Support of detecting dangling documentation (at the end of `Block`, `UncheckedBlock`, `ContractDefinition`).
- [x] Fixes to statement nodes to properly reflect `StructuredDocumentation` as part of their children.
- [x] Related tweaks to documentation reconstruction logic for `ASTReader` postprocessor.
- [x] Related tweaks to ast-to-source writing components.
- [x] Related tweaks to affected test snapshots.

Regards.