### PR TITLE
More influence of `ABIEncoder`

### DIFF
--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -241,9 +241,6 @@ function* lookupInContractDefinition(
                     continue;
                 }
 
-                /**
-                 * Its a safe to assume V2 as its backward-compatible and we only use it internally here
-                 */
                 const sigHash =
                     child instanceof FunctionDefinition ||
                     child instanceof EventDefinition ||

--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -1,7 +1,7 @@
 import { gte, lt } from "semver";
 import { FunctionVisibility } from ".";
 import { assert, forAll, pp } from "../misc";
-import { ABIEncoderVersion, InferType } from "../types";
+import { InferType } from "../types";
 import { ASTNode } from "./ast_node";
 import { StateVariableVisibility } from "./constants";
 import { ContractDefinition } from "./implementation/declaration/contract_definition";
@@ -249,7 +249,7 @@ function* lookupInContractDefinition(
                     child instanceof EventDefinition ||
                     (child instanceof VariableDeclaration &&
                         child.visibility === StateVariableVisibility.Public)
-                        ? inference.signatureHash(child, ABIEncoderVersion.V2)
+                        ? inference.signatureHash(child)
                         : undefined;
 
                 if (sigHash !== undefined) {

--- a/src/ast/dispatch.ts
+++ b/src/ast/dispatch.ts
@@ -1,4 +1,4 @@
-import { ABIEncoderVersion, InferType } from "../types";
+import { InferType } from "../types";
 import { ASTNodeConstructor } from "./ast_node";
 import { StateVariableVisibility } from "./constants";
 import { ContractDefinition } from "./implementation/declaration/contract_definition";
@@ -48,10 +48,9 @@ export function resolve<T extends Resolvable>(
     if (target instanceof VariableDeclaration) {
         finder = (candidate) => candidate.name === target.name;
     } else {
-        const signatureHash = inference.signatureHash(target, ABIEncoderVersion.V2);
+        const signatureHash = inference.signatureHash(target);
 
-        finder = (candidate) =>
-            signatureHash === inference.signatureHash(candidate, ABIEncoderVersion.V2);
+        finder = (candidate) => signatureHash === inference.signatureHash(candidate);
     }
 
     for (const base of scope.vLinearizedBaseContracts) {
@@ -112,7 +111,7 @@ export function resolveByName<T extends Resolvable>(
             const resolvableIdentifier =
                 resolvable instanceof VariableDeclaration
                     ? resolvable.name
-                    : inference.signatureHash(resolvable, ABIEncoderVersion.V2);
+                    : inference.signatureHash(resolvable);
 
             if (resolvable.name === name && !found.has(resolvableIdentifier)) {
                 result.push(resolvable as T);
@@ -164,7 +163,7 @@ export function resolveCallable(
     inference: InferType,
     onlyParents = false
 ): FunctionDefinition | VariableDeclaration | undefined {
-    const selector = inference.signatureHash(definition, ABIEncoderVersion.V2);
+    const selector = inference.signatureHash(definition);
 
     for (const base of scope.vLinearizedBaseContracts) {
         if (onlyParents && base === scope) {
@@ -172,14 +171,14 @@ export function resolveCallable(
         }
 
         for (const fn of base.vFunctions) {
-            if (inference.signatureHash(fn, ABIEncoderVersion.V2) === selector) {
+            if (inference.signatureHash(fn) === selector) {
                 return fn;
             }
         }
 
         for (const v of base.vStateVariables) {
             if (v.visibility === StateVariableVisibility.Public) {
-                if (inference.signatureHash(v, ABIEncoderVersion.V2) === selector) {
+                if (inference.signatureHash(v) === selector) {
                     return v;
                 }
             }

--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -372,8 +372,9 @@ function error(message: string): never {
             console.log(indent + message);
         };
 
+        const compilerVersion = result.compilerVersion || LatestCompilerVersion;
+
         for (const unit of units) {
-            const compilerVersion = result.compilerVersion || LatestCompilerVersion;
             const encoderVersion = getABIEncoderVersion(unit, compilerVersion);
             const inference = new InferType(compilerVersion, encoderVersion);
 

--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import fse from "fs-extra";
 import {
     ASTKind,
-    ASTNodeCallback,
+    ASTNode,
     ASTNodeFormatter,
     ASTReader,
     ASTWriter,
@@ -315,13 +315,7 @@ function error(message: string): never {
     if (options.tree) {
         const INDENT = "|   ";
 
-        const encoderVersion = result.compilerVersion
-            ? getABIEncoderVersion(units, result.compilerVersion as string)
-            : undefined;
-
-        const inference = new InferType(result.compilerVersion || LatestCompilerVersion);
-
-        const walker: ASTNodeCallback = (node) => {
+        const writer = (unit: SourceUnit, inference: InferType, node: ASTNode) => {
             const level = node.getParents().length;
             const indent = INDENT.repeat(level);
 
@@ -332,9 +326,7 @@ function error(message: string): never {
             } else if (node instanceof ContractDefinition) {
                 message += " -> " + node.kind + " " + node.name;
 
-                const interfaceId = encoderVersion
-                    ? inference.interfaceId(node, encoderVersion)
-                    : undefined;
+                const interfaceId = inference.interfaceId(node);
 
                 if (interfaceId) {
                     message += ` [id: ${interfaceId}]`;
@@ -343,35 +335,29 @@ function error(message: string): never {
                 const signature =
                     node.vScope instanceof ContractDefinition &&
                     (node.visibility === FunctionVisibility.Public ||
-                        node.visibility === FunctionVisibility.External) &&
-                    encoderVersion
-                        ? inference.signature(node, encoderVersion)
+                        node.visibility === FunctionVisibility.External)
+                        ? inference.signature(node)
                         : undefined;
 
-                if (signature && encoderVersion) {
-                    const selector = inference.signatureHash(node, encoderVersion);
+                if (signature) {
+                    const selector = inference.signatureHash(node);
 
                     message += ` -> ${signature} [selector: ${selector}]`;
                 } else {
                     message += ` -> ${node.kind}`;
                 }
             } else if (node instanceof ErrorDefinition || node instanceof EventDefinition) {
-                if (encoderVersion) {
-                    const signature = inference.signature(node, encoderVersion);
-                    const selector = inference.signatureHash(node, encoderVersion);
+                const signature = inference.signature(node);
+                const selector = inference.signatureHash(node);
 
-                    message += ` -> ${signature} [selector: ${selector}]`;
-                }
+                message += ` -> ${signature} [selector: ${selector}]`;
             } else if (node instanceof VariableDeclaration) {
                 if (node.stateVariable) {
                     message += ` -> ${node.typeString} ${node.visibility} ${node.name}`;
 
-                    if (
-                        node.visibility === StateVariableVisibility.Public &&
-                        encoderVersion !== undefined
-                    ) {
-                        const signature = inference.signature(node, encoderVersion);
-                        const selector = inference.signatureHash(node, encoderVersion);
+                    if (node.visibility === StateVariableVisibility.Public) {
+                        const signature = inference.signature(node);
+                        const selector = inference.signatureHash(node);
 
                         message += ` [getter: ${signature}, selector: ${selector}]`;
                     }
@@ -387,7 +373,11 @@ function error(message: string): never {
         };
 
         for (const unit of units) {
-            unit.walk(walker);
+            const compilerVersion = result.compilerVersion || LatestCompilerVersion;
+            const encoderVersion = getABIEncoderVersion(unit, compilerVersion);
+            const inference = new InferType(compilerVersion, encoderVersion);
+
+            unit.walk(writer.bind(undefined, unit, inference));
 
             console.log();
         }

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -2081,16 +2081,6 @@ export class InferType {
                     continue;
                 }
 
-                if (
-                    memberT instanceof UserDefinedTypeName &&
-                    memberT.vReferencedDeclaration instanceof StructDefinition
-                ) {
-                    assert(
-                        this.encoderVersion !== ABIEncoderVersion.V1,
-                        "Nested structs in getter return type are not supported by ABI encoder v1"
-                    );
-                }
-
                 elements.push(this.typeNameToSpecializedTypeNode(memberT, DataLocation.Memory));
             }
 
@@ -2245,7 +2235,7 @@ export class InferType {
 
     /**
      * Convert an internal TypeNode to the external TypeNode that would correspond to it
-     * after ABI-encoding with encoder version `encoderVersion`. Follows the following rules:
+     * after ABI-encoding with encoder version. Follows the following rules:
      *
      * 1. Contract definitions turned to address.
      * 2. Enum definitions turned to uint of minimal fitting size.
@@ -2286,11 +2276,6 @@ export class InferType {
             }
 
             if (type.definition instanceof StructDefinition) {
-                assert(
-                    this.encoderVersion !== ABIEncoderVersion.V1,
-                    "Getters of struct return type are not supported by ABI encoder v1"
-                );
-
                 const fieldTs = type.definition.vMembers.map((fieldT) =>
                     this.variableDeclarationToTypeNode(fieldT)
                 );
@@ -2330,8 +2315,8 @@ export class InferType {
                 return "";
             }
 
-            // Signatures are computed differently depending on whether this is a library function
-            // or a contract method
+            // Signatures are computed differently depending on
+            // whether this is a library function or a contract method
             if (
                 node.vScope instanceof ContractDefinition &&
                 node.vScope.kind === ContractKind.Library

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -881,7 +881,9 @@ export class InferType {
 
         if (innerT instanceof UserDefinedType && innerT.definition instanceof ContractDefinition) {
             const resTemplateT =
-                innerT.definition.kind === ContractKind.Interface ? typeInterface : typeContract;
+                innerT.definition.kind === ContractKind.Interface || innerT.definition.abstract
+                    ? typeInterface
+                    : typeContract;
 
             return applySubstitution(resTemplateT, new Map([["T", innerT]]));
         }

--- a/test/integration/types/infer.spec.ts
+++ b/test/integration/types/infer.spec.ts
@@ -46,6 +46,7 @@ import {
     FunctionLikeSetType,
     FunctionType,
     generalizeType,
+    getABIEncoderVersion,
     ImportRefType,
     InferType,
     IntLiteralType,
@@ -696,9 +697,12 @@ describe("Type inference for expressions", () => {
             const reader = new ASTReader();
             const sourceUnits = reader.read(data, astKind);
 
-            const inference = new InferType(compilerVersion);
-
             for (const unit of sourceUnits) {
+                const inference = new InferType(
+                    compilerVersion,
+                    getABIEncoderVersion(unit, compilerVersion)
+                );
+
                 for (const expr of unit.getChildrenBySelector<Expression>(
                     (child) => child instanceof Expression
                 )) {

--- a/test/integration/types/typestrings.spec.ts
+++ b/test/integration/types/typestrings.spec.ts
@@ -23,7 +23,8 @@ import {
     MappingType,
     PointerType,
     specializeType,
-    generalizeType
+    generalizeType,
+    getABIEncoderVersion
 } from "../../../src";
 import { getNodeType } from "../../utils/typeStrings/typeString_parser";
 
@@ -137,9 +138,12 @@ describe("Round-trip tests for typestring parser/printer", () => {
                 const reader = new ASTReader();
                 const sourceUnits = reader.read(data, astKind);
 
-                const inference = new InferType(compilerVersion);
-
                 for (const unit of sourceUnits) {
+                    const inference = new InferType(
+                        compilerVersion,
+                        getABIEncoderVersion(unit, compilerVersion)
+                    );
+
                     for (const node of unit.getChildrenBySelector(
                         (child) =>
                             child instanceof Expression || child instanceof VariableDeclaration

--- a/test/samples/solidity/signatures.sol
+++ b/test/samples/solidity/signatures.sol
@@ -40,3 +40,33 @@ contract C {
         L.f(caller, v);
     }
 }
+
+/**
+ * Note that structs can not participate as mapping keys,
+ * therefore can not be subject of public variable getters arguments.
+ * They can only appear as return types.
+ */
+contract D {
+    struct S0 {
+        address s;
+    }
+
+    struct S1 {
+        uint x;
+        uint y;
+        S0 p;
+    }
+
+    struct S2 {
+        bool b;
+        S1 s;
+        address a;
+    }
+
+    S2 public s2;
+    S1 public s1;
+    S0 public s0;
+
+    function fnA(S2 memory _s2, S1 memory _s1, S0 memory _s0) public returns (S2 memory, S1 memory, S0 memory) {}
+    function fnB(S2[] memory _s2, S1[] memory _s1, S0[] memory _s0) public returns (S2[] memory, S1[] memory, S0[] memory) {}
+}

--- a/test/unit/ast/dispatch.spec.ts
+++ b/test/unit/ast/dispatch.spec.ts
@@ -8,6 +8,7 @@ import {
     EmitStatement,
     EventDefinition,
     FunctionDefinition,
+    getABIEncoderVersion,
     InferType,
     ModifierDefinition,
     resolve,
@@ -23,10 +24,14 @@ describe("Dynamic dispatch AST utils", async () => {
     const reader = new ASTReader();
     const { data } = await compileJson("test/samples/solidity/dispatch_05.json", "auto");
 
+    const compilerVersion = CompilerVersions05[CompilerVersions05.length - 1];
     const [mainUnit] = reader.read(data);
     const [a, b, c, d, i] = mainUnit.vContracts;
 
-    const inference = new InferType(CompilerVersions05[CompilerVersions05.length - 1]);
+    const inference = new InferType(
+        compilerVersion,
+        getABIEncoderVersion(mainUnit, compilerVersion)
+    );
 
     describe("resolve()", () => {
         const cases: Array<

--- a/test/unit/misc/pretty_printing.spec.ts
+++ b/test/unit/misc/pretty_printing.spec.ts
@@ -1,5 +1,6 @@
 import expect from "expect";
 import {
+    ABIEncoderVersion,
     ASTContext,
     ASTNode,
     ASTNodeFactory,
@@ -92,7 +93,7 @@ describe("Utility formatting routines", () => {
     });
 
     describe("pp()", () => {
-        const infer = new InferType("0.8.15");
+        const infer = new InferType("0.8.15", ABIEncoderVersion.V2);
 
         const cases: Array<[any, string]> = [
             [1, "1"],

--- a/test/unit/types/getters.spec.ts
+++ b/test/unit/types/getters.spec.ts
@@ -14,6 +14,7 @@ import {
     FunctionStateMutability,
     FunctionType,
     FunctionVisibility,
+    getABIEncoderVersion,
     getFQDefName,
     InferType,
     IntType,
@@ -385,7 +386,7 @@ describe("getterFunType()", () => {
                 let inference: InferType;
 
                 before(async () => {
-                    const { data, compilerVersion } = await compileSol(
+                    const result = await compileSol(
                         sample,
                         "auto",
                         undefined,
@@ -393,6 +394,9 @@ describe("getterFunType()", () => {
                         undefined,
                         kind as CompilerKind
                     );
+
+                    const data = result.data;
+                    const compilerVersion = result.compilerVersion || LatestCompilerVersion;
 
                     const errors = detectCompileErrors(data);
 
@@ -405,7 +409,10 @@ describe("getterFunType()", () => {
 
                     unit = units[0];
 
-                    inference = new InferType(compilerVersion || LatestCompilerVersion);
+                    inference = new InferType(
+                        compilerVersion,
+                        getABIEncoderVersion(unit, compilerVersion)
+                    );
                 });
 
                 for (const [stateVarName, typing] of mapping) {

--- a/test/unit/types/signatures.spec.ts
+++ b/test/unit/types/signatures.spec.ts
@@ -99,7 +99,7 @@ describe("Check canonical signatures are generated correctly", () => {
                 const sourceUnits = reader.read(data, ASTKind.Any);
                 const unit = sourceUnits[0];
 
-                const inference = new InferType(compilerVersion);
+                const inference = new InferType(compilerVersion, encoderVer);
 
                 const runTestsHelper = (
                     contractName: string,
@@ -120,7 +120,7 @@ describe("Check canonical signatures are generated correctly", () => {
                             def instanceof VariableDeclaration ||
                             def instanceof FunctionDefinition
                         ) {
-                            signature = inference.signature(def, encoderVer);
+                            signature = inference.signature(def);
                         } else {
                             throw new Error(`NYI: ${def.print()}`);
                         }


### PR DESCRIPTION
## Tasks
This PR fixes #167, fixes #168, fixes #169.

## Preface
We had ABI encoder version switches here and there, while there was no general type system component. Now it appears that type system significantly affected by ABI encoder version - getter signatures are composed differently, overloading resolution is also affected by this. Attemps to introduce encoder as and argument are causing insane set of interface breaking changes, however we can reduce impact by adding it as a state parameter of `InferType`.

## Changes
- [x] Introduce ABI encoder version as an `InferType` field.
- [x] Adjust multiple functions to respect ABI encoder, including `resolve*` family (#168).
- [x] Removed `encoderVersion` argument for `InferType` methods (it is now used from field).
- [x] Removed assertion checks for nested struct type arguments during compostion of public getter types when ABI encoder V1 is used (#169).
- [x] Tweak `getABIEncoderVersion()` to compute encoder version for single source unit only (#167).
- [x] Allow `type(<interface>)` members to be applied to `abstract` contracts.
- [x] Adjust codebase to respect changes. Fix tests.

Regards.