### PR TITLE
Improve precision of `isFunctionCallExternal()`

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -332,11 +332,26 @@ export function isFunctionCallExternal(call: FunctionCall, inference: InferType)
     const exprT = inference.typeOf(call.vExpression);
 
     if (exprT instanceof FunctionType) {
+        if (exprT.implicitFirstArg) {
+            /**
+             * Calls for using-for are not considered as external.
+             * Currently "implicitFirstArg" is used only for using-for.
+             */
+            return false;
+        }
+
         if (exprT.visibility === FunctionVisibility.External) {
             return true;
         }
 
         if (exprT.visibility === FunctionVisibility.Public) {
+            /**
+             * We have external calls when we have call expression like "expr.fun()",
+             * where "expr" is an identifier, "this" or an expression of ContractType.
+             *
+             * Other expressions, that are invoked via an identifier are causing internal calls,
+             * so we exclude them.
+             */
             return call.vExpression.getChildrenByType(MemberAccess, true).length > 0;
         }
     }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -337,7 +337,7 @@ export function isFunctionCallExternal(call: FunctionCall, inference: InferType)
         }
 
         if (exprT.visibility === FunctionVisibility.Public) {
-            return call.getChildrenByType(MemberAccess).length > 0;
+            return call.vExpression.getChildrenByType(MemberAccess, true).length > 0;
         }
     }
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -334,7 +334,7 @@ export function isFunctionCallExternal(call: FunctionCall, inference: InferType)
     if (exprT instanceof FunctionType) {
         if (exprT.implicitFirstArg) {
             /**
-             * Calls for using-for are not considered as external.
+             * Calls via using-for are not considered as external.
              * Currently "implicitFirstArg" is used only for using-for.
              */
             return false;
@@ -346,11 +346,12 @@ export function isFunctionCallExternal(call: FunctionCall, inference: InferType)
 
         if (exprT.visibility === FunctionVisibility.Public) {
             /**
-             * We have external calls when we have call expression like "expr.fun()",
+             * We have external calls when call expression have pattern "expr.fun()",
              * where "expr" is an identifier, "this" or an expression of ContractType.
              *
-             * Other expressions, that are invoked via an identifier are causing internal calls,
-             * so we exclude them.
+             * Other expressions, that are invoked via an identifier or struct type
+             * are requiring function type to have non-public visibility,
+             * so they are handled by other cases.
              */
             return call.vExpression.getChildrenByType(MemberAccess, true).length > 0;
         }

--- a/test/integration/types/external_calls.spec.ts
+++ b/test/integration/types/external_calls.spec.ts
@@ -126,20 +126,10 @@ describe("isFunctionCallExternal()", () => {
             );
 
             const actual = units[0]
-                .getChildrenBySelector<FunctionCall>((node): node is FunctionCall => {
-                    /**
-                     * This function is expanded for debug purposes.
-                     *
-                     * Collapsing this code to a single return forces regular rewriting.
-                     */
-                    if (node instanceof FunctionCall) {
-                        if (isFunctionCallExternal(node, inference)) {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                })
+                .getChildrenBySelector<FunctionCall>(
+                    (node): node is FunctionCall => node instanceof FunctionCall
+                )
+                .filter((node) => isFunctionCallExternal(node, inference))
                 .map((node) => writer.write(node.vExpression));
 
             expect(actual).toEqual(expected);

--- a/test/integration/types/external_calls.spec.ts
+++ b/test/integration/types/external_calls.spec.ts
@@ -78,8 +78,7 @@ contract Main {
 
         this.v();
     }
-}       
-`,
+}`,
         [
             "this.c",
             "f.a",


### PR DESCRIPTION
## Preface
This PR fixes #171.

## Changes
- [x] Tweak `isFunctionCallExternal()` to rely on type inference instead of analyzing `typeString`s.

Regards.