### PR TITLE
Fix inaccurate tuple type inference

### DIFF
--- a/src/types/abi.ts
+++ b/src/types/abi.ts
@@ -51,7 +51,8 @@ export function abiTypeToCanonicalName(t: TypeNode): string {
     if (t instanceof TupleType) {
         assert(
             forAll(t.elements, (el) => el !== null),
-            ``
+            "Empty tuple elements are disallowed. Got {0}",
+            t
         );
 
         return `(${t.elements
@@ -99,7 +100,8 @@ export function abiTypeToLibraryCanonicalName(t: TypeNode): string {
     if (t instanceof TupleType) {
         assert(
             forAll(t.elements, (el) => el !== null),
-            ``
+            "Empty tuple elements are disallowed. Got {0}",
+            t
         );
 
         return `(${t.elements

--- a/src/types/abi.ts
+++ b/src/types/abi.ts
@@ -1,5 +1,5 @@
 import { DataLocation } from "..";
-import { assert } from "../misc";
+import { assert, forAll } from "../misc";
 import {
     AddressType,
     ArrayType,
@@ -49,7 +49,14 @@ export function abiTypeToCanonicalName(t: TypeNode): string {
     }
 
     if (t instanceof TupleType) {
-        return `(${t.elements.map((elementT) => abiTypeToCanonicalName(elementT)).join(",")})`;
+        assert(
+            forAll(t.elements, (el) => el !== null),
+            ``
+        );
+
+        return `(${t.elements
+            .map((elementT) => abiTypeToCanonicalName(elementT as TypeNode))
+            .join(",")})`;
     }
 
     // Locations are skipped in signature canonical names
@@ -90,8 +97,13 @@ export function abiTypeToLibraryCanonicalName(t: TypeNode): string {
     }
 
     if (t instanceof TupleType) {
+        assert(
+            forAll(t.elements, (el) => el !== null),
+            ``
+        );
+
         return `(${t.elements
-            .map((elementT) => abiTypeToLibraryCanonicalName(elementT))
+            .map((elementT) => abiTypeToLibraryCanonicalName(elementT as TypeNode))
             .join(",")})`;
     }
 

--- a/src/types/ast/tuple_type.ts
+++ b/src/types/ast/tuple_type.ts
@@ -3,19 +3,19 @@ import { Node } from "../../misc/node";
 import { TypeNode } from "./type";
 
 export class TupleType extends TypeNode {
-    public readonly elements: TypeNode[];
+    public readonly elements: Array<TypeNode | null>;
 
-    constructor(elements: TypeNode[], src?: Range) {
+    constructor(elements: Array<TypeNode | null>, src?: Range) {
         super(src);
 
         this.elements = elements;
     }
 
     getChildren(): Node[] {
-        return this.elements;
+        return this.elements.filter((e) => e !== null) as Node[];
     }
 
     pp(): string {
-        return `tuple(${this.elements.map((element) => element.pp()).join(",")})`;
+        return `tuple(${this.elements.map((element) => (element ? element.pp() : "")).join(",")})`;
     }
 }

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -51,7 +51,7 @@ import {
     VariableDeclarationStatement
 } from "../ast";
 import { DataLocation } from "../ast/constants";
-import { assert, eq, forAny, pp } from "../misc";
+import { assert, eq, forAll, forAny, pp } from "../misc";
 import { ABIEncoderVersion, abiTypeToCanonicalName, abiTypeToLibraryCanonicalName } from "./abi";
 import {
     AddressType,
@@ -244,7 +244,7 @@ export class InferType {
                 node
             );
 
-            const resTs: TypeNode[] = [];
+            const resTs: Array<TypeNode | null> = [];
 
             for (let i = 0; i < comps.length; i++) {
                 const lhsComp = comps[i];
@@ -378,23 +378,36 @@ export class InferType {
             b instanceof TupleType &&
             a.elements.length === b.elements.length
         ) {
-            const commonElTs: TypeNode[] = [];
+            const commonElTs: Array<TypeNode | null> = [];
 
             for (let i = 0; i < a.elements.length; i++) {
-                let commonElT = this.inferCommonType(a.elements[i], b.elements[i]);
+                const aElT = a.elements[i];
+                const bElT = b.elements[i];
 
-                if (commonElT instanceof IntLiteralType && commonElT.literal !== undefined) {
-                    const fittingT = smallestFittingType(commonElT.literal);
+                let commonElT: TypeNode | null;
 
-                    assert(
-                        fittingT !== undefined,
-                        "Can't infer common type for tuple elements {0} between {1} and {2}",
-                        i,
-                        a,
-                        b
-                    );
+                if (aElT !== null && bElT !== null) {
+                    commonElT = this.inferCommonType(aElT, bElT);
 
-                    commonElT = fittingT;
+                    if (commonElT instanceof IntLiteralType && commonElT.literal !== undefined) {
+                        const fittingT = smallestFittingType(commonElT.literal);
+
+                        assert(
+                            fittingT !== undefined,
+                            "Can't infer common type for tuple elements {0} between {1} and {2}",
+                            i,
+                            a,
+                            b
+                        );
+
+                        commonElT = fittingT;
+                    }
+                } else if (aElT === null && bElT !== null) {
+                    commonElT = bElT;
+                } else if (aElT !== null && bElT === null) {
+                    commonElT = aElT;
+                } else {
+                    commonElT = null;
                 }
 
                 commonElTs.push(commonElT);
@@ -954,7 +967,8 @@ export class InferType {
 
             assert(rhsT.elements.length > tupleIdx, "Rhs not a tuple of right size in {0}", stmt);
 
-            return rhsT.elements[tupleIdx];
+            const rhsElT = rhsT.elements[tupleIdx];
+            return rhsElT !== null ? rhsElT : undefined;
         }
 
         return rhsT;
@@ -1617,15 +1631,29 @@ export class InferType {
     }
 
     typeOfTupleExpression(node: TupleExpression): TypeNode {
-        const componentTs = node.vComponents.map((cmp) => this.typeOf(cmp));
+        const componentTs = node.vOriginalComponents.map((cmp) =>
+            cmp === null ? cmp : this.typeOf(cmp)
+        );
 
         if (!node.isInlineArray) {
-            return componentTs.length === 1 ? componentTs[0] : new TupleType(componentTs);
+            if (componentTs.length === 1) {
+                const resT = componentTs[0];
+                assert(resT !== null, ``);
+                return resT;
+            }
+
+            return new TupleType(componentTs);
         }
 
         assert(node.vComponents.length > 0, "Can't have an empty array initializer");
+        assert(
+            forAll(componentTs, (elT) => elT !== null),
+            ``
+        );
 
-        let elT = componentTs.reduce((prev, cur) => this.inferCommonType(prev, cur));
+        let elT = componentTs.reduce((prev, cur) =>
+            this.inferCommonType(prev as TypeNode, cur as TypeNode)
+        ) as TypeNode;
 
         if (elT instanceof IntLiteralType) {
             const concreteT = elT.smallestFittingType();
@@ -2038,10 +2066,18 @@ export class InferType {
     getterFunType(v: VariableDeclaration): FunctionType {
         const [args, ret] = this.getterArgsAndReturn(v);
 
+        let rets: TypeNode[];
+
+        if (ret instanceof TupleType) {
+            rets = ret.elements as TypeNode[];
+        } else {
+            rets = [ret];
+        }
+
         return new FunctionType(
             v.name,
             args,
-            ret instanceof TupleType ? ret.elements : [ret],
+            rets,
             FunctionVisibility.External,
             FunctionStateMutability.View
         );

--- a/src/types/polymorphic.ts
+++ b/src/types/polymorphic.ts
@@ -103,7 +103,9 @@ export function buildSubstituion(
     if (a instanceof TupleType && b instanceof TupleType) {
         assert(
             forAll(a.elements, (el) => el !== null) && forAll(b.elements, (el) => el !== null),
-            ``
+            `Unexpected tuple with empty elements when building type substitution: {0} or {1}`,
+            a,
+            b
         );
 
         buildSubstitutions(a.elements as TypeNode[], b.elements as TypeNode[], m, compilerVersion);
@@ -259,7 +261,8 @@ export function applySubstitution(a: TypeNode, m: TypeSubstituion): TypeNode {
     if (a instanceof TupleType) {
         assert(
             forAll(a.elements, (el) => el !== null),
-            ``
+            "Unexpected tuple with empty elements when applying type substitution: {0}",
+            a
         );
 
         return new TupleType(applySubstitutions(a.elements as TypeNode[], m));

--- a/src/types/polymorphic.ts
+++ b/src/types/polymorphic.ts
@@ -1,4 +1,4 @@
-import { assert, eq, pp } from "../misc";
+import { assert, eq, forAll, pp } from "../misc";
 import {
     ArrayType,
     BuiltinFunctionType,
@@ -101,7 +101,12 @@ export function buildSubstituion(
     }
 
     if (a instanceof TupleType && b instanceof TupleType) {
-        buildSubstitutions(a.elements, b.elements, m, compilerVersion);
+        assert(
+            forAll(a.elements, (el) => el !== null) && forAll(b.elements, (el) => el !== null),
+            ``
+        );
+
+        buildSubstitutions(a.elements as TypeNode[], b.elements as TypeNode[], m, compilerVersion);
         return;
     }
 
@@ -252,7 +257,12 @@ export function applySubstitution(a: TypeNode, m: TypeSubstituion): TypeNode {
     }
 
     if (a instanceof TupleType) {
-        return new TupleType(applySubstitutions(a.elements, m));
+        assert(
+            forAll(a.elements, (el) => el !== null),
+            ``
+        );
+
+        return new TupleType(applySubstitutions(a.elements as TypeNode[], m));
     }
 
     if (a instanceof TypeNameType) {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -252,7 +252,12 @@ export function generalizeType(type: TypeNode): [TypeNode, DataLocation | undefi
     }
 
     if (type instanceof TupleType) {
-        return [new TupleType(type.elements.map((elT) => generalizeType(elT)[0])), undefined];
+        return [
+            new TupleType(
+                type.elements.map((elT) => (elT === null ? null : generalizeType(elT)[0]))
+            ),
+            undefined
+        ];
     }
 
     return [type, undefined];

--- a/test/integration/types/infer.spec.ts
+++ b/test/integration/types/infer.spec.ts
@@ -151,7 +151,15 @@ function toSoliditySource(expr: Expression, compilerVersion: string) {
     return writer.write(expr);
 }
 
-function externalParamEq(a: TypeNode, b: TypeNode): boolean {
+function externalParamEq(a: TypeNode | null, b: TypeNode | null): boolean {
+    if (a === null && b === null) {
+        return true;
+    }
+
+    if (a === null || b === null) {
+        return false;
+    }
+
     if (a instanceof PointerType && b instanceof PointerType) {
         if (
             !(
@@ -217,7 +225,9 @@ function exprIsABIDecodeArg(expr: Expression): boolean {
 
 function stripSingleTuples(t: TypeNode): TypeNode {
     while (t instanceof TupleType && t.elements.length === 1) {
-        t = t.elements[0];
+        const elT = t.elements[0];
+        assert(elT !== null, ``);
+        t = elT;
     }
 
     return t;
@@ -493,8 +503,8 @@ function compareTypeNodes(
         for (let i = 0; i < parsedT.elements.length; i++) {
             if (
                 !compareTypeNodes(
-                    generalizeType(inferredT.elements[i])[0],
-                    generalizeType(parsedT.elements[i])[0],
+                    generalizeType(inferredT.elements[i] as TypeNode)[0],
+                    generalizeType(parsedT.elements[i] as TypeNode)[0],
                     expr,
                     version
                 )

--- a/test/integration/types/infer.spec.ts
+++ b/test/integration/types/infer.spec.ts
@@ -224,13 +224,17 @@ function exprIsABIDecodeArg(expr: Expression): boolean {
 }
 
 function stripSingleTuples(t: TypeNode): TypeNode {
-    while (t instanceof TupleType && t.elements.length === 1) {
-        const elT = t.elements[0];
-        assert(elT !== null, ``);
-        t = elT;
+    let res = t;
+
+    while (res instanceof TupleType && res.elements.length === 1) {
+        const elT = res.elements[0];
+
+        assert(elT !== null, "Unexpected tuple with single empty element: {0}", t);
+
+        res = elT;
     }
 
-    return t;
+    return res;
 }
 
 /**


### PR DESCRIPTION
Solidity tuples can have empty elements. E.g:

`(1, ,"foo", , false)`

The type inference currently ignores empty elements and for the above tuple would compute a type `(int_literal 1, string memory, bool)`. However this is not accurate. This is the type of the tuple `(1, "foo", false)`. Fix this by allowing element types of the tuple type to also be `null`. 

This change simplifies decoding tuple assignments with potentially empty elements.