### PR TITLE
Normalize value in string literals to null when undefined

### DIFF
--- a/src/ast/modern/literal_processor.ts
+++ b/src/ast/modern/literal_processor.ts
@@ -13,7 +13,7 @@ export class ModernLiteralProcessor extends ModernExpressionProcessor<Literal> {
 
         const kind: LiteralKind = raw.kind;
         const hexValue: string = raw.hexValue;
-        const value: string = raw.value;
+        const value: string = raw.value === undefined ? null : raw.value;
         const subdenomination: TimeUnit | EtherUnit | undefined = raw.subdenomination
             ? raw.subdenomination
             : undefined;

--- a/test/integration/compile/latest_08.spec.ts
+++ b/test/integration/compile/latest_08.spec.ts
@@ -117,7 +117,7 @@ for (const compilerKind of PossibleCompilerKinds) {
             // console.log(sourceUnit.getChildren().length);
 
             expect(sourceUnit.id).toEqual(738);
-            expect(sourceUnit.src).toEqual("0:8593:0");
+            expect(sourceUnit.src).toEqual("0:8621:0");
             expect(sourceUnit.absolutePath).toEqual(mainSample);
             expect(sourceUnit.children.length).toEqual(30);
             expect(sourceUnit.getChildren().length).toEqual(731);

--- a/test/integration/factory/copy.spec.ts
+++ b/test/integration/factory/copy.spec.ts
@@ -73,7 +73,7 @@ describe(`ASTNodeFactory.copy() validation`, () => {
                         .replace(new RegExp(process.cwd(), "g"), ".");
 
                     // Uncomment next line to update snapshots
-                    // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+                    fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
 
                     const content = fse.readFileSync(snapshot, { encoding: "utf-8" });
 

--- a/test/integration/factory/copy.spec.ts
+++ b/test/integration/factory/copy.spec.ts
@@ -73,7 +73,7 @@ describe(`ASTNodeFactory.copy() validation`, () => {
                         .replace(new RegExp(process.cwd(), "g"), ".");
 
                     // Uncomment next line to update snapshots
-                    fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
+                    // fse.writeFileSync(snapshot, result, { encoding: "utf-8" });
 
                     const content = fse.readFileSync(snapshot, { encoding: "utf-8" });
 

--- a/test/samples/solidity/latest_08.nodes.native.txt
+++ b/test/samples/solidity/latest_08.nodes.native.txt
@@ -4801,7 +4801,7 @@ SourceUnit #1486
                     documentation: undefined
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "3661:221:0", statements: Array(6) [ Object { nodeType: "YulVariableDeclaration", src: "3675:15:0", value: Object { hexValue: "74657374", kind: "string", nodeType: "YulLiteral", src: "3684:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nodeType: "YulTypedName", src: "3679:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3703:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nodeType: "YulLiteral", src: "3712:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nodeType: "YulTypedName", src: "3707:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3770:23:0", value: Object { hexValue: "1234abcd", kind: "string", nodeType: "YulLiteral", src: "3779:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nodeType: "YulTypedName", src: "3774:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3814:1:0", type: "", value: "0" }, Object { name: "x", nodeType: "YulIdentifier", src: "3817:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3807:6:0" }, nodeType: "YulFunctionCall", src: "3807:12:0" }, nodeType: "YulExpressionStatement", src: "3807:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3839:1:0", type: "", value: "1" }, Object { name: "y", nodeType: "YulIdentifier", src: "3842:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3832:6:0" }, nodeType: "YulFunctionCall", src: "3832:12:0" }, nodeType: "YulExpressionStatement", src: "3832:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nodeType: "YulLiteral", src: "3862:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nodeType: "YulIdentifier", src: "3858:3:0" }, nodeType: "YulFunctionCall", src: "3858:14:0" }, nodeType: "YulExpressionStatement", src: "3858:14:0" } ] }
+                    yul: Object { nodeType: "YulBlock", src: "3661:249:0", statements: Array(7) [ Object { nodeType: "YulVariableDeclaration", src: "3675:15:0", value: Object { hexValue: "74657374", kind: "string", nodeType: "YulLiteral", src: "3684:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nodeType: "YulTypedName", src: "3679:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3703:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nodeType: "YulLiteral", src: "3712:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nodeType: "YulTypedName", src: "3707:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3770:23:0", value: Object { hexValue: "1234abcd", kind: "string", nodeType: "YulLiteral", src: "3779:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nodeType: "YulTypedName", src: "3774:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3806:15:0", value: Object { hexValue: "c3", kind: "string", nodeType: "YulLiteral", src: "3815:6:0", type: "" }, variables: Array(1) [ Object { name: "z", nodeType: "YulTypedName", src: "3810:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3842:1:0", type: "", value: "0" }, Object { name: "x", nodeType: "YulIdentifier", src: "3845:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3835:6:0" }, nodeType: "YulFunctionCall", src: "3835:12:0" }, nodeType: "YulExpressionStatement", src: "3835:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3867:1:0", type: "", value: "1" }, Object { name: "y", nodeType: "YulIdentifier", src: "3870:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3860:6:0" }, nodeType: "YulFunctionCall", src: "3860:12:0" }, nodeType: "YulExpressionStatement", src: "3860:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nodeType: "YulLiteral", src: "3890:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nodeType: "YulIdentifier", src: "3886:3:0" }, nodeType: "YulFunctionCall", src: "3886:14:0" }, nodeType: "YulExpressionStatement", src: "3886:14:0" } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -4827,7 +4827,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "3903:22:0"
+            nameLocation: "3931:22:0"
             vParameters: ParameterList #1001
             vReturnParameters: ParameterList #1004
             vModifiers: Array(0)
@@ -4873,7 +4873,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3939:1:0"
+                    nameLocation: "3967:1:0"
                     vType: ElementaryTypeName #997
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -4919,7 +4919,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3955:1:0"
+                    nameLocation: "3983:1:0"
                     vType: ElementaryTypeName #999
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -4980,7 +4980,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3992:1:0"
+                    nameLocation: "4020:1:0"
                     vType: ElementaryTypeName #1002
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -5176,7 +5176,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4052:41:0"
+            nameLocation: "4080:41:0"
             vParameters: ParameterList #1014
             vReturnParameters: ParameterList #1015
             vModifiers: Array(0)
@@ -5273,7 +5273,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "uint256"
                         documentation: undefined
-                        nameLocation: "4169:1:0"
+                        nameLocation: "4197:1:0"
                         vType: ElementaryTypeName #1016
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -5337,7 +5337,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4197:13:0"
+            nameLocation: "4225:13:0"
             vParameters: ParameterList #1022
             vReturnParameters: ParameterList #1023
             vModifiers: Array(0)
@@ -5513,7 +5513,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4326:13:0"
+            nameLocation: "4354:13:0"
             vParameters: ParameterList #1031
             vReturnParameters: ParameterList #1032
             vModifiers: Array(0)
@@ -5651,7 +5651,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4393:24:0"
+            nameLocation: "4421:24:0"
             vParameters: ParameterList #1038
             vReturnParameters: ParameterList #1039
             vModifiers: Array(0)
@@ -5807,7 +5807,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1063 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "4484:11:0"
+        nameLocation: "4512:11:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -5847,7 +5847,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4511:13:0"
+            nameLocation: "4539:13:0"
             vParameters: ParameterList #1047
             vReturnParameters: ParameterList #1050
             vModifiers: Array(0)
@@ -6027,7 +6027,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4608:21:0"
+            nameLocation: "4636:21:0"
             vParameters: ParameterList #1056
             vReturnParameters: ParameterList #1059
             vModifiers: Array(0)
@@ -6088,7 +6088,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "4660:3:0"
+                    nameLocation: "4688:3:0"
                     vType: ElementaryTypeName #1057
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6143,9 +6143,9 @@ SourceUnit #1486
                     id: 1060
                     src: "0:0:0"
                     documentation: undefined
-                    externalReferences: Array(1) [ Object { declaration: 309, isOffset: false, isSlot: false, src: "4698:3:0", valueSize: 1 } ]
+                    externalReferences: Array(1) [ Object { declaration: 309, isOffset: false, isSlot: false, src: "4726:3:0", valueSize: 1 } ]
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "4684:40:0", statements: Array(1) [ Object { nodeType: "YulAssignment", src: "4698:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nodeType: "YulIdentifier", src: "4705:7:0" }, nodeType: "YulFunctionCall", src: "4705:9:0" }, variableNames: Array(1) [ Object { name: "ret", nodeType: "YulIdentifier", src: "4698:3:0" } ] } ] }
+                    yul: Object { nodeType: "YulBlock", src: "4712:40:0", statements: Array(1) [ Object { nodeType: "YulAssignment", src: "4726:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nodeType: "YulIdentifier", src: "4733:7:0" }, nodeType: "YulFunctionCall", src: "4733:9:0" }, variableNames: Array(1) [ Object { name: "ret", nodeType: "YulIdentifier", src: "4726:3:0" } ] } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -6164,7 +6164,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "Price"
         underlyingType: ElementaryTypeName #1064
-        nameLocation: "4739:5:0"
+        nameLocation: "4767:5:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1064 ]
@@ -6200,7 +6200,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "Quantity"
         underlyingType: ElementaryTypeName #1066
-        nameLocation: "4762:8:0"
+        nameLocation: "4790:8:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1066 ]
@@ -6242,7 +6242,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1155 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "4792:15:0"
+        nameLocation: "4820:15:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -6275,7 +6275,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "UFixed"
             underlyingType: ElementaryTypeName #1068
-            nameLocation: "4819:6:0"
+            nameLocation: "4847:6:0"
             context: ASTContext #1000
             parent: ContractDefinition #1155
             <getter> children: Array(1) [ ElementaryTypeName #1068 ]
@@ -6319,7 +6319,7 @@ SourceUnit #1486
             mutability: "constant"
             typeString: "uint256"
             documentation: undefined
-            nameLocation: "4857:10:0"
+            nameLocation: "4885:10:0"
             vType: ElementaryTypeName #1070
             vOverrideSpecifier: undefined
             vValue: BinaryOperation #1073
@@ -6420,7 +6420,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4892:3:0"
+            nameLocation: "4920:3:0"
             vParameters: ParameterList #1081
             vReturnParameters: ParameterList #1085
             vModifiers: Array(0)
@@ -6466,7 +6466,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "4903:1:0"
+                    nameLocation: "4931:1:0"
                     vType: UserDefinedTypeName #1076
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6531,7 +6531,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "4913:1:0"
+                    nameLocation: "4941:1:0"
                     vType: UserDefinedTypeName #1079
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6956,7 +6956,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5034:3:0"
+            nameLocation: "5062:3:0"
             vParameters: ParameterList #1106
             vReturnParameters: ParameterList #1110
             vModifiers: Array(0)
@@ -7002,7 +7002,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "5045:1:0"
+                    nameLocation: "5073:1:0"
                     vType: UserDefinedTypeName #1102
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7067,7 +7067,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "5056:1:0"
+                    nameLocation: "5084:1:0"
                     vType: ElementaryTypeName #1104
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7410,7 +7410,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5162:5:0"
+            nameLocation: "5190:5:0"
             vParameters: ParameterList #1126
             vReturnParameters: ParameterList #1129
             vModifiers: Array(0)
@@ -7456,7 +7456,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "5175:1:0"
+                    nameLocation: "5203:1:0"
                     vType: UserDefinedTypeName #1124
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7736,7 +7736,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5278:8:0"
+            nameLocation: "5306:8:0"
             vParameters: ParameterList #1141
             vReturnParameters: ParameterList #1145
             vModifiers: Array(0)
@@ -7782,7 +7782,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "5295:1:0"
+                    nameLocation: "5323:1:0"
                     vType: ElementaryTypeName #1139
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -8061,7 +8061,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1166 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5394:21:0"
+        nameLocation: "5422:21:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8094,7 +8094,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "EntityReference"
             underlyingType: ElementaryTypeName #1156
-            nameLocation: "5483:15:0"
+            nameLocation: "5511:15:0"
             context: ASTContext #1000
             parent: ContractDefinition #1166
             <getter> children: Array(1) [ ElementaryTypeName #1156 ]
@@ -8137,7 +8137,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5533:7:0"
+            nameLocation: "5561:7:0"
             vParameters: ParameterList #1161
             vReturnParameters: ParameterList #1164
             vModifiers: Array(0)
@@ -8183,7 +8183,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "InterfaceWithUDTV_088.EntityReference"
                     documentation: undefined
-                    nameLocation: "5557:2:0"
+                    nameLocation: "5585:2:0"
                     vType: UserDefinedTypeName #1159
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -8307,7 +8307,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1191 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5602:18:0"
+        nameLocation: "5630:18:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8347,7 +8347,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5636:14:0"
+            nameLocation: "5664:14:0"
             vParameters: ParameterList #1167
             vReturnParameters: ParameterList #1168
             vModifiers: Array(0)
@@ -8820,7 +8820,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1222 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5781:33:0"
+        nameLocation: "5809:33:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8860,7 +8860,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5830:12:0"
+            nameLocation: "5858:12:0"
             vParameters: ParameterList #1192
             vReturnParameters: ParameterList #1193
             vModifiers: Array(0)
@@ -8938,7 +8938,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5871:4:0"
+            nameLocation: "5899:4:0"
             vParameters: ParameterList #1200
             vReturnParameters: ParameterList #1205
             vModifiers: Array(0)
@@ -8984,7 +8984,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "5884:10:0"
+                    nameLocation: "5912:10:0"
                     vType: ElementaryTypeName #1196
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9030,7 +9030,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint32"
                     documentation: undefined
-                    nameLocation: "5903:11:0"
+                    nameLocation: "5931:11:0"
                     vType: ElementaryTypeName #1198
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9091,7 +9091,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "5945:3:0"
+                    nameLocation: "5973:3:0"
                     vType: ElementaryTypeName #1201
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9137,7 +9137,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes4"
                     documentation: undefined
-                    nameLocation: "5957:3:0"
+                    nameLocation: "5985:3:0"
                     vType: ElementaryTypeName #1203
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9219,7 +9219,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "5992:2:0"
+                        nameLocation: "6020:2:0"
                         vType: FunctionTypeName #1208
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -9326,9 +9326,9 @@ SourceUnit #1486
                     id: 1213
                     src: "0:0:0"
                     documentation: undefined
-                    externalReferences: Array(6) [ Object { declaration: 460, isOffset: false, isSlot: false, src: "6057:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6114:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6089:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6151:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 448, isOffset: false, isSlot: false, src: "6128:10:0", valueSize: 1 }, Object { declaration: 450, isOffset: false, isSlot: false, src: "6166:11:0", valueSize: 1 } ]
+                    externalReferences: Array(6) [ Object { declaration: 460, isOffset: false, isSlot: false, src: "6085:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6142:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6117:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6179:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 448, isOffset: false, isSlot: false, src: "6156:10:0", valueSize: 1 }, Object { declaration: 450, isOffset: false, isSlot: false, src: "6194:11:0", valueSize: 1 } ]
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "6034:153:0", statements: Array(4) [ Object { nodeType: "YulVariableDeclaration", src: "6048:19:0", value: Object { name: "fp.address", nodeType: "YulIdentifier", src: "6057:10:0" }, variables: Array(1) [ Object { name: "o", nodeType: "YulTypedName", src: "6052:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "6080:20:0", value: Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6089:11:0" }, variables: Array(1) [ Object { name: "s", nodeType: "YulTypedName", src: "6084:1:0", type: "" } ] }, Object { nodeType: "YulAssignment", src: "6114:24:0", value: Object { name: "newAddress", nodeType: "YulIdentifier", src: "6128:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nodeType: "YulIdentifier", src: "6114:10:0" } ] }, Object { nodeType: "YulAssignment", src: "6151:26:0", value: Object { name: "newSelector", nodeType: "YulIdentifier", src: "6166:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6151:11:0" } ] } ] }
+                    yul: Object { nodeType: "YulBlock", src: "6062:153:0", statements: Array(4) [ Object { nodeType: "YulVariableDeclaration", src: "6076:19:0", value: Object { name: "fp.address", nodeType: "YulIdentifier", src: "6085:10:0" }, variables: Array(1) [ Object { name: "o", nodeType: "YulTypedName", src: "6080:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "6108:20:0", value: Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6117:11:0" }, variables: Array(1) [ Object { name: "s", nodeType: "YulTypedName", src: "6112:1:0", type: "" } ] }, Object { nodeType: "YulAssignment", src: "6142:24:0", value: Object { name: "newAddress", nodeType: "YulIdentifier", src: "6156:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nodeType: "YulIdentifier", src: "6142:10:0" } ] }, Object { nodeType: "YulAssignment", src: "6179:26:0", value: Object { name: "newSelector", nodeType: "YulIdentifier", src: "6194:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6179:11:0" } ] } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -9466,7 +9466,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1261 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "6249:13:0"
+        nameLocation: "6277:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -9506,7 +9506,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6278:4:0"
+            nameLocation: "6306:4:0"
             vParameters: ParameterList #1229
             vReturnParameters: ParameterList #1236
             vModifiers: Array(0)
@@ -9552,7 +9552,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "6288:1:0"
+                    nameLocation: "6316:1:0"
                     vType: ElementaryTypeName #1223
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9598,7 +9598,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "int256"
                     documentation: undefined
-                    nameLocation: "6295:1:0"
+                    nameLocation: "6323:1:0"
                     vType: ElementaryTypeName #1225
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9644,7 +9644,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes2"
                     documentation: undefined
-                    nameLocation: "6305:1:0"
+                    nameLocation: "6333:1:0"
                     vType: ElementaryTypeName #1227
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9705,7 +9705,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes2"
                     documentation: undefined
-                    nameLocation: "6337:1:0"
+                    nameLocation: "6365:1:0"
                     vType: ElementaryTypeName #1230
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9751,7 +9751,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "int256"
                     documentation: undefined
-                    nameLocation: "6344:1:0"
+                    nameLocation: "6372:1:0"
                     vType: ElementaryTypeName #1232
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9797,7 +9797,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "6352:1:0"
+                    nameLocation: "6380:1:0"
                     vType: ElementaryTypeName #1234
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9954,7 +9954,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6403:4:0"
+            nameLocation: "6431:4:0"
             vParameters: ParameterList #1244
             vReturnParameters: ParameterList #1245
             vModifiers: Array(0)
@@ -10051,7 +10051,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "bytes"
                         documentation: undefined
-                        nameLocation: "6445:7:0"
+                        nameLocation: "6473:7:0"
                         vType: ElementaryTypeName #1246
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -10290,7 +10290,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1324 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "6517:13:0"
+        nameLocation: "6545:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -10331,7 +10331,7 @@ SourceUnit #1486
             mutability: "mutable"
             typeString: "function () external"
             documentation: undefined
-            nameLocation: "6558:15:0"
+            nameLocation: "6586:15:0"
             vType: FunctionTypeName #1264
             vOverrideSpecifier: undefined
             vValue: undefined
@@ -10408,7 +10408,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6589:10:0"
+            nameLocation: "6617:10:0"
             vParameters: ParameterList #1266
             vReturnParameters: ParameterList #1267
             vModifiers: Array(0)
@@ -10505,7 +10505,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "6640:14:0"
+                        nameLocation: "6668:14:0"
                         vType: FunctionTypeName #1270
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -10601,7 +10601,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "6685:14:0"
+                        nameLocation: "6713:14:0"
                         vType: FunctionTypeName #1275
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11196,7 +11196,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "6958:1:0"
+                        nameLocation: "6986:1:0"
                         vType: ElementaryTypeName #1305
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11279,7 +11279,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "6991:1:0"
+                        nameLocation: "7019:1:0"
                         vType: ElementaryTypeName #1309
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11362,7 +11362,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "7024:1:0"
+                        nameLocation: "7052:1:0"
                         vType: ElementaryTypeName #1313
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11515,7 +11515,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "RestrictedNumber_0813"
         underlyingType: ElementaryTypeName #1325
-        nameLocation: "7063:21:0"
+        nameLocation: "7091:21:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1325 ]
@@ -11732,7 +11732,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7221:7:0"
+        nameLocation: "7249:7:0"
         vParameters: ParameterList #1340
         vReturnParameters: ParameterList #1344
         vModifiers: Array(0)
@@ -11778,7 +11778,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "RestrictedNumber_0813"
                 documentation: undefined
-                nameLocation: "7251:1:0"
+                nameLocation: "7279:1:0"
                 vType: UserDefinedTypeName #1338
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -12158,7 +12158,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7407:8:0"
+        nameLocation: "7435:8:0"
         vParameters: ParameterList #1361
         vReturnParameters: ParameterList #1365
         vModifiers: Array(0)
@@ -12204,7 +12204,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "RestrictedNumber_0813"
                 documentation: undefined
-                nameLocation: "7438:1:0"
+                nameLocation: "7466:1:0"
                 vType: UserDefinedTypeName #1359
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -12584,7 +12584,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7594:27:0"
+        nameLocation: "7622:27:0"
         vParameters: ParameterList #1381
         vReturnParameters: ParameterList #1385
         vModifiers: Array(0)
@@ -12630,7 +12630,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "int256"
                 documentation: undefined
-                nameLocation: "7629:5:0"
+                nameLocation: "7657:5:0"
                 vType: ElementaryTypeName #1379
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -13137,7 +13137,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1435 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "7782:6:0"
+        nameLocation: "7810:6:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13177,7 +13177,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "7804:3:0"
+            nameLocation: "7832:3:0"
             vParameters: ParameterList #1413
             vReturnParameters: ParameterList #1417
             vModifiers: Array(0)
@@ -13223,7 +13223,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7830:1:0"
+                    nameLocation: "7858:1:0"
                     vType: UserDefinedTypeName #1408
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13288,7 +13288,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7855:1:0"
+                    nameLocation: "7883:1:0"
                     vType: UserDefinedTypeName #1411
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13368,7 +13368,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7898:1:0"
+                    nameLocation: "7926:1:0"
                     vType: UserDefinedTypeName #1415
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13747,7 +13747,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1442 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "8028:13:0"
+        nameLocation: "8056:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13787,7 +13787,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "8057:13:0"
+            nameLocation: "8085:13:0"
             vParameters: ParameterList #1436
             vReturnParameters: ParameterList #1437
             vModifiers: Array(0)
@@ -13859,7 +13859,7 @@ SourceUnit #1486
                     documentation: undefined
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "8115:2:0", statements: Array(0) }
+                    yul: Object { nodeType: "YulBlock", src: "8143:2:0", statements: Array(0) }
                     flags: Array(1) [ "memory-safe" ]
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -13879,7 +13879,7 @@ SourceUnit #1486
                     documentation: "@solidity memory-safe-assembly"
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "8178:2:0", statements: Array(0) }
+                    yul: Object { nodeType: "YulBlock", src: "8206:2:0", statements: Array(0) }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -13904,7 +13904,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1485 ]
         usedErrors: Array(1) [ 1454 ]
         docString: undefined
-        nameLocation: "8199:13:0"
+        nameLocation: "8227:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13938,7 +13938,7 @@ SourceUnit #1486
             anonymous: false
             name: "SomeEvent"
             documentation: undefined
-            nameLocation: "8225:9:0"
+            nameLocation: "8253:9:0"
             vParameters: ParameterList #1447
             context: ASTContext #1000
             parent: ContractDefinition #1485
@@ -13980,7 +13980,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "8251:4:0"
+                    nameLocation: "8279:4:0"
                     vType: ElementaryTypeName #1443
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14026,7 +14026,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "8270:1:0"
+                    nameLocation: "8298:1:0"
                     vType: ElementaryTypeName #1445
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14064,7 +14064,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "SomeError"
             documentation: undefined
-            nameLocation: "8284:9:0"
+            nameLocation: "8312:9:0"
             vParameters: ParameterList #1453
             context: ASTContext #1000
             parent: ContractDefinition #1485
@@ -14106,7 +14106,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "8302:4:0"
+                    nameLocation: "8330:4:0"
                     vType: ElementaryTypeName #1449
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14152,7 +14152,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "8313:1:0"
+                    nameLocation: "8341:1:0"
                     vType: ElementaryTypeName #1451
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14197,7 +14197,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "8331:14:0"
+            nameLocation: "8359:14:0"
             vParameters: ParameterList #1455
             vReturnParameters: ParameterList #1460
             vModifiers: Array(0)
@@ -14258,7 +14258,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes32"
                     documentation: undefined
-                    nameLocation: "8377:2:0"
+                    nameLocation: "8405:2:0"
                     vType: ElementaryTypeName #1456
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14304,7 +14304,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes4"
                     documentation: undefined
-                    nameLocation: "8388:2:0"
+                    nameLocation: "8416:2:0"
                     vType: ElementaryTypeName #1458
                     vOverrideSpecifier: undefined
                     vValue: undefined

--- a/test/samples/solidity/latest_08.nodes.wasm.txt
+++ b/test/samples/solidity/latest_08.nodes.wasm.txt
@@ -4801,7 +4801,7 @@ SourceUnit #1486
                     documentation: undefined
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "3661:221:0", statements: Array(6) [ Object { nodeType: "YulVariableDeclaration", src: "3675:15:0", value: Object { hexValue: "74657374", kind: "string", nodeType: "YulLiteral", src: "3684:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nodeType: "YulTypedName", src: "3679:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3703:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nodeType: "YulLiteral", src: "3712:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nodeType: "YulTypedName", src: "3707:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3770:23:0", value: Object { hexValue: "1234abcd", kind: "string", nodeType: "YulLiteral", src: "3779:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nodeType: "YulTypedName", src: "3774:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3814:1:0", type: "", value: "0" }, Object { name: "x", nodeType: "YulIdentifier", src: "3817:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3807:6:0" }, nodeType: "YulFunctionCall", src: "3807:12:0" }, nodeType: "YulExpressionStatement", src: "3807:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3839:1:0", type: "", value: "1" }, Object { name: "y", nodeType: "YulIdentifier", src: "3842:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3832:6:0" }, nodeType: "YulFunctionCall", src: "3832:12:0" }, nodeType: "YulExpressionStatement", src: "3832:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nodeType: "YulLiteral", src: "3862:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nodeType: "YulIdentifier", src: "3858:3:0" }, nodeType: "YulFunctionCall", src: "3858:14:0" }, nodeType: "YulExpressionStatement", src: "3858:14:0" } ] }
+                    yul: Object { nodeType: "YulBlock", src: "3661:249:0", statements: Array(7) [ Object { nodeType: "YulVariableDeclaration", src: "3675:15:0", value: Object { hexValue: "74657374", kind: "string", nodeType: "YulLiteral", src: "3684:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nodeType: "YulTypedName", src: "3679:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3703:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nodeType: "YulLiteral", src: "3712:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nodeType: "YulTypedName", src: "3707:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3770:23:0", value: Object { hexValue: "1234abcd", kind: "string", nodeType: "YulLiteral", src: "3779:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nodeType: "YulTypedName", src: "3774:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "3806:15:0", value: Object { hexValue: "c3", kind: "string", nodeType: "YulLiteral", src: "3815:6:0", type: "" }, variables: Array(1) [ Object { name: "z", nodeType: "YulTypedName", src: "3810:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3842:1:0", type: "", value: "0" }, Object { name: "x", nodeType: "YulIdentifier", src: "3845:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3835:6:0" }, nodeType: "YulFunctionCall", src: "3835:12:0" }, nodeType: "YulExpressionStatement", src: "3835:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nodeType: "YulLiteral", src: "3867:1:0", type: "", value: "1" }, Object { name: "y", nodeType: "YulIdentifier", src: "3870:1:0" } ], functionName: Object { name: "sstore", nodeType: "YulIdentifier", src: "3860:6:0" }, nodeType: "YulFunctionCall", src: "3860:12:0" }, nodeType: "YulExpressionStatement", src: "3860:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nodeType: "YulLiteral", src: "3890:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nodeType: "YulIdentifier", src: "3886:3:0" }, nodeType: "YulFunctionCall", src: "3886:14:0" }, nodeType: "YulExpressionStatement", src: "3886:14:0" } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -4827,7 +4827,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "3903:22:0"
+            nameLocation: "3931:22:0"
             vParameters: ParameterList #1001
             vReturnParameters: ParameterList #1004
             vModifiers: Array(0)
@@ -4873,7 +4873,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3939:1:0"
+                    nameLocation: "3967:1:0"
                     vType: ElementaryTypeName #997
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -4919,7 +4919,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3955:1:0"
+                    nameLocation: "3983:1:0"
                     vType: ElementaryTypeName #999
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -4980,7 +4980,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes"
                     documentation: undefined
-                    nameLocation: "3992:1:0"
+                    nameLocation: "4020:1:0"
                     vType: ElementaryTypeName #1002
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -5176,7 +5176,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4052:41:0"
+            nameLocation: "4080:41:0"
             vParameters: ParameterList #1014
             vReturnParameters: ParameterList #1015
             vModifiers: Array(0)
@@ -5273,7 +5273,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "uint256"
                         documentation: undefined
-                        nameLocation: "4169:1:0"
+                        nameLocation: "4197:1:0"
                         vType: ElementaryTypeName #1016
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -5337,7 +5337,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4197:13:0"
+            nameLocation: "4225:13:0"
             vParameters: ParameterList #1022
             vReturnParameters: ParameterList #1023
             vModifiers: Array(0)
@@ -5513,7 +5513,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4326:13:0"
+            nameLocation: "4354:13:0"
             vParameters: ParameterList #1031
             vReturnParameters: ParameterList #1032
             vModifiers: Array(0)
@@ -5651,7 +5651,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4393:24:0"
+            nameLocation: "4421:24:0"
             vParameters: ParameterList #1038
             vReturnParameters: ParameterList #1039
             vModifiers: Array(0)
@@ -5807,7 +5807,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1063 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "4484:11:0"
+        nameLocation: "4512:11:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -5847,7 +5847,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4511:13:0"
+            nameLocation: "4539:13:0"
             vParameters: ParameterList #1047
             vReturnParameters: ParameterList #1050
             vModifiers: Array(0)
@@ -6027,7 +6027,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4608:21:0"
+            nameLocation: "4636:21:0"
             vParameters: ParameterList #1056
             vReturnParameters: ParameterList #1059
             vModifiers: Array(0)
@@ -6088,7 +6088,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "4660:3:0"
+                    nameLocation: "4688:3:0"
                     vType: ElementaryTypeName #1057
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6143,9 +6143,9 @@ SourceUnit #1486
                     id: 1060
                     src: "0:0:0"
                     documentation: undefined
-                    externalReferences: Array(1) [ Object { declaration: 309, isOffset: false, isSlot: false, src: "4698:3:0", valueSize: 1 } ]
+                    externalReferences: Array(1) [ Object { declaration: 309, isOffset: false, isSlot: false, src: "4726:3:0", valueSize: 1 } ]
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "4684:40:0", statements: Array(1) [ Object { nodeType: "YulAssignment", src: "4698:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nodeType: "YulIdentifier", src: "4705:7:0" }, nodeType: "YulFunctionCall", src: "4705:9:0" }, variableNames: Array(1) [ Object { name: "ret", nodeType: "YulIdentifier", src: "4698:3:0" } ] } ] }
+                    yul: Object { nodeType: "YulBlock", src: "4712:40:0", statements: Array(1) [ Object { nodeType: "YulAssignment", src: "4726:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nodeType: "YulIdentifier", src: "4733:7:0" }, nodeType: "YulFunctionCall", src: "4733:9:0" }, variableNames: Array(1) [ Object { name: "ret", nodeType: "YulIdentifier", src: "4726:3:0" } ] } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -6164,7 +6164,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "Price"
         underlyingType: ElementaryTypeName #1064
-        nameLocation: "4739:5:0"
+        nameLocation: "4767:5:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1064 ]
@@ -6200,7 +6200,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "Quantity"
         underlyingType: ElementaryTypeName #1066
-        nameLocation: "4762:8:0"
+        nameLocation: "4790:8:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1066 ]
@@ -6242,7 +6242,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1155 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "4792:15:0"
+        nameLocation: "4820:15:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -6275,7 +6275,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "UFixed"
             underlyingType: ElementaryTypeName #1068
-            nameLocation: "4819:6:0"
+            nameLocation: "4847:6:0"
             context: ASTContext #1000
             parent: ContractDefinition #1155
             <getter> children: Array(1) [ ElementaryTypeName #1068 ]
@@ -6319,7 +6319,7 @@ SourceUnit #1486
             mutability: "constant"
             typeString: "uint256"
             documentation: undefined
-            nameLocation: "4857:10:0"
+            nameLocation: "4885:10:0"
             vType: ElementaryTypeName #1070
             vOverrideSpecifier: undefined
             vValue: BinaryOperation #1073
@@ -6420,7 +6420,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "4892:3:0"
+            nameLocation: "4920:3:0"
             vParameters: ParameterList #1081
             vReturnParameters: ParameterList #1085
             vModifiers: Array(0)
@@ -6466,7 +6466,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "4903:1:0"
+                    nameLocation: "4931:1:0"
                     vType: UserDefinedTypeName #1076
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6531,7 +6531,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "4913:1:0"
+                    nameLocation: "4941:1:0"
                     vType: UserDefinedTypeName #1079
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -6956,7 +6956,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5034:3:0"
+            nameLocation: "5062:3:0"
             vParameters: ParameterList #1106
             vReturnParameters: ParameterList #1110
             vModifiers: Array(0)
@@ -7002,7 +7002,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "5045:1:0"
+                    nameLocation: "5073:1:0"
                     vType: UserDefinedTypeName #1102
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7067,7 +7067,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "5056:1:0"
+                    nameLocation: "5084:1:0"
                     vType: ElementaryTypeName #1104
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7410,7 +7410,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5162:5:0"
+            nameLocation: "5190:5:0"
             vParameters: ParameterList #1126
             vReturnParameters: ParameterList #1129
             vModifiers: Array(0)
@@ -7456,7 +7456,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "LibWithUDVT_088.UFixed"
                     documentation: undefined
-                    nameLocation: "5175:1:0"
+                    nameLocation: "5203:1:0"
                     vType: UserDefinedTypeName #1124
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -7736,7 +7736,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5278:8:0"
+            nameLocation: "5306:8:0"
             vParameters: ParameterList #1141
             vReturnParameters: ParameterList #1145
             vModifiers: Array(0)
@@ -7782,7 +7782,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "5295:1:0"
+                    nameLocation: "5323:1:0"
                     vType: ElementaryTypeName #1139
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -8061,7 +8061,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1166 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5394:21:0"
+        nameLocation: "5422:21:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8094,7 +8094,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "EntityReference"
             underlyingType: ElementaryTypeName #1156
-            nameLocation: "5483:15:0"
+            nameLocation: "5511:15:0"
             context: ASTContext #1000
             parent: ContractDefinition #1166
             <getter> children: Array(1) [ ElementaryTypeName #1156 ]
@@ -8137,7 +8137,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5533:7:0"
+            nameLocation: "5561:7:0"
             vParameters: ParameterList #1161
             vReturnParameters: ParameterList #1164
             vModifiers: Array(0)
@@ -8183,7 +8183,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "InterfaceWithUDTV_088.EntityReference"
                     documentation: undefined
-                    nameLocation: "5557:2:0"
+                    nameLocation: "5585:2:0"
                     vType: UserDefinedTypeName #1159
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -8307,7 +8307,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1191 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5602:18:0"
+        nameLocation: "5630:18:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8347,7 +8347,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5636:14:0"
+            nameLocation: "5664:14:0"
             vParameters: ParameterList #1167
             vReturnParameters: ParameterList #1168
             vModifiers: Array(0)
@@ -8820,7 +8820,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1222 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "5781:33:0"
+        nameLocation: "5809:33:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -8860,7 +8860,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5830:12:0"
+            nameLocation: "5858:12:0"
             vParameters: ParameterList #1192
             vReturnParameters: ParameterList #1193
             vModifiers: Array(0)
@@ -8938,7 +8938,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "5871:4:0"
+            nameLocation: "5899:4:0"
             vParameters: ParameterList #1200
             vReturnParameters: ParameterList #1205
             vModifiers: Array(0)
@@ -8984,7 +8984,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "5884:10:0"
+                    nameLocation: "5912:10:0"
                     vType: ElementaryTypeName #1196
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9030,7 +9030,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint32"
                     documentation: undefined
-                    nameLocation: "5903:11:0"
+                    nameLocation: "5931:11:0"
                     vType: ElementaryTypeName #1198
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9091,7 +9091,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "5945:3:0"
+                    nameLocation: "5973:3:0"
                     vType: ElementaryTypeName #1201
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9137,7 +9137,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes4"
                     documentation: undefined
-                    nameLocation: "5957:3:0"
+                    nameLocation: "5985:3:0"
                     vType: ElementaryTypeName #1203
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9219,7 +9219,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "5992:2:0"
+                        nameLocation: "6020:2:0"
                         vType: FunctionTypeName #1208
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -9326,9 +9326,9 @@ SourceUnit #1486
                     id: 1213
                     src: "0:0:0"
                     documentation: undefined
-                    externalReferences: Array(6) [ Object { declaration: 460, isOffset: false, isSlot: false, src: "6057:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6114:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6089:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6151:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 448, isOffset: false, isSlot: false, src: "6128:10:0", valueSize: 1 }, Object { declaration: 450, isOffset: false, isSlot: false, src: "6166:11:0", valueSize: 1 } ]
+                    externalReferences: Array(6) [ Object { declaration: 460, isOffset: false, isSlot: false, src: "6085:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6142:10:0", suffix: "address", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6117:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 460, isOffset: false, isSlot: false, src: "6179:11:0", suffix: "selector", valueSize: 1 }, Object { declaration: 448, isOffset: false, isSlot: false, src: "6156:10:0", valueSize: 1 }, Object { declaration: 450, isOffset: false, isSlot: false, src: "6194:11:0", valueSize: 1 } ]
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "6034:153:0", statements: Array(4) [ Object { nodeType: "YulVariableDeclaration", src: "6048:19:0", value: Object { name: "fp.address", nodeType: "YulIdentifier", src: "6057:10:0" }, variables: Array(1) [ Object { name: "o", nodeType: "YulTypedName", src: "6052:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "6080:20:0", value: Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6089:11:0" }, variables: Array(1) [ Object { name: "s", nodeType: "YulTypedName", src: "6084:1:0", type: "" } ] }, Object { nodeType: "YulAssignment", src: "6114:24:0", value: Object { name: "newAddress", nodeType: "YulIdentifier", src: "6128:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nodeType: "YulIdentifier", src: "6114:10:0" } ] }, Object { nodeType: "YulAssignment", src: "6151:26:0", value: Object { name: "newSelector", nodeType: "YulIdentifier", src: "6166:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6151:11:0" } ] } ] }
+                    yul: Object { nodeType: "YulBlock", src: "6062:153:0", statements: Array(4) [ Object { nodeType: "YulVariableDeclaration", src: "6076:19:0", value: Object { name: "fp.address", nodeType: "YulIdentifier", src: "6085:10:0" }, variables: Array(1) [ Object { name: "o", nodeType: "YulTypedName", src: "6080:1:0", type: "" } ] }, Object { nodeType: "YulVariableDeclaration", src: "6108:20:0", value: Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6117:11:0" }, variables: Array(1) [ Object { name: "s", nodeType: "YulTypedName", src: "6112:1:0", type: "" } ] }, Object { nodeType: "YulAssignment", src: "6142:24:0", value: Object { name: "newAddress", nodeType: "YulIdentifier", src: "6156:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nodeType: "YulIdentifier", src: "6142:10:0" } ] }, Object { nodeType: "YulAssignment", src: "6179:26:0", value: Object { name: "newSelector", nodeType: "YulIdentifier", src: "6194:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nodeType: "YulIdentifier", src: "6179:11:0" } ] } ] }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -9466,7 +9466,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1261 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "6249:13:0"
+        nameLocation: "6277:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -9506,7 +9506,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6278:4:0"
+            nameLocation: "6306:4:0"
             vParameters: ParameterList #1229
             vReturnParameters: ParameterList #1236
             vModifiers: Array(0)
@@ -9552,7 +9552,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "6288:1:0"
+                    nameLocation: "6316:1:0"
                     vType: ElementaryTypeName #1223
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9598,7 +9598,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "int256"
                     documentation: undefined
-                    nameLocation: "6295:1:0"
+                    nameLocation: "6323:1:0"
                     vType: ElementaryTypeName #1225
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9644,7 +9644,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes2"
                     documentation: undefined
-                    nameLocation: "6305:1:0"
+                    nameLocation: "6333:1:0"
                     vType: ElementaryTypeName #1227
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9705,7 +9705,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes2"
                     documentation: undefined
-                    nameLocation: "6337:1:0"
+                    nameLocation: "6365:1:0"
                     vType: ElementaryTypeName #1230
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9751,7 +9751,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "int256"
                     documentation: undefined
-                    nameLocation: "6344:1:0"
+                    nameLocation: "6372:1:0"
                     vType: ElementaryTypeName #1232
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9797,7 +9797,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "6352:1:0"
+                    nameLocation: "6380:1:0"
                     vType: ElementaryTypeName #1234
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -9954,7 +9954,7 @@ SourceUnit #1486
             stateMutability: "view"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6403:4:0"
+            nameLocation: "6431:4:0"
             vParameters: ParameterList #1244
             vReturnParameters: ParameterList #1245
             vModifiers: Array(0)
@@ -10051,7 +10051,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "bytes"
                         documentation: undefined
-                        nameLocation: "6445:7:0"
+                        nameLocation: "6473:7:0"
                         vType: ElementaryTypeName #1246
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -10290,7 +10290,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1324 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "6517:13:0"
+        nameLocation: "6545:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -10331,7 +10331,7 @@ SourceUnit #1486
             mutability: "mutable"
             typeString: "function () external"
             documentation: undefined
-            nameLocation: "6558:15:0"
+            nameLocation: "6586:15:0"
             vType: FunctionTypeName #1264
             vOverrideSpecifier: undefined
             vValue: undefined
@@ -10408,7 +10408,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "6589:10:0"
+            nameLocation: "6617:10:0"
             vParameters: ParameterList #1266
             vReturnParameters: ParameterList #1267
             vModifiers: Array(0)
@@ -10505,7 +10505,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "6640:14:0"
+                        nameLocation: "6668:14:0"
                         vType: FunctionTypeName #1270
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -10601,7 +10601,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "function () external"
                         documentation: undefined
-                        nameLocation: "6685:14:0"
+                        nameLocation: "6713:14:0"
                         vType: FunctionTypeName #1275
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11196,7 +11196,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "6958:1:0"
+                        nameLocation: "6986:1:0"
                         vType: ElementaryTypeName #1305
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11279,7 +11279,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "6991:1:0"
+                        nameLocation: "7019:1:0"
                         vType: ElementaryTypeName #1309
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11362,7 +11362,7 @@ SourceUnit #1486
                         mutability: "mutable"
                         typeString: "string"
                         documentation: undefined
-                        nameLocation: "7024:1:0"
+                        nameLocation: "7052:1:0"
                         vType: ElementaryTypeName #1313
                         vOverrideSpecifier: undefined
                         vValue: undefined
@@ -11515,7 +11515,7 @@ SourceUnit #1486
         src: "0:0:0"
         name: "RestrictedNumber_0813"
         underlyingType: ElementaryTypeName #1325
-        nameLocation: "7063:21:0"
+        nameLocation: "7091:21:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> children: Array(1) [ ElementaryTypeName #1325 ]
@@ -11732,7 +11732,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7221:7:0"
+        nameLocation: "7249:7:0"
         vParameters: ParameterList #1340
         vReturnParameters: ParameterList #1344
         vModifiers: Array(0)
@@ -11778,7 +11778,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "RestrictedNumber_0813"
                 documentation: undefined
-                nameLocation: "7251:1:0"
+                nameLocation: "7279:1:0"
                 vType: UserDefinedTypeName #1338
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -12158,7 +12158,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7407:8:0"
+        nameLocation: "7435:8:0"
         vParameters: ParameterList #1361
         vReturnParameters: ParameterList #1365
         vModifiers: Array(0)
@@ -12204,7 +12204,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "RestrictedNumber_0813"
                 documentation: undefined
-                nameLocation: "7438:1:0"
+                nameLocation: "7466:1:0"
                 vType: UserDefinedTypeName #1359
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -12584,7 +12584,7 @@ SourceUnit #1486
         stateMutability: "pure"
         isConstructor: false
         documentation: undefined
-        nameLocation: "7594:27:0"
+        nameLocation: "7622:27:0"
         vParameters: ParameterList #1381
         vReturnParameters: ParameterList #1385
         vModifiers: Array(0)
@@ -12630,7 +12630,7 @@ SourceUnit #1486
                 mutability: "mutable"
                 typeString: "int256"
                 documentation: undefined
-                nameLocation: "7629:5:0"
+                nameLocation: "7657:5:0"
                 vType: ElementaryTypeName #1379
                 vOverrideSpecifier: undefined
                 vValue: undefined
@@ -13137,7 +13137,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1435 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "7782:6:0"
+        nameLocation: "7810:6:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13177,7 +13177,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "7804:3:0"
+            nameLocation: "7832:3:0"
             vParameters: ParameterList #1413
             vReturnParameters: ParameterList #1417
             vModifiers: Array(0)
@@ -13223,7 +13223,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7830:1:0"
+                    nameLocation: "7858:1:0"
                     vType: UserDefinedTypeName #1408
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13288,7 +13288,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7855:1:0"
+                    nameLocation: "7883:1:0"
                     vType: UserDefinedTypeName #1411
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13368,7 +13368,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "RestrictedNumber_0813"
                     documentation: undefined
-                    nameLocation: "7898:1:0"
+                    nameLocation: "7926:1:0"
                     vType: UserDefinedTypeName #1415
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -13747,7 +13747,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1442 ]
         usedErrors: Array(0)
         docString: undefined
-        nameLocation: "8028:13:0"
+        nameLocation: "8056:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13787,7 +13787,7 @@ SourceUnit #1486
             stateMutability: "nonpayable"
             isConstructor: false
             documentation: undefined
-            nameLocation: "8057:13:0"
+            nameLocation: "8085:13:0"
             vParameters: ParameterList #1436
             vReturnParameters: ParameterList #1437
             vModifiers: Array(0)
@@ -13859,7 +13859,7 @@ SourceUnit #1486
                     documentation: undefined
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "8115:2:0", statements: Array(0) }
+                    yul: Object { nodeType: "YulBlock", src: "8143:2:0", statements: Array(0) }
                     flags: Array(1) [ "memory-safe" ]
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -13879,7 +13879,7 @@ SourceUnit #1486
                     documentation: "@solidity memory-safe-assembly"
                     externalReferences: Array(0)
                     operations: undefined
-                    yul: Object { nodeType: "YulBlock", src: "8178:2:0", statements: Array(0) }
+                    yul: Object { nodeType: "YulBlock", src: "8206:2:0", statements: Array(0) }
                     flags: undefined
                     evmVersion: "london"
                     context: ASTContext #1000
@@ -13904,7 +13904,7 @@ SourceUnit #1486
         linearizedBaseContracts: Array(1) [ 1485 ]
         usedErrors: Array(1) [ 1454 ]
         docString: undefined
-        nameLocation: "8199:13:0"
+        nameLocation: "8227:13:0"
         context: ASTContext #1000
         parent: SourceUnit #1486
         <getter> documentation: undefined
@@ -13938,7 +13938,7 @@ SourceUnit #1486
             anonymous: false
             name: "SomeEvent"
             documentation: undefined
-            nameLocation: "8225:9:0"
+            nameLocation: "8253:9:0"
             vParameters: ParameterList #1447
             context: ASTContext #1000
             parent: ContractDefinition #1485
@@ -13980,7 +13980,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "8251:4:0"
+                    nameLocation: "8279:4:0"
                     vType: ElementaryTypeName #1443
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14026,7 +14026,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "8270:1:0"
+                    nameLocation: "8298:1:0"
                     vType: ElementaryTypeName #1445
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14064,7 +14064,7 @@ SourceUnit #1486
             src: "0:0:0"
             name: "SomeError"
             documentation: undefined
-            nameLocation: "8284:9:0"
+            nameLocation: "8312:9:0"
             vParameters: ParameterList #1453
             context: ASTContext #1000
             parent: ContractDefinition #1485
@@ -14106,7 +14106,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "address"
                     documentation: undefined
-                    nameLocation: "8302:4:0"
+                    nameLocation: "8330:4:0"
                     vType: ElementaryTypeName #1449
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14152,7 +14152,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "uint256"
                     documentation: undefined
-                    nameLocation: "8313:1:0"
+                    nameLocation: "8341:1:0"
                     vType: ElementaryTypeName #1451
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14197,7 +14197,7 @@ SourceUnit #1486
             stateMutability: "pure"
             isConstructor: false
             documentation: undefined
-            nameLocation: "8331:14:0"
+            nameLocation: "8359:14:0"
             vParameters: ParameterList #1455
             vReturnParameters: ParameterList #1460
             vModifiers: Array(0)
@@ -14258,7 +14258,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes32"
                     documentation: undefined
-                    nameLocation: "8377:2:0"
+                    nameLocation: "8405:2:0"
                     vType: ElementaryTypeName #1456
                     vOverrideSpecifier: undefined
                     vValue: undefined
@@ -14304,7 +14304,7 @@ SourceUnit #1486
                     mutability: "mutable"
                     typeString: "bytes4"
                     documentation: undefined
-                    nameLocation: "8388:2:0"
+                    nameLocation: "8416:2:0"
                     vType: ElementaryTypeName #1458
                     vOverrideSpecifier: undefined
                     vValue: undefined

--- a/test/samples/solidity/latest_08.sol
+++ b/test/samples/solidity/latest_08.sol
@@ -169,6 +169,7 @@ contract Features084 {
             let a := "test"
             let x := hex"112233445566778899aabbccddeeff6677889900"
             let y := hex"1234_abcd"
+            let z := "\xc3"
 
             sstore(0, x)
             sstore(1, y)

--- a/test/samples/solidity/latest_08.sourced.sol
+++ b/test/samples/solidity/latest_08.sourced.sol
@@ -158,6 +158,7 @@ contract Features084 {
             let a := "test"
             let x := hex"112233445566778899aabbccddeeff6677889900"
             let y := hex"1234abcd"
+            let z := hex"c3"
             sstore(0, x)
             sstore(1, y)
             pop("\"3")


### PR DESCRIPTION
This PR fixes a small issue that causes problems when writing our string literals like the example below:

```
pragma solidity 0.7.6;

contract Foo {
        function main() public {
                "\xc3";
        }
}
```

Due to legacy ASTs, when writing out string literals we use `hexValue` when kind is `hexString` or `value=== null`. However its also possible for `value===undefined` as in the example below. To avoid this always normalize `undefined -> null` during `Literal` processing.