### PR TITLE
Dont treat contract types as pointers

### DIFF
--- a/src/types/typeStrings/typeString_grammar.pegjs
+++ b/src/types/typeStrings/typeString_grammar.pegjs
@@ -344,7 +344,7 @@ TypeList =
     head: Type tail: (__ "," __ Type)* {
         return tail.reduce(
             (lst, cur) => {
-                lst.push(wrapContract(cur[3]));
+                lst.push(cur[3]);
 
                 return lst;
             },
@@ -445,7 +445,7 @@ ArrayPtrType =
     )* {
     return tail.reduce(
             (acc, cur) => {
-                acc = wrapContract(acc);
+                acc = acc;
                 
                 if (cur.length > 3) {
                     const size = cur[4];

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -105,11 +105,6 @@ export function specializeType(type: TypeNode, loc: DataLocation): TypeNode {
             type
         );
 
-        if (def instanceof ContractDefinition) {
-            // Contracts are always concretized as storage poitners
-            return new PointerType(type, DataLocation.Storage);
-        }
-
         if (def instanceof StructDefinition) {
             return new PointerType(type, loc);
         }

--- a/test/unit/types/getters.spec.ts
+++ b/test/unit/types/getters.spec.ts
@@ -150,7 +150,7 @@ const cases: Array<[string, Array<[string, TypeNode | DeferredTypeNode]>]> = [
                     return new FunctionType(
                         "g",
                         [new IntType(256, false)],
-                        [new PointerType(new UserDefinedType(def.name, def), DataLocation.Storage)],
+                        [new UserDefinedType(def.name, def)],
                         FunctionVisibility.External,
                         FunctionStateMutability.View
                     );
@@ -365,7 +365,7 @@ const cases: Array<[string, Array<[string, TypeNode | DeferredTypeNode]>]> = [
                     return new FunctionType(
                         "f",
                         [new IntType(256, false)],
-                        [new PointerType(new UserDefinedType(def.name, def), DataLocation.Storage)],
+                        [new UserDefinedType(def.name, def)],
                         FunctionVisibility.External,
                         FunctionStateMutability.View
                     );

--- a/test/unit/types/typestrings.spec.ts
+++ b/test/unit/types/typestrings.spec.ts
@@ -105,7 +105,6 @@ function normalizeTypeString(typeStr: string): string {
         .replace(/ ref/g, "")
         .replace(/ pointer/g, "")
         .replace(/ slice/g, "")
-        .replace(/ storage/g, "")
         .trim();
 }
 


### PR DESCRIPTION
This PR undoes the change in the type_inference branch where I treated contracts as pointers. I oirignally did this to be closer to some internal tooling's type system. However @blitz-1306 pointed out that this moves us further away from Solidity's type system, so its not a smart move.