### PR TITLE
Fix incorrect block scoping rules for legacy code

### DIFF
--- a/test/samples/solidity/resolving/block_04.sol
+++ b/test/samples/solidity/resolving/block_04.sol
@@ -8,5 +8,27 @@ contract Foo {
         foo memory m = foo(bar);
         
         uint bar = m.x;
+
+        uint m1 = k;
+        {uint k;}
+    }
+
+    uint256 x1;
+    uint256 x2;
+    uint256 x3;
+    uint256 x4;
+
+    function second() internal {
+        {
+            uint256 x1 = 1;
+            if (x1 > 0) {
+                uint256 x2 = 2;
+            }
+            {
+                uint256 x3 = 3;
+            }
+        }
+        for (uint256 x4; x4 < 10; x4++) {}
+        uint256 y = x1 + x2 + x3 + x4;
     }
 }

--- a/test/samples/solidity/resolving/block_05.sol
+++ b/test/samples/solidity/resolving/block_05.sol
@@ -13,4 +13,23 @@ contract Foo {
         
         foo = 2;
     }
+
+    uint256 x1;
+    uint256 x2;
+    uint256 x3;
+    uint256 x4;
+
+    function second() internal {
+        {
+            uint256 x1 = 1;
+            if (x1 > 0) {
+                uint256 x2 = 2;
+            }
+            {
+                uint256 x3 = 3;
+            }
+        }
+        for (uint256 x4; x4 < 10; x4++) {}
+        uint256 y = x1 + x2 + x3 + x4;
+    }
 }


### PR DESCRIPTION
The scoping rules in ast/definitions.ts incorrectly handle pre-0.5 blocks. Looking up a variable in a block should resolve to any VariableDeclaration anywhere in the block.

In the code below, `y` is equal to `16` because the scope is shared throughout the entire block, but `resolveAny` will resolve every `xn` to the contract's storage values.


## Scenario

```solidity
pragma solidity ^0.4.0;

contract A {
    uint256 x1; // Declaration ID = 3
    uint256 x2; // Declaration ID = 5
    uint256 x3; // Declaration ID = 7
    uint256 x4; // Declaration ID = 9

    function f() {
        {
            uint256 x1 = 1; // Declaration ID = 13
            if (x1 > 0) {
                uint256 x2 = 2; // Declaration ID = 20
            }
            {
                uint256 x3 = 3; // Declaration ID = 26
            }
        }
        // Declaration ID = 32
        for (uint256 x4; x4 < 10; x4++) {}
        // Declaration ID = 51
        uint256 y = x1 + x2 + x3 + x4;
    }
}
```

```typescript
const result = await compileSol(sample, "0.4.26");
const reader = new ASTReader();
const [sourceUnits] = reader.read(result.data, astKind);
const yDeclaration = reader.context.locate(51) as VariableDeclarationStatement;
const [[x1], [x2], [x3], [x4]] = ["x1", "x2", "x3", "x4"].map((name) =>
    resolveAny(name, yDeclaration, "0.4.26")
) as Array<Set<VariableDeclaration>>;
```

## Expected behavior

x1,x2,x3,x4 resolve to declarations within function `f` with IDs 13, 20, 26, 32.

## Current behavior

x1,x2,x3,x4 resolve to declarations within contract with IDs 3,5,7,9


## Solution

The fix is to search for all `VariableDeclaration` nodes when performing a lookup in the scope of a block when the version is <0.5. I modified `lookupInBlock` to perform this check and had to change `lookupInScope` and `resolveAny` to pass along the version. I also updated the `block_04` and `block_05` tests in `test/samples/solidity/resolving` to test this behavior. 