### PR TITLE
Version change from 10.2.0 to 10.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "solc-typed-ast",
-    "version": "10.2.0",
+    "version": "10.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "solc-typed-ast",
-            "version": "10.2.0",
+            "version": "10.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "solc-typed-ast",
-    "version": "10.2.0",
+    "version": "10.3.0",
     "description": "A TypeScript library providing a normalized typed Solidity AST along with the utilities necessary to generate the AST (from Solc) and traverse/manipulate it.",
     "keywords": [],
     "files": [


### PR DESCRIPTION
## Changes
- [x] Changed package version to `10.3.0`.

## Pending release references
- #152
- #153

## Notes
Following functionality is now considered as **deprecated**:
- `canonicalSignature()` method of `ErrorDefinition`, `EventDefinition`, `FunctionDefinition` and `ModifierDefinition` nodes
- `canonicalSignatureHash()` method of `ErrorDefinition`, `EventDefinition`, `FunctionDefinition` and `ModifierDefinition` nodes
- `canonicalSignatureType()`, `getterArgsAndReturn()`, `getterFunType()`, `getterCanonicalSignature()` and `getterCanonicalSignatureHash()` methods of `VariableDeclaration` node
- `referencedCanonicalSignature()` and `referencedCanonicalSignatureHash()` methods of `FunctionCall` node
- `typeNameToTypeNode()` function
- `typeNameToSpecializedTypeNode()` function
- `inferVariableDeclLocation()` function
- `getNodeType()` function
- `getNodeTypeInCtx()` function

Regards.