### PR TITLE
Migrate functionality from sol-dbg

### DIFF
--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,5 +1,6 @@
 export * from "./location";
 export * from "./node";
 export * from "./pretty_printing";
+export * from "./srcmap";
 export * from "./struct_equality";
 export * from "./utils";

--- a/src/misc/srcmap.ts
+++ b/src/misc/srcmap.ts
@@ -1,0 +1,105 @@
+export type DecodedBytecodeSourceMapEntry = {
+    start: number;
+    length: number;
+    sourceIndex: number;
+    jump: "i" | "o" | "-" | undefined;
+};
+
+export function fastParseBytecodeSourceMapping(sourceMap: string): DecodedBytecodeSourceMapEntry[] {
+    const res: DecodedBytecodeSourceMapEntry[] = [];
+    let curNum: number | undefined = undefined;
+    let elIdx = 0;
+
+    let sign = 1;
+    let start = 0;
+    let length = 0;
+    let sourceIndex = 0;
+    let jump: "i" | "o" | "-" | undefined;
+
+    for (let i = 0; i < sourceMap.length; i++) {
+        const c = sourceMap.charCodeAt(i);
+
+        if (c === 45 /*-*/) {
+            sign = -1;
+        }
+
+        if (c == 59 /*;*/ || c == 58 /*:*/) {
+            if (curNum !== undefined) {
+                if (elIdx === 0) {
+                    start = sign * curNum;
+                } else if (elIdx === 1) {
+                    length = sign * curNum;
+                } else if (elIdx === 2) {
+                    sourceIndex = sign * curNum;
+                }
+            }
+
+            curNum = undefined;
+            sign = 1;
+
+            if (c == 59 /*;*/) {
+                res.push({
+                    start,
+                    length,
+                    sourceIndex,
+                    jump
+                });
+
+                elIdx = 0;
+            } else {
+                elIdx++;
+            }
+
+            continue;
+        }
+
+        // jump specifier
+        if (c == 105 /*i*/ || c == 111 /*o*/ || c == 45 /*-*/) {
+            jump = String.fromCharCode(c) as "i" | "o" | "-";
+            continue;
+        }
+
+        // Must be a digit
+        const digit = c - 48; /*0*/
+        curNum = curNum === undefined ? digit : curNum * 10 + digit;
+    }
+
+    res.push({
+        start,
+        length,
+        sourceIndex,
+        jump
+    });
+
+    return res;
+}
+
+/**
+ * @see https://ethereum.stackexchange.com/a/26216 for the original implementation
+ */
+export function parseBytecodeSourceMapping(sourceMap: string): DecodedBytecodeSourceMapEntry[] {
+    return sourceMap
+        .split(";")
+        .map((chunk) => chunk.split(":"))
+        .map(([start, length, sourceIndex, jump]) => ({
+            start: start === "" ? undefined : start,
+            length: length === "" ? undefined : length,
+            sourceIndex: sourceIndex === "" ? undefined : sourceIndex,
+            jump: jump === "" ? undefined : jump
+        }))
+        .reduce(
+            ([previous, ...all], entry) => [
+                {
+                    start: parseInt(entry.start || previous.start, 10),
+                    length: parseInt(entry.length || previous.length, 10),
+                    sourceIndex: parseInt(entry.sourceIndex || previous.sourceIndex, 10),
+                    jump: entry.jump || previous.jump
+                },
+                previous,
+                ...all
+            ],
+            [{} as any]
+        )
+        .reverse()
+        .slice(1);
+}

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -2299,13 +2299,58 @@ export class InferType {
     }
 
     /**
+     * Determine if the specified type `typ` is dynamic or not. Dynamic means
+     * that if we are trying to read `typ` at location `loc`, in `loc` there should be just a
+     * uint256 offset into memory/storage/calldata, where the actual data lives. Otherwise
+     * (if the type is "static"), the direct encoding of the data will start at `loc`.
+     *
+     * Usually "static" types are just the value types - i.e. anything of statically
+     * known size that fits in a uint256. As per https://docs.soliditylang.org/en/latest/abi-spec.html#formal-specification-of-the-encoding
+     * there are several exceptions to the rule when encoding types in calldata:
+     *
+     * 1. Fixed size arrays with fixed-sized element types
+     * 2. Tuples where all the tuple elements are fixed-size
+     *
+     * @todo (Dimo):
+     * 1. Check again that its not possible for tuples in internal calls to somehow get encoded on the stack
+     * 2. What happens with return tuples? Are they always in memory?
+     */
+    isTypeEncodingDynamic(typ: TypeNode): boolean {
+        if (
+            typ instanceof PointerType ||
+            typ instanceof ArrayType ||
+            typ instanceof StringType ||
+            typ instanceof BytesType
+        ) {
+            return true;
+        }
+
+        // Tuples in calldata with static elements
+        if (typ instanceof TupleType) {
+            for (const elT of typ.elements) {
+                assert(elT !== null, `Unexpected empty tuple element in {0}`, typ);
+
+                if (this.isTypeEncodingDynamic(elT)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
      * Convert an internal TypeNode to the external TypeNode that would correspond to it
-     * after ABI-encoding with encoder version. Follows the following rules:
+     * after ABI-encoding with encoder version `encoderVersion`. Follows the following rules:
      *
      * 1. Contract definitions turned to address.
      * 2. Enum definitions turned to uint of minimal fitting size.
-     * 3. Any storage pointer types are converted to memory pointer types.
+     * 3. Storage pointer types are converted to memory pointer types when `normalizePointers` is set to `true`.
      * 4. Throw an error on any nested mapping types.
+     * 5. Fixed-size arrays with fixed-sized element types are encoded as inlined tuples
+     * 6. Structs with fixed-sized elements are encoded as inlined tuples
      *
      * @see https://docs.soliditylang.org/en/latest/abi-spec.html
      */
@@ -2319,16 +2364,27 @@ export class InferType {
         }
 
         if (type instanceof ArrayType) {
-            return new ArrayType(
-                this.toABIEncodedType(type.elementT, encoderVersion, normalizePointers),
-                type.size
-            );
+            const elT = this.toABIEncodedType(type.elementT, encoderVersion);
+
+            if (type.size !== undefined) {
+                const elements = [];
+
+                for (let i = 0; i < type.size; i++) {
+                    elements.push(elT);
+                }
+
+                return new TupleType(elements);
+            }
+
+            return new ArrayType(elT, type.size);
         }
 
         if (type instanceof PointerType) {
             const toT = this.toABIEncodedType(type.to, encoderVersion, normalizePointers);
 
-            return new PointerType(toT, normalizePointers ? DataLocation.Memory : type.location);
+            return this.isTypeEncodingDynamic(toT)
+                ? new PointerType(toT, normalizePointers ? DataLocation.Memory : type.location)
+                : toT;
         }
 
         if (type instanceof UserDefinedType) {

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -2315,7 +2315,7 @@ export class InferType {
      * 1. Check again that its not possible for tuples in internal calls to somehow get encoded on the stack
      * 2. What happens with return tuples? Are they always in memory?
      */
-    isTypeEncodingDynamic(typ: TypeNode): boolean {
+    isABITypeEncodingDynamic(typ: TypeNode): boolean {
         if (
             typ instanceof PointerType ||
             typ instanceof ArrayType ||
@@ -2330,7 +2330,7 @@ export class InferType {
             for (const elT of typ.elements) {
                 assert(elT !== null, `Unexpected empty tuple element in {0}`, typ);
 
-                if (this.isTypeEncodingDynamic(elT)) {
+                if (this.isABITypeEncodingDynamic(elT)) {
                     return true;
                 }
             }
@@ -2382,7 +2382,7 @@ export class InferType {
         if (type instanceof PointerType) {
             const toT = this.toABIEncodedType(type.to, encoderVersion, normalizePointers);
 
-            return this.isTypeEncodingDynamic(toT)
+            return this.isABITypeEncodingDynamic(toT)
                 ? new PointerType(toT, normalizePointers ? DataLocation.Memory : type.location)
                 : toT;
         }

--- a/test/unit/misc/srcmap.spec.ts
+++ b/test/unit/misc/srcmap.spec.ts
@@ -1,0 +1,27 @@
+import expect from "expect";
+import { fastParseBytecodeSourceMapping, parseBytecodeSourceMapping } from "../../../src";
+
+const samples: string[] = [
+    "29071:3352:71:-:0;;;1572:26:47;;;-1:-1:-1;;1572:26:47;1594:4;1572:26;;;29071:3352:71;;;;;;;;;;;;;;;;",
+    "8223:2087:74:-:0;;;8278:61;;;;;;;;;-1:-1:-1;8302:14:74;:30;;-1:-1:-1;;;;;;8302:30:74;8327:4;8302:30;;;8223:2087;;;;;;",
+    "23093:1079:71:-:0;;;1572:26:47;;;-1:-1:-1;;1572:26:47;1594:4;1572:26;;;23093:1079:71;;;;;;;;;;;;;;;;",
+    "5343:1530:78:-:0;;;;;;;;;;;;;;;;;;;"
+];
+
+describe("Source map parsing tests", () => {
+    for (const sample of samples) {
+        it(sample, () => {
+            const common = parseBytecodeSourceMapping(sample);
+            const fast = fastParseBytecodeSourceMapping(sample);
+
+            expect(common.length).toEqual(fast.length);
+
+            for (let i = 0; i < common.length; i++) {
+                expect(common[i].start).toEqual(fast[i].start);
+                expect(common[i].length).toEqual(fast[i].length);
+                expect(common[i].jump).toEqual(fast[i].jump);
+                expect(common[i].sourceIndex).toEqual(fast[i].sourceIndex);
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Preface
This PR migrates some functionality from https://github.com/ConsenSys/sol-dbg to be reusable in other dependent packages (like https://github.com/ConsenSys/scribble).

## Changes
- [x] Introduced source map parsing functions `fastParseBytecodeSourceMapping()` and `parseBytecodeSourceMapping()`.
- [x] Tweak `InferType.toABIEncodedType()`.
- [x] Add tests.

Regards.