### PR TITLE
Expose constant expression evaluator logic and tweak `getTypeForCompilerVersion()`

### DIFF
--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -176,7 +176,7 @@ export function evalUnaryImpl(operator: string, value: Value): Value {
             return ~value;
         }
 
-        throw new EvalError(`Expected ${str(value)} to be an bigint`);
+        throw new EvalError(`Expected ${str(value)} to be a bigint`);
     }
 
     if (operator === "+") {
@@ -184,7 +184,7 @@ export function evalUnaryImpl(operator: string, value: Value): Value {
             return value;
         }
 
-        throw new EvalError(`Expected ${str(value)} to be an bigint or decimal`);
+        throw new EvalError(`Expected ${str(value)} to be a bigint or a decimal`);
     }
 
     if (operator === "-") {
@@ -196,7 +196,7 @@ export function evalUnaryImpl(operator: string, value: Value): Value {
             return -value;
         }
 
-        throw new EvalError(`Expected ${str(value)} to be an bigint or decimal`);
+        throw new EvalError(`Expected ${str(value)} to be a bigint or a decimal`);
     }
 
     throw new EvalError(`Unable to process ${operator}${str(value)}`);

--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -204,7 +204,7 @@ export function evalUnaryImpl(operator: string, value: Value): Value {
 
 export function evalBinaryImpl(operator: string, left: Value, right: Value): Value {
     if (BINARY_OPERATOR_GROUPS.Logical.includes(operator)) {
-        if (!(typeof left === "boolean" && typeof left === "boolean")) {
+        if (!(typeof left === "boolean" && typeof right === "boolean")) {
             throw new EvalError(`${operator} expects booleans not ${str(left)} and ${str(right)}`);
         }
 

--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -2,18 +2,20 @@ import Decimal from "decimal.js";
 import {
     BinaryOperation,
     Conditional,
+    EtherUnit,
     Expression,
     FunctionCall,
     FunctionCallKind,
     Identifier,
     Literal,
     LiteralKind,
+    TimeUnit,
     TupleExpression,
     UnaryOperation,
     VariableDeclaration
 } from "../ast";
 import { pp } from "../misc";
-import { SUBDENOMINATION_MULTIPLIERS, BINARY_OPERATOR_GROUPS } from "./utils";
+import { BINARY_OPERATOR_GROUPS, SUBDENOMINATION_MULTIPLIERS } from "./utils";
 /**
  * Tune up precision of decimal values to follow Solidity behavior.
  * Be careful with precision - setting it to large values causes NodeJS to crash.
@@ -25,19 +27,23 @@ Decimal.set({ precision: 100 });
 export type Value = Decimal | boolean | string | bigint;
 
 export class EvalError extends Error {
-    expr: Expression;
+    expr?: Expression;
 
-    constructor(e: Expression, msg: string) {
+    constructor(msg: string, expr?: Expression) {
         super(msg);
 
-        this.expr = e;
+        this.expr = expr;
     }
 }
 
 export class NonConstantExpressionError extends EvalError {
-    constructor(e: Expression) {
-        super(e, `Found non-constant expression ${pp(e)} during constant evaluation`);
+    constructor(expr: Expression) {
+        super(`Found non-constant expression ${pp(expr)} during constant evaluation`, expr);
     }
+}
+
+function str(value: Value): string {
+    return value instanceof Decimal ? value.toString() : pp(value);
 }
 
 function promoteToDec(v: Value): Decimal {
@@ -115,28 +121,32 @@ export function isConstant(expr: Expression): boolean {
     return false;
 }
 
-function evalLiteral(expr: Literal): Value {
-    if (expr.kind === LiteralKind.Bool) {
-        return expr.value === "true";
+export function evalLiteralImpl(
+    kind: LiteralKind,
+    value: string,
+    subdenomination?: TimeUnit | EtherUnit
+): Value {
+    if (kind === LiteralKind.Bool) {
+        return value === "true";
     }
 
-    if (expr.kind === LiteralKind.String || expr.kind === LiteralKind.UnicodeString) {
-        return expr.value;
+    if (
+        kind === LiteralKind.String ||
+        kind === LiteralKind.UnicodeString ||
+        kind === LiteralKind.HexString
+    ) {
+        return value;
     }
 
-    if (expr.kind === LiteralKind.HexString) {
-        return expr.hexValue;
-    }
-
-    if (expr.kind === LiteralKind.Number) {
-        const dec = new Decimal(expr.value.replaceAll("_", ""));
+    if (kind === LiteralKind.Number) {
+        const dec = new Decimal(value.replaceAll("_", ""));
         const val = dec.isInteger() ? BigInt(dec.toFixed()) : dec;
 
-        if (expr.subdenomination !== undefined) {
-            const multiplier = SUBDENOMINATION_MULTIPLIERS.get(expr.subdenomination);
+        if (subdenomination) {
+            const multiplier = SUBDENOMINATION_MULTIPLIERS.get(subdenomination);
 
             if (multiplier === undefined) {
-                throw new EvalError(expr, `Unknown denomination ${expr.subdenomination}`);
+                throw new EvalError(`Unknown denomination ${subdenomination}`);
             }
 
             if (val instanceof Decimal) {
@@ -149,212 +159,213 @@ function evalLiteral(expr: Literal): Value {
         return val;
     }
 
-    throw new EvalError(expr, `Unsupported literal kind "${expr.kind}"`);
+    throw new EvalError(`Unsupported literal kind "${kind}"`);
 }
 
-function evalUnary(expr: UnaryOperation): Value {
-    const subVal = evalConstantExpr(expr.vSubExpression);
+export function evalUnaryImpl(operator: string, value: Value): Value {
+    if (operator === "!") {
+        if (typeof value === "boolean") {
+            return !value;
+        }
 
-    if (expr.operator === "!") {
-        if (!(typeof subVal === "boolean")) {
+        throw new EvalError(`Expected ${str(value)} to be boolean`);
+    }
+
+    if (operator === "~") {
+        if (typeof value === "bigint") {
+            return ~value;
+        }
+
+        throw new EvalError(`Expected ${str(value)} to be an bigint`);
+    }
+
+    if (operator === "+") {
+        if (value instanceof Decimal || typeof value === "bigint") {
+            return value;
+        }
+
+        throw new EvalError(`Expected ${str(value)} to be an bigint or decimal`);
+    }
+
+    if (operator === "-") {
+        if (value instanceof Decimal) {
+            return value.negated();
+        }
+
+        if (typeof value === "bigint") {
+            return -value;
+        }
+
+        throw new EvalError(`Expected ${str(value)} to be an bigint or decimal`);
+    }
+
+    throw new EvalError(`Unable to process ${operator}${str(value)}`);
+}
+
+export function evalBinaryImpl(operator: string, left: Value, right: Value): Value {
+    if (BINARY_OPERATOR_GROUPS.Logical.includes(operator)) {
+        if (!(typeof left === "boolean" && typeof left === "boolean")) {
+            throw new EvalError(`${operator} expects booleans not ${str(left)} and ${str(right)}`);
+        }
+
+        if (operator === "&&") {
+            return left && right;
+        }
+
+        if (operator === "||") {
+            return left || right;
+        }
+
+        throw new EvalError(`Unknown logical operator ${operator}`);
+    }
+
+    if (BINARY_OPERATOR_GROUPS.Equality.includes(operator)) {
+        if (typeof left === "string" || typeof right === "string") {
             throw new EvalError(
-                expr.vSubExpression,
-                `Expected a boolean in ${pp(expr.vSubExpression)} not ${subVal}`
+                `${operator} not allowed for strings ${str(left)} and ${str(right)}`
             );
         }
 
-        return !subVal;
-    }
+        let isEqual: boolean;
 
-    if (expr.operator === "~") {
-        if (typeof subVal === "bigint") {
-            return ~subVal;
+        if (left instanceof Decimal && right instanceof Decimal) {
+            isEqual = left.equals(right);
+        } else {
+            isEqual = left === right;
         }
 
-        throw new EvalError(
-            expr.vSubExpression,
-            `Expected an integer number in ${pp(expr.vSubExpression)} not ${subVal}`
+        if (operator === "==") {
+            return isEqual;
+        }
+
+        if (operator === "!=") {
+            return !isEqual;
+        }
+
+        throw new EvalError(`Unknown equality operator ${operator}`);
+    }
+
+    if (BINARY_OPERATOR_GROUPS.Comparison.includes(operator)) {
+        const leftDec = promoteToDec(left);
+        const rightDec = promoteToDec(right);
+
+        if (operator === "<") {
+            return leftDec.lessThan(rightDec);
+        }
+
+        if (operator === "<=") {
+            return leftDec.lessThanOrEqualTo(rightDec);
+        }
+
+        if (operator === ">") {
+            return leftDec.greaterThan(rightDec);
+        }
+
+        if (operator === ">=") {
+            return leftDec.greaterThanOrEqualTo(rightDec);
+        }
+
+        throw new EvalError(`Unknown comparison operator ${operator}`);
+    }
+
+    if (BINARY_OPERATOR_GROUPS.Arithmetic.includes(operator)) {
+        const leftDec = promoteToDec(left);
+        const rightDec = promoteToDec(right);
+
+        let res: Decimal;
+
+        if (operator === "+") {
+            res = leftDec.plus(rightDec);
+        } else if (operator === "-") {
+            res = leftDec.minus(rightDec);
+        } else if (operator === "*") {
+            res = leftDec.times(rightDec);
+        } else if (operator === "/") {
+            res = leftDec.div(rightDec);
+        } else if (operator === "%") {
+            res = leftDec.modulo(rightDec);
+        } else if (operator === "**") {
+            res = leftDec.pow(rightDec);
+        } else {
+            throw new EvalError(`Unknown arithmetic operator ${operator}`);
+        }
+
+        return demoteFromDec(res);
+    }
+
+    if (BINARY_OPERATOR_GROUPS.Bitwise.includes(operator)) {
+        if (!(typeof left === "bigint" && typeof right === "bigint")) {
+            throw new EvalError(`${operator} expects integers not ${str(left)} and ${str(right)}`);
+        }
+
+        if (operator === "<<") {
+            return left << right;
+        }
+
+        if (operator === ">>") {
+            return left >> right;
+        }
+
+        if (operator === "|") {
+            return left | right;
+        }
+
+        if (operator === "&") {
+            return left & right;
+        }
+
+        if (operator === "^") {
+            return left ^ right;
+        }
+
+        throw new EvalError(`Unknown bitwise operator ${operator}`);
+    }
+
+    throw new EvalError(`Unable to process ${str(left)} ${operator} ${str(right)}`);
+}
+
+export function evalLiteral(node: Literal): Value {
+    try {
+        return evalLiteralImpl(
+            node.kind,
+            node.kind === LiteralKind.HexString ? node.hexValue : node.value,
+            node.subdenomination
         );
-    }
-
-    if (expr.operator === "+") {
-        if (subVal instanceof Decimal || typeof subVal === "bigint") {
-            return subVal;
+    } catch (e: unknown) {
+        if (e instanceof EvalError) {
+            e.expr = node;
         }
 
-        throw new EvalError(
-            expr.vSubExpression,
-            `Expected a number in ${pp(expr.vSubExpression)} not ${subVal}`
+        throw e;
+    }
+}
+
+export function evalUnary(node: UnaryOperation): Value {
+    try {
+        return evalUnaryImpl(node.operator, evalConstantExpr(node.vSubExpression));
+    } catch (e: unknown) {
+        if (e instanceof EvalError && e.expr === undefined) {
+            e.expr = node;
+        }
+
+        throw e;
+    }
+}
+
+export function evalBinary(node: BinaryOperation): Value {
+    try {
+        return evalBinaryImpl(
+            node.operator,
+            evalConstantExpr(node.vLeftExpression),
+            evalConstantExpr(node.vRightExpression)
         );
-    }
-
-    if (expr.operator === "-") {
-        if (subVal instanceof Decimal) {
-            return subVal.negated();
+    } catch (e: unknown) {
+        if (e instanceof EvalError && e.expr === undefined) {
+            e.expr = node;
         }
 
-        if (typeof subVal === "bigint") {
-            return -subVal;
-        }
-
-        throw new EvalError(
-            expr.vSubExpression,
-            `Expected a number in ${pp(expr.vSubExpression)} not ${subVal}`
-        );
+        throw e;
     }
-
-    throw new EvalError(expr, `NYI unary operator ${expr.operator}`);
-}
-
-function evalBinaryLogic(expr: BinaryOperation, lVal: Value, rVal: Value): Value {
-    const op = expr.operator;
-
-    if (!(typeof lVal === "boolean" && typeof lVal === "boolean")) {
-        throw new EvalError(expr, `${op} expects booleans not ${lVal} and ${rVal}`);
-    }
-
-    if (op === "&&") {
-        return lVal && rVal;
-    }
-
-    if (op === "||") {
-        return lVal || rVal;
-    }
-
-    throw new Error(`Unknown logic op ${op}`);
-}
-
-function evalBinaryEquality(expr: BinaryOperation, lVal: Value, rVal: Value): Value {
-    let equal: boolean;
-
-    if (typeof lVal === "string" || typeof rVal === "string") {
-        throw new EvalError(expr, `Comparison not allowed for strings ${lVal} and ${rVal}`);
-    }
-
-    if (lVal instanceof Decimal && rVal instanceof Decimal) {
-        equal = lVal.equals(rVal);
-    } else {
-        equal = lVal === rVal;
-    }
-
-    if (expr.operator === "==") {
-        return equal;
-    }
-
-    if (expr.operator === "!=") {
-        return !equal;
-    }
-
-    throw new EvalError(expr, `Unknown equality op ${expr.operator}`);
-}
-
-function evalBinaryComparison(expr: BinaryOperation, lVal: Value, rVal: Value): Value {
-    const op = expr.operator;
-
-    const lDec = promoteToDec(lVal);
-    const rDec = promoteToDec(rVal);
-
-    if (op === "<") {
-        return lDec.lessThan(rDec);
-    }
-
-    if (op === "<=") {
-        return lDec.lessThanOrEqualTo(rDec);
-    }
-
-    if (op === ">") {
-        return lDec.greaterThan(rDec);
-    }
-
-    if (op === ">=") {
-        return lDec.greaterThanOrEqualTo(rDec);
-    }
-
-    throw new EvalError(expr, `Unknown comparison op ${expr.operator}`);
-}
-
-function evalBinaryArithmetic(expr: BinaryOperation, lVal: Value, rVal: Value): Value {
-    const op = expr.operator;
-
-    const lDec = promoteToDec(lVal);
-    const rDec = promoteToDec(rVal);
-
-    let res: Decimal;
-
-    if (op === "+") {
-        res = lDec.plus(rDec);
-    } else if (op === "-") {
-        res = lDec.minus(rDec);
-    } else if (op === "*") {
-        res = lDec.times(rDec);
-    } else if (op === "/") {
-        res = lDec.div(rDec);
-    } else if (op === "%") {
-        res = lDec.modulo(rDec);
-    } else if (op === "**") {
-        res = lDec.pow(rDec);
-    } else {
-        throw new EvalError(expr, `Unknown arithmetic op ${expr.operator}`);
-    }
-
-    return demoteFromDec(res);
-}
-
-function evalBinaryBitwise(expr: BinaryOperation, lVal: Value, rVal: Value): Value {
-    const op = expr.operator;
-
-    if (!(typeof lVal === "bigint" && typeof rVal === "bigint")) {
-        throw new EvalError(expr, `${op} expects integers not ${lVal} and ${rVal}`);
-    }
-
-    if (op === "<<") {
-        return lVal << rVal;
-    }
-
-    if (op === ">>") {
-        return lVal >> rVal;
-    }
-
-    if (op === "|") {
-        return lVal | rVal;
-    }
-
-    if (op === "&") {
-        return lVal & rVal;
-    }
-
-    if (op === "^") {
-        return lVal ^ rVal;
-    }
-
-    throw new EvalError(expr, `Unknown bitwise op ${expr.operator}`);
-}
-
-function evalBinary(expr: BinaryOperation): Value {
-    const lVal = evalConstantExpr(expr.vLeftExpression);
-    const rVal = evalConstantExpr(expr.vRightExpression);
-
-    if (BINARY_OPERATOR_GROUPS.Logical.includes(expr.operator)) {
-        return evalBinaryLogic(expr, lVal, rVal);
-    }
-
-    if (BINARY_OPERATOR_GROUPS.Equality.includes(expr.operator)) {
-        return evalBinaryEquality(expr, lVal, rVal);
-    }
-
-    if (BINARY_OPERATOR_GROUPS.Comparison.includes(expr.operator)) {
-        return evalBinaryComparison(expr, lVal, rVal);
-    }
-
-    if (BINARY_OPERATOR_GROUPS.Arithmetic.includes(expr.operator)) {
-        return evalBinaryArithmetic(expr, lVal, rVal);
-    }
-
-    if (BINARY_OPERATOR_GROUPS.Bitwise.includes(expr.operator)) {
-        return evalBinaryBitwise(expr, lVal, rVal);
-    }
-
-    throw new EvalError(expr, `Unknown binary op ${expr.operator}`);
 }
 
 /**
@@ -364,51 +375,51 @@ function evalBinary(expr: BinaryOperation): Value {
  * TODO: The order of some operations changed in some version.
  * So perhaps to be fully precise here we will need a compiler version too?
  */
-export function evalConstantExpr(expr: Expression): Value {
-    if (!isConstant(expr)) {
-        throw new NonConstantExpressionError(expr);
+export function evalConstantExpr(node: Expression): Value {
+    if (!isConstant(node)) {
+        throw new NonConstantExpressionError(node);
     }
 
-    if (expr instanceof Literal) {
-        return evalLiteral(expr);
+    if (node instanceof Literal) {
+        return evalLiteral(node);
     }
 
-    if (expr instanceof UnaryOperation) {
-        return evalUnary(expr);
+    if (node instanceof UnaryOperation) {
+        return evalUnary(node);
     }
 
-    if (expr instanceof BinaryOperation) {
-        return evalBinary(expr);
+    if (node instanceof BinaryOperation) {
+        return evalBinary(node);
     }
 
-    if (expr instanceof TupleExpression) {
-        return evalConstantExpr(expr.vOriginalComponents[0] as Expression);
+    if (node instanceof TupleExpression) {
+        return evalConstantExpr(node.vOriginalComponents[0] as Expression);
     }
 
-    if (expr instanceof Conditional) {
-        return evalConstantExpr(expr.vCondition)
-            ? evalConstantExpr(expr.vTrueExpression)
-            : evalConstantExpr(expr.vFalseExpression);
+    if (node instanceof Conditional) {
+        return evalConstantExpr(node.vCondition)
+            ? evalConstantExpr(node.vTrueExpression)
+            : evalConstantExpr(node.vFalseExpression);
     }
 
-    if (expr instanceof Identifier) {
-        const decl = expr.vReferencedDeclaration;
+    if (node instanceof Identifier) {
+        const decl = node.vReferencedDeclaration;
 
         if (decl instanceof VariableDeclaration) {
             return evalConstantExpr(decl.vValue as Expression);
         }
     }
 
-    if (expr instanceof FunctionCall) {
+    if (node instanceof FunctionCall) {
         /**
          * @todo Implement properly, as Solidity permits overflow and underflow
-         * during constant evaluation.
+         * during constant evaluation when performing type conversions.
          */
-        return evalConstantExpr(expr.vArguments[0]);
+        return evalConstantExpr(node.vArguments[0]);
     }
 
     /// Note that from the point of view of the type system constant conditionals and
     /// indexing in constant array literals are not considered constant expressions.
     /// So for now we don't support them, but we may change that in the future.
-    throw new EvalError(expr, `Unable to evaluate constant expression ${pp(expr)}`);
+    throw new EvalError(`Unable to evaluate constant expression ${pp(node)}`, node);
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -74,9 +74,13 @@ export const BINARY_OPERATOR_GROUPS = {
 };
 
 export function getTypeForCompilerVersion(
-    typing: VersionDependentType,
+    typing: TypeNode | VersionDependentType,
     compilerVersion: string
 ): TypeNode | undefined {
+    if (typing instanceof TypeNode) {
+        return typing;
+    }
+
     const [type, version] = typing;
 
     return satisfies(compilerVersion, version) ? type : undefined;


### PR DESCRIPTION
## Tasks
This PR fixes #170 and fixes #173.

## Changes
- Allow `TypeNode` as a `typing` for `getTypeForCompilerVersion()`.
- Introduce `evalLiteralImpl()`, `evalUnaryImpl()`, `evalBinaryImpl()`.
- Export constant expression evaluator internal functions.

## Notes
This PR slightly changes `EvalError` class.

Regards.