### PR TITLE
File remapping nit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build-type-parser": "tspegjs -o src/types/typeStrings/typeString_parser.ts --custom-header-file src/types/typeStrings/typeString_parser_header.ts --cache src/types/typeStrings/typeString_grammar.pegjs",
         "build-file-level-definitions-parser": "tspegjs -o src/compile/inference/file_level_definitions_parser.ts --custom-header-file src/compile/inference/file_level_definitions_parser_header.ts --cache src/compile/inference/file_level_definitions.pegjs",
         "build-parsers": "npm run build-type-parser && npm run build-file-level-definitions-parser",
-        "build": "npm run clean && npm run build-parsers && npm run transpile",
+        "build": "npm run clean && npm run build-parsers && npm run transpile && chmod u+x dist/bin/compile.js",
         "lint": "eslint src/ test/ --ext=ts",
         "lint:fix": "eslint src/ test/ --ext=ts --fix",
         "test": "NODE_OPTIONS='--max-old-space-size=2048' nyc mocha",

--- a/src/compile/utils.ts
+++ b/src/compile/utils.ts
@@ -46,7 +46,8 @@ export interface CompileResult {
      * Map from file-names appearing in the `files` map, to the
      * actual resolved paths on disk (if any).
      *
-     * For `compileJSONData()` this map is empty (since nothing was resolved on disk).
+     * For `compileJSONData()` this maps each unit absolutePath to itself as no resolution is done.
+     *
      */
     resolvedFileNames: Map<string, string>;
 
@@ -364,6 +365,7 @@ export async function compileJsonData(
     }
 
     const sources: { [fileName: string]: any } = data.sources;
+    const resolvedFileNames = new Map<string, string>(Object.keys(sources).map((x) => [x, x]));
 
     if (consistentlyContainsOneOf(sources, "ast", "legacyAST", "AST")) {
         const compilerVersion = undefined;
@@ -379,7 +381,7 @@ export async function compileJsonData(
             data,
             compilerVersion,
             files,
-            resolvedFileNames: new Map(),
+            resolvedFileNames,
             inferredRemappings: new Map()
         };
     }
@@ -409,7 +411,7 @@ export async function compileJsonData(
                     data: compileData,
                     compilerVersion,
                     files,
-                    resolvedFileNames: new Map(),
+                    resolvedFileNames,
                     inferredRemappings: new Map()
                 };
             }


### PR DESCRIPTION
In the last PR #119  we added a mapping from unit absolute paths to their resolved paths on disk to the `CompileResult` struct. However for the case of `compileJsonData` this returned an empty map, as no resolution was done on disk. However a more friendly behavior (especially for Scribble) is to return a map where each unit absolute path is resolved to itself. This PR tweaks this