### PR TITLE
Inject `InferType` instance to `evalConstantExpr()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,11 @@
             "devDependencies": {
                 "@types/fs-extra": "^11.0.1",
                 "@types/mocha": "^10.0.1",
-                "@types/node": "^16.18.21",
+                "@types/node": "^16.18.23",
                 "@types/semver": "^7.3.13",
-                "@typescript-eslint/eslint-plugin": "^5.56.0",
-                "@typescript-eslint/parser": "^5.56.0",
-                "eslint": "^8.36.0",
+                "@typescript-eslint/eslint-plugin": "^5.57.1",
+                "@typescript-eslint/parser": "^5.57.1",
+                "eslint": "^8.37.0",
                 "eslint-config-prettier": "^8.8.0",
                 "eslint-plugin-prettier": "^4.2.1",
                 "expect": "^29.5.0",
@@ -41,7 +41,7 @@
                 "ts-node": "^10.9.1",
                 "ts-pegjs": "^3.1.0",
                 "typedoc": "^0.23.28",
-                "typescript": "^5.0.2"
+                "typescript": "^5.0.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -494,14 +494,14 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+            "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.0",
+                "espree": "^9.5.1",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -517,9 +517,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+            "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1256,9 +1256,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.21.tgz",
-            "integrity": "sha512-TassPGd0AEZWA10qcNnXnSNwHlLfSth8XwUaWc3gTSDmBz/rKb613Qw5qRf6o2fdRBrLbsgeC9PMZshobkuUqg=="
+            "version": "16.18.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+            "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
         },
         "node_modules/@types/pbkdf2": {
             "version": "3.1.0",
@@ -1304,15 +1304,15 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
-            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz",
+            "integrity": "sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/type-utils": "5.56.0",
-                "@typescript-eslint/utils": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/type-utils": "5.57.1",
+                "@typescript-eslint/utils": "5.57.1",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
@@ -1338,14 +1338,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
-            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.1.tgz",
+            "integrity": "sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/typescript-estree": "5.57.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1365,13 +1365,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
-            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+            "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/visitor-keys": "5.56.0"
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/visitor-keys": "5.57.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1382,13 +1382,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
-            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz",
+            "integrity": "sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.56.0",
-                "@typescript-eslint/utils": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.57.1",
+                "@typescript-eslint/utils": "5.57.1",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -1409,9 +1409,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
-            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+            "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1422,13 +1422,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
-            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+            "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/visitor-keys": "5.56.0",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/visitor-keys": "5.57.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1449,17 +1449,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
-            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.1.tgz",
+            "integrity": "sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/typescript-estree": "5.57.1",
                 "eslint-scope": "^5.1.1",
                 "semver": "^7.3.7"
             },
@@ -1475,12 +1475,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
-            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+            "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/types": "5.57.1",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -2207,15 +2207,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+            "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.1",
-                "@eslint/js": "8.36.0",
+                "@eslint/eslintrc": "^2.0.2",
+                "@eslint/js": "8.37.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -2226,8 +2226,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.5.0",
+                "eslint-visitor-keys": "^3.4.0",
+                "espree": "^9.5.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2310,12 +2310,15 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+            "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
@@ -2341,14 +2344,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+            "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5100,9 +5103,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+            "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5745,14 +5748,14 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+            "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.0",
+                "espree": "^9.5.1",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -5762,9 +5765,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+            "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
             "dev": true
         },
         "@ethersproject/abi": {
@@ -6256,9 +6259,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.21.tgz",
-            "integrity": "sha512-TassPGd0AEZWA10qcNnXnSNwHlLfSth8XwUaWc3gTSDmBz/rKb613Qw5qRf6o2fdRBrLbsgeC9PMZshobkuUqg=="
+            "version": "16.18.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+            "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
         },
         "@types/pbkdf2": {
             "version": "3.1.0",
@@ -6304,15 +6307,15 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
-            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz",
+            "integrity": "sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/type-utils": "5.56.0",
-                "@typescript-eslint/utils": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/type-utils": "5.57.1",
+                "@typescript-eslint/utils": "5.57.1",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
@@ -6322,53 +6325,53 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
-            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.1.tgz",
+            "integrity": "sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/typescript-estree": "5.57.1",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
-            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+            "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/visitor-keys": "5.56.0"
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/visitor-keys": "5.57.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
-            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz",
+            "integrity": "sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "5.56.0",
-                "@typescript-eslint/utils": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.57.1",
+                "@typescript-eslint/utils": "5.57.1",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
-            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+            "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
-            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+            "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/visitor-keys": "5.56.0",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/visitor-keys": "5.57.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -6377,28 +6380,28 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
-            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.1.tgz",
+            "integrity": "sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.56.0",
-                "@typescript-eslint/types": "5.56.0",
-                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/scope-manager": "5.57.1",
+                "@typescript-eslint/types": "5.57.1",
+                "@typescript-eslint/typescript-estree": "5.57.1",
                 "eslint-scope": "^5.1.1",
                 "semver": "^7.3.7"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
-            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
+            "version": "5.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+            "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/types": "5.57.1",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -6957,15 +6960,15 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+            "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.1",
-                "@eslint/js": "8.36.0",
+                "@eslint/eslintrc": "^2.0.2",
+                "@eslint/js": "8.37.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -6976,8 +6979,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.5.0",
+                "eslint-visitor-keys": "^3.4.0",
+                "espree": "^9.5.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -7049,20 +7052,20 @@
             }
         },
         "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+            "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
             "dev": true
         },
         "espree": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+            "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
             "dev": true,
             "requires": {
                 "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.0"
             }
         },
         "esprima": {
@@ -9096,9 +9099,9 @@
             }
         },
         "typescript": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+            "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "devDependencies": {
         "@types/fs-extra": "^11.0.1",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^16.18.21",
+        "@types/node": "^16.18.23",
         "@types/semver": "^7.3.13",
-        "@typescript-eslint/eslint-plugin": "^5.56.0",
-        "@typescript-eslint/parser": "^5.56.0",
-        "eslint": "^8.36.0",
+        "@typescript-eslint/eslint-plugin": "^5.57.1",
+        "@typescript-eslint/parser": "^5.57.1",
+        "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "expect": "^29.5.0",
@@ -56,7 +56,7 @@
         "ts-node": "^10.9.1",
         "ts-pegjs": "^3.1.0",
         "typedoc": "^0.23.28",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.3"
     },
     "homepage": "https://consensys.github.io/solc-typed-ast",
     "bugs": "https://github.com/ConsenSys/solc-typed-ast/issues",

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -498,7 +498,7 @@ export class InferType {
         const b = this.typeOf(node.vRightExpression);
 
         if (a instanceof NumericLiteralType && b instanceof NumericLiteralType) {
-            const res = evalConstantExpr(node);
+            const res = evalConstantExpr(node, this);
 
             assert(
                 res instanceof Decimal || typeof res === "bigint",
@@ -1711,7 +1711,7 @@ export class InferType {
         }
 
         if (innerT instanceof NumericLiteralType) {
-            const res = evalConstantExpr(node);
+            const res = evalConstantExpr(node, this);
 
             assert(
                 res instanceof Decimal || typeof res === "bigint",
@@ -1730,7 +1730,7 @@ export class InferType {
         throw new Error(`NYI unary operator ${node.operator} in ${pp(node)}`);
     }
 
-    typeOfElementaryTypeNameExpression(node: ElementaryTypeNameExpression): TypeNode {
+    typeOfElementaryTypeNameExpression(node: ElementaryTypeNameExpression): TypeNameType {
         let innerT: TypeNode;
 
         if (node.typeName instanceof TypeName) {
@@ -2261,7 +2261,7 @@ export class InferType {
             let size: bigint | undefined;
 
             if (node.vLength) {
-                const result = evalConstantExpr(node.vLength);
+                const result = evalConstantExpr(node.vLength, this);
 
                 assert(
                     typeof result === "bigint",

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -550,6 +550,18 @@ export function smallestFittingType(...literals: bigint[]): IntType | undefined 
     return undefined;
 }
 
+/**
+ * Helper to cast the bigint `val` to the `IntType` `type`.
+ */
+export function clampIntToType(val: bigint, type: IntType): bigint {
+    const min = type.min();
+    const max = type.max();
+
+    const size = max - min + 1n;
+
+    return val < min ? ((val - max) % size) + max : ((val - min) % size) + min;
+}
+
 export function decimalToRational(d: Decimal): Rational {
     if (!d.isFinite()) {
         throw new Error(`Unexpected infinite rational ${d.toString()} in decimalToRational`);

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -7,7 +7,9 @@ import {
     evalConstantExpr,
     Expression,
     FunctionCallKind,
+    InferType,
     isConstant,
+    LatestCompilerVersion,
     LiteralKind,
     Mutability,
     StateVariableVisibility,
@@ -1228,9 +1230,11 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
 
 describe("Constant expression evaluator unit test (isConstant() + evalConstantExpr())", () => {
     let factory: ASTNodeFactory;
+    let inference: InferType;
 
     before(() => {
         factory = new ASTNodeFactory();
+        inference = new InferType(LatestCompilerVersion);
     });
 
     for (const [name, exprBuilder, isConst, value] of cases) {
@@ -1240,9 +1244,9 @@ describe("Constant expression evaluator unit test (isConstant() + evalConstantEx
             expect(isConstant(expr)).toEqual(isConst);
 
             if (value === undefined) {
-                expect(() => evalConstantExpr(expr)).toThrow();
+                expect(() => evalConstantExpr(expr, inference)).toThrow();
             } else {
-                expect(evalConstantExpr(expr)).toEqual(value);
+                expect(evalConstantExpr(expr, inference)).toEqual(value);
             }
         });
     }


### PR DESCRIPTION
## Brief
This is a followup PR after #193.

## Changes
- [x] Update dependencies.
- [x] Inject `InferType` instance as an argument for constant expression evaluator. This would allow us to react in behavior difference for various Solidity versions in the future.
- [x] Tweak `InferType.typeOfElementaryTypeNameExpression()` to have more precise return type.
- [x] Fix affected tests.

## Notes
This PR contains API breaking changes. Pending release should increase **major** version of the package to not break the dependent packages.

Regards.