### PR TITLE
Respect types when evaluating unary and binary operations in `evalConstantExpr()`

### DIFF
--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -362,11 +362,11 @@ export function evalLiteral(node: Literal): Value {
 
 export function evalUnary(node: UnaryOperation, inference: InferType): Value {
     try {
-        const opT = inference.typeOfUnaryOperation(node);
+        const exprT = inference.typeOf(node.vSubExpression);
         const val = evalUnaryImpl(node.operator, evalConstantExpr(node.vSubExpression, inference));
 
-        if (opT instanceof IntType && typeof val === "bigint") {
-            return clampIntToType(val, opT);
+        if (exprT instanceof IntType && typeof val === "bigint") {
+            return clampIntToType(val, exprT);
         }
 
         return val;
@@ -381,18 +381,11 @@ export function evalUnary(node: UnaryOperation, inference: InferType): Value {
 
 export function evalBinary(node: BinaryOperation, inference: InferType): Value {
     try {
-        const opT = inference.typeOfBinaryOperation(node);
-        const val = evalBinaryImpl(
+        return evalBinaryImpl(
             node.operator,
             evalConstantExpr(node.vLeftExpression, inference),
             evalConstantExpr(node.vRightExpression, inference)
         );
-
-        if (opT instanceof IntType && typeof val === "bigint") {
-            return clampIntToType(val, opT);
-        }
-
-        return val;
     } catch (e: unknown) {
         if (e instanceof EvalError && e.expr === undefined) {
             e.expr = node;

--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -381,11 +381,18 @@ export function evalUnary(node: UnaryOperation, inference: InferType): Value {
 
 export function evalBinary(node: BinaryOperation, inference: InferType): Value {
     try {
-        return evalBinaryImpl(
+        const opT = inference.typeOfBinaryOperation(node);
+        const val = evalBinaryImpl(
             node.operator,
             evalConstantExpr(node.vLeftExpression, inference),
             evalConstantExpr(node.vRightExpression, inference)
         );
+
+        if (opT instanceof IntType && typeof val === "bigint") {
+            return clampIntToType(val, opT);
+        }
+
+        return val;
     } catch (e: unknown) {
         if (e instanceof EvalError && e.expr === undefined) {
             e.expr = node;

--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -362,7 +362,14 @@ export function evalLiteral(node: Literal): Value {
 
 export function evalUnary(node: UnaryOperation, inference: InferType): Value {
     try {
-        return evalUnaryImpl(node.operator, evalConstantExpr(node.vSubExpression, inference));
+        const opT = inference.typeOfUnaryOperation(node);
+        const val = evalUnaryImpl(node.operator, evalConstantExpr(node.vSubExpression, inference));
+
+        if (opT instanceof IntType && typeof val === "bigint") {
+            return clampIntToType(val, opT);
+        }
+
+        return val;
     } catch (e: unknown) {
         if (e instanceof EvalError && e.expr === undefined) {
             e.expr = node;

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -1684,6 +1684,10 @@ export class InferType {
             return innerT;
         }
 
+        if (node.operator === "-" || node.operator === "+" || node.operator === "~") {
+            return innerT;
+        }
+
         if (innerT instanceof NumericLiteralType) {
             const res = evalConstantExpr(node, this);
 
@@ -1695,10 +1699,6 @@ export class InferType {
             return typeof res === "bigint"
                 ? new IntLiteralType(res)
                 : new RationalLiteralType(decimalToRational(res));
-        }
-
-        if (node.operator === "-" || node.operator === "+" || node.operator === "~") {
-            return innerT;
         }
 
         throw new Error(`NYI unary operator ${node.operator} in ${pp(node)}`);

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -497,6 +497,19 @@ export class InferType {
         const a = this.typeOf(node.vLeftExpression);
         const b = this.typeOf(node.vRightExpression);
 
+        if (a instanceof NumericLiteralType && b instanceof NumericLiteralType) {
+            const res = evalConstantExpr(node, this);
+
+            assert(
+                res instanceof Decimal || typeof res === "bigint",
+                "Unexpected result of const binary op"
+            );
+
+            return typeof res === "bigint"
+                ? new IntLiteralType(res)
+                : new RationalLiteralType(decimalToRational(res));
+        }
+
         // After 0.6.0 the type of ** is just the type of the lhs
         // Between 0.6.0 and 0.7.0 if the lhs is an int literal type it
         // took the type of the rhs if it wasn't a literal type. After 0.7.0 it
@@ -544,19 +557,6 @@ export class InferType {
             // For all other bitwise operators infer a common type. In earlier versions it wa allowed
             // to have bitwise ops between differing sizes
             return this.inferCommonType(a, b);
-        }
-
-        if (a instanceof NumericLiteralType && b instanceof NumericLiteralType) {
-            const res = evalConstantExpr(node, this);
-
-            assert(
-                res instanceof Decimal || typeof res === "bigint",
-                "Unexpected result of const binary op"
-            );
-
-            return typeof res === "bigint"
-                ? new IntLiteralType(res)
-                : new RationalLiteralType(decimalToRational(res));
         }
 
         throw new Error(`NYI Binary op ${node.operator}`);
@@ -1684,10 +1684,6 @@ export class InferType {
             return innerT;
         }
 
-        if (node.operator === "-" || node.operator === "+" || node.operator === "~") {
-            return innerT;
-        }
-
         if (innerT instanceof NumericLiteralType) {
             const res = evalConstantExpr(node, this);
 
@@ -1699,6 +1695,10 @@ export class InferType {
             return typeof res === "bigint"
                 ? new IntLiteralType(res)
                 : new RationalLiteralType(decimalToRational(res));
+        }
+
+        if (node.operator === "-" || node.operator === "+" || node.operator === "~") {
+            return innerT;
         }
 
         throw new Error(`NYI unary operator ${node.operator} in ${pp(node)}`);

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -497,19 +497,6 @@ export class InferType {
         const a = this.typeOf(node.vLeftExpression);
         const b = this.typeOf(node.vRightExpression);
 
-        if (a instanceof NumericLiteralType && b instanceof NumericLiteralType) {
-            const res = evalConstantExpr(node, this);
-
-            assert(
-                res instanceof Decimal || typeof res === "bigint",
-                "Unexpected result of const binary op"
-            );
-
-            return typeof res === "bigint"
-                ? new IntLiteralType(res)
-                : new RationalLiteralType(decimalToRational(res));
-        }
-
         // After 0.6.0 the type of ** is just the type of the lhs
         // Between 0.6.0 and 0.7.0 if the lhs is an int literal type it
         // took the type of the rhs if it wasn't a literal type. After 0.7.0 it
@@ -557,6 +544,19 @@ export class InferType {
             // For all other bitwise operators infer a common type. In earlier versions it wa allowed
             // to have bitwise ops between differing sizes
             return this.inferCommonType(a, b);
+        }
+
+        if (a instanceof NumericLiteralType && b instanceof NumericLiteralType) {
+            const res = evalConstantExpr(node, this);
+
+            assert(
+                res instanceof Decimal || typeof res === "bigint",
+                "Unexpected result of const binary op"
+            );
+
+            return typeof res === "bigint"
+                ? new IntLiteralType(res)
+                : new RationalLiteralType(decimalToRational(res));
         }
 
         throw new Error(`NYI Binary op ${node.operator}`);

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -1227,7 +1227,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             1n
         ],
         [
-            "FunctionCall (typeConversion, uint256(~uint8(1))",
+            "Edge-case: uint256(~uint8(1))",
             (factory: ASTNodeFactory) =>
                 factory.makeFunctionCall(
                     "uint256",
@@ -1249,6 +1249,57 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                 ),
             true,
             254n
+        ],
+        [
+            "Edge-case <0.8.0: -uint8(1)",
+            (factory: ASTNodeFactory) =>
+                factory.makeUnaryOperation(
+                    "<missing>",
+                    true,
+                    "-",
+                    factory.makeFunctionCall(
+                        "uint8",
+                        FunctionCallKind.TypeConversion,
+                        factory.makeElementaryTypeNameExpression("type(uint8)", "uint8"),
+                        [factory.makeLiteral("int_const 1", LiteralKind.Number, "31", "1")]
+                    )
+                ),
+            true,
+            255n
+        ],
+        [
+            "Edge-case <0.8.0: uint8(255) + 1",
+            (factory: ASTNodeFactory) =>
+                factory.makeBinaryOperation(
+                    "<missing>",
+                    "+",
+                    factory.makeFunctionCall(
+                        "uint8",
+                        FunctionCallKind.TypeConversion,
+                        factory.makeElementaryTypeNameExpression("type(uint8)", "uint8"),
+                        [factory.makeLiteral("int_const 255", LiteralKind.Number, "", "255")]
+                    ),
+                    factory.makeLiteral("int_const 1", LiteralKind.Number, "31", "1")
+                ),
+            true,
+            0n
+        ],
+        [
+            "Edge-case <0.8.0: 1 + uint8(255)",
+            (factory: ASTNodeFactory) =>
+                factory.makeBinaryOperation(
+                    "<missing>",
+                    "+",
+                    factory.makeLiteral("int_const 1", LiteralKind.Number, "31", "1"),
+                    factory.makeFunctionCall(
+                        "uint8",
+                        FunctionCallKind.TypeConversion,
+                        factory.makeElementaryTypeNameExpression("type(uint8)", "uint8"),
+                        [factory.makeLiteral("int_const 255", LiteralKind.Number, "", "255")]
+                    )
+                ),
+            true,
+            0n
         ]
     ];
 

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -1179,7 +1179,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             127n
         ],
         [
-            "FunctionCall (nsigned->signed typeConversion 1)",
+            "FunctionCall (unsigned->signed typeConversion 1)",
             (factory: ASTNodeFactory) =>
                 factory.makeFunctionCall(
                     "int8",
@@ -1191,7 +1191,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             -128n
         ],
         [
-            "FunctionCall (nsigned->signed typeConversion 2)",
+            "FunctionCall (unsigned->signed typeConversion 2)",
             (factory: ASTNodeFactory) =>
                 factory.makeFunctionCall(
                     "int8",
@@ -1203,7 +1203,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             127n
         ],
         [
-            "FunctionCall (nsigned->signed typeConversion 3)",
+            "FunctionCall (unsigned->signed typeConversion 3)",
             (factory: ASTNodeFactory) =>
                 factory.makeFunctionCall(
                     "int8",
@@ -1215,7 +1215,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             0n
         ],
         [
-            "FunctionCall (nsigned->signed typeConversion 3)",
+            "FunctionCall (unsigned->signed typeConversion 3)",
             (factory: ASTNodeFactory) =>
                 factory.makeFunctionCall(
                     "int8",
@@ -1225,6 +1225,30 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                 ),
             true,
             1n
+        ],
+        [
+            "FunctionCall (typeConversion, uint256(~uint8(1))",
+            (factory: ASTNodeFactory) =>
+                factory.makeFunctionCall(
+                    "uint256",
+                    FunctionCallKind.TypeConversion,
+                    factory.makeElementaryTypeNameExpression("type(uint256)", "uint256"),
+                    [
+                        factory.makeUnaryOperation(
+                            "uint8",
+                            true,
+                            "~",
+                            factory.makeFunctionCall(
+                                "uint8",
+                                FunctionCallKind.TypeConversion,
+                                factory.makeElementaryTypeNameExpression("type(uint8)", "uint8"),
+                                [factory.makeLiteral("int_const 1", LiteralKind.Number, "31", "1")]
+                            )
+                        )
+                    ]
+                ),
+            true,
+            254n
         ]
     ];
 

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -722,7 +722,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                     factory.makeLiteral("<missing>", LiteralKind.Number, "", "2")
                 ),
             true,
-            -1n
+            255n
         ],
         [
             "BinaryOperation (2 * 2)",
@@ -809,7 +809,12 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                     factory.makeLiteral("<missing>", LiteralKind.Number, "", "256")
                 ),
             true,
-            115792089237316195423570985008687907853269984665640564039457584007913129639936n
+            /**
+             * Note that actual result is
+             * 115792089237316195423570985008687907853269984665640564039457584007913129639936n
+             * but it gets clamped to 0 to respect uint256 type boundaries.
+             */
+            0n
         ],
         [
             "BinaryOperation (2 << 5)",

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -722,7 +722,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                     factory.makeLiteral("<missing>", LiteralKind.Number, "", "2")
                 ),
             true,
-            255n
+            -1n
         ],
         [
             "BinaryOperation (2 * 2)",
@@ -809,12 +809,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                     factory.makeLiteral("<missing>", LiteralKind.Number, "", "256")
                 ),
             true,
-            /**
-             * Note that actual result is
-             * 115792089237316195423570985008687907853269984665640564039457584007913129639936n
-             * but it gets clamped to 0 to respect uint256 type boundaries.
-             */
-            0n
+            115792089237316195423570985008687907853269984665640564039457584007913129639936n
         ],
         [
             "BinaryOperation (2 << 5)",


### PR DESCRIPTION
## Changes
- [x] Respect types when evaluating unary and binary operations in `evalConstantExpr()`.
- [x] Add edge-cases to tests.

Regards.