### PR TITLE
Report resolved paths in CompileResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "solc-typed-ast",
-            "version": "9.1.3",
+            "version": "10.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "^0.27.2",

--- a/src/compile/inference/imports.ts
+++ b/src/compile/inference/imports.ts
@@ -101,6 +101,7 @@ async function resolveSourceUnitName(
 
         if (resolvedPath !== undefined) {
             const contents = await fse.readFile(resolvedPath, "utf-8");
+
             return [contents, resolvedPath];
         }
     }
@@ -112,7 +113,7 @@ async function resolveSourceUnitName(
  * Given a partial map `files` from **source unit names** to file contents, a list of
  * `remappings` and a list of `ImportResolver`s - `resolvers`, find all
  * files that are imported from the starting set `files` but are
- * **missing** in `files` and add them into the files map. Also for each imported file
+ * **missing** in `files` and add them into the `files` map. Also for each imported file
  * add a mapping from its source unit name to the actual file name in `fileNames`.
  */
 export async function findAllFiles(
@@ -141,18 +142,20 @@ export async function findAllFiles(
 
         let content = files.get(sourceUnitName);
 
-        // Missing contents - try and fill them in from the resolvers
+        /**
+         * Missing contents - try and fill them in from the resolvers
+         */
         if (content === undefined) {
-            const res = await resolveSourceUnitName(sourceUnitName, resolvers);
+            const result = await resolveSourceUnitName(sourceUnitName, resolvers);
 
-            if (res === undefined) {
+            if (result === undefined) {
                 throw new CompileInferenceError(`Couldn't find ${sourceUnitName}`);
             }
 
-            content = res[0];
+            content = result[0];
 
             files.set(sourceUnitName, content);
-            fileNames.set(sourceUnitName, res[1]);
+            fileNames.set(sourceUnitName, result[1]);
         }
 
         let flds: AnyFileLevelNode[];

--- a/test/unit/compile/inference/findAllFiles.spec.ts
+++ b/test/unit/compile/inference/findAllFiles.spec.ts
@@ -52,7 +52,7 @@ describe("findAllFiles() find all needed imports", () => {
             const contents = fse.readFileSync(fileName).toString();
             const files = new Map<string, string>([[fileName, contents]]);
 
-            await findAllFiles(files, [], [new FileSystemResolver()]);
+            await findAllFiles(files, new Map(), [], [new FileSystemResolver()]);
 
             expect(new Set(files.keys())).toEqual(new Set(expectedAllFiles));
         });
@@ -71,7 +71,9 @@ contract Foo {
             ]
         ]);
 
-        await expect(findAllFiles(files, [], [])).rejects.toThrow(/Failed parsing imports/);
+        await expect(findAllFiles(files, new Map(), [], [])).rejects.toThrow(
+            /Failed parsing imports/
+        );
     });
 
     it("Missing file error", async () => {
@@ -85,6 +87,6 @@ contract Foo {
             ]
         ]);
 
-        await expect(findAllFiles(files, [], [])).rejects.toThrow(/Couldn't find a.sol/);
+        await expect(findAllFiles(files, new Map(), [], [])).rejects.toThrow(/Couldn't find a.sol/);
     });
 });

--- a/test/unit/compile/inference/findAllFiles.spec.ts
+++ b/test/unit/compile/inference/findAllFiles.spec.ts
@@ -1,8 +1,7 @@
 import expect from "expect";
 import fse from "fs-extra";
 import { join } from "path";
-import { FileSystemResolver } from "../../../../src";
-import { findAllFiles } from "../../../../src/compile/inference";
+import { FileSystemResolver, findAllFiles } from "../../../../src";
 
 const SAMPLES_DIR = join("test", "samples", "solidity");
 


### PR DESCRIPTION
The compilation helper functions perform several complex tasks to resolve imported files:

- do path remappings;
- look for files under `node_modules` and infer some remappings;
- take into account `--base-path` and `--include-paths` when looking for files.

As a result, even though in the compilation result there is some file X/Y/Z.sol, its not obvious to the callers of `compile*()` where that file may live on disk. This is especially useful to Scribble, which needs to move files around when arming.

To support this, this PR suggest to add a new field to `CompileResult` - `resolvedFileNames`:

```
    /**
     * Map from file names appearing in the files map, to the
     * actual resolved paths on disk (if any). For compileJSONData this
     * map is empty (since nothing was resolved on disk)
     */
    resolvedFileNames: Map<string, string>;
```