### PR TITLE
Support `TryCatchClause` for `InferType.signature*`

### DIFF
--- a/test/integration/types/infer.spec.ts
+++ b/test/integration/types/infer.spec.ts
@@ -782,7 +782,7 @@ describe("Type inference for expressions", () => {
                     const calleeT = inference.typeOfCallee(expr);
 
                     expect(calleeT).toBeDefined();
-                    assert(calleeT !== undefined, ``);
+                    assert(calleeT !== undefined, "Expected callee type to be defined");
 
                     const hasImplicitArg =
                         calleeT instanceof FunctionType && calleeT.implicitFirstArg;


### PR DESCRIPTION
## Tasks
Resolves #190.

## Changes
- [x] Support passing `TryCatchClause` to `InferType.signature()` and `InferType.signatureHash()`.
- [x] Fix camelCase for `InferType.specializeBuiltinTypeToCall()`.

## Notes
Unsure about tests. Would be great to have a related sample.

Regards.