### PR TITLE
Introduce `license` field of `SourceUnit`

### DIFF
--- a/src/ast/ast_node_factory.ts
+++ b/src/ast/ast_node_factory.ts
@@ -425,6 +425,7 @@ const argExtractionMapping = new Map<ASTNodeConstructor<ASTNode>, (node: any) =>
             node.absolutePath,
             node.exportedSymbols,
             node.children,
+            node.license,
             node.raw
         ]
     ],

--- a/src/ast/implementation/meta/source_unit.ts
+++ b/src/ast/implementation/meta/source_unit.ts
@@ -42,6 +42,11 @@ export class SourceUnit extends ASTNodeWithChildren<ASTNode> {
      */
     exportedSymbols: Map<string, number>;
 
+    /**
+     * SPDX license identifier (if provided)
+     */
+    license?: string;
+
     constructor(
         id: number,
         src: string,
@@ -50,6 +55,7 @@ export class SourceUnit extends ASTNodeWithChildren<ASTNode> {
         absolutePath: string,
         exportedSymbols: Map<string, number>,
         children?: Iterable<ASTNode>,
+        license?: string,
         raw?: any
     ) {
         super(id, src, raw);
@@ -58,6 +64,7 @@ export class SourceUnit extends ASTNodeWithChildren<ASTNode> {
         this.sourceListIndex = sourceListIndex;
         this.absolutePath = absolutePath;
         this.exportedSymbols = exportedSymbols;
+        this.license = license;
 
         if (children) {
             for (const node of children) {

--- a/src/ast/legacy/source_unit_processor.ts
+++ b/src/ast/legacy/source_unit_processor.ts
@@ -23,6 +23,16 @@ export class LegacySourceUnitProcessor extends LegacyNodeProcessor<SourceUnit> {
             symbols.set(name, exportedSymbols[name][0]);
         }
 
-        return [id, src, sourceEntryKey, sourceListIndex, absolutePath, symbols, children, raw];
+        return [
+            id,
+            src,
+            sourceEntryKey,
+            sourceListIndex,
+            absolutePath,
+            symbols,
+            children,
+            undefined,
+            raw
+        ];
     }
 }

--- a/src/ast/modern/source_unit_processor.ts
+++ b/src/ast/modern/source_unit_processor.ts
@@ -14,6 +14,7 @@ export class ModernSourceUnitProcessor extends ModernNodeProcessor<SourceUnit> {
         const sourceListIndex = parseInt(src.slice(src.lastIndexOf(":") + 1), 10);
         const absolutePath: string = raw.absolutePath;
         const exportedSymbols = raw.exportedSymbols;
+        const license: string | undefined = raw.license;
 
         const symbols = new Map<string, number>();
 
@@ -23,6 +24,16 @@ export class ModernSourceUnitProcessor extends ModernNodeProcessor<SourceUnit> {
 
         const children = reader.convertArray(raw.nodes, config);
 
-        return [id, src, sourceEntryKey, sourceListIndex, absolutePath, symbols, children, raw];
+        return [
+            id,
+            src,
+            sourceEntryKey,
+            sourceListIndex,
+            absolutePath,
+            symbols,
+            children,
+            license,
+            raw
+        ];
     }
 }

--- a/src/ast/writing/ast_mapping.ts
+++ b/src/ast/writing/ast_mapping.ts
@@ -102,14 +102,14 @@ function descTrimRight(desc: SrcDesc): void {
     }
 }
 
-function isSpdxLicence(desc: SrcDesc): boolean {
+function hasSpdxLicence(desc: SrcDesc): boolean {
     const first = desc[0];
 
     if (typeof first === "string") {
         return first.includes("SPDX-License-Identifier");
     }
 
-    return isSpdxLicence(first[1]);
+    return hasSpdxLicence(first[1]);
 }
 
 /**
@@ -1474,12 +1474,13 @@ class SourceUnitWriter extends ASTNodeWriter {
 
         descTrimRight(result);
 
-        if (node.license && !isSpdxLicence(result)) {
+        if (node.license && !hasSpdxLicence(result)) {
             result.unshift(
                 StructuredDocumentationWriter.render(
                     "SPDX-License-Identifier: " + node.license,
                     writer.formatter
-                ) + wrap
+                ),
+                wrap
             );
         }
 

--- a/src/ast/writing/ast_mapping.ts
+++ b/src/ast/writing/ast_mapping.ts
@@ -102,6 +102,16 @@ function descTrimRight(desc: SrcDesc): void {
     }
 }
 
+function isSpdxLicence(desc: SrcDesc): boolean {
+    const first = desc[0];
+
+    if (typeof first === "string") {
+        return first.includes("SPDX-License-Identifier");
+    }
+
+    return isSpdxLicence(first[1]);
+}
+
 /**
  * A small hack to handle semicolons in the last statement of compound statements like if and while. Given:
  *
@@ -1463,6 +1473,15 @@ class SourceUnitWriter extends ASTNodeWriter {
         }
 
         descTrimRight(result);
+
+        if (node.license && !isSpdxLicence(result)) {
+            result.unshift(
+                StructuredDocumentationWriter.render(
+                    "SPDX-License-Identifier: " + node.license,
+                    writer.formatter
+                ) + wrap
+            );
+        }
 
         return result;
     }

--- a/src/misc/struct_equality.ts
+++ b/src/misc/struct_equality.ts
@@ -9,11 +9,6 @@ export function isPrimitive(a: any): boolean {
     );
 }
 
-// Hack to recognize big ints
-export function isBigInt(a: any): boolean {
-    return typeof a === "number" || typeof a === "bigint";
-}
-
 export function hasKeysOf(a: Record<string, any>, b: Record<string, any>): boolean {
     const hasProperty = Object.prototype.hasOwnProperty;
 
@@ -48,6 +43,10 @@ export function eq(a: any, b: any, visited?: Map<any, any>): boolean {
         return true;
     }
 
+    if (isPrimitive(a) || isPrimitive(b)) {
+        return a === b;
+    }
+
     if (visited === undefined) {
         visited = new Map<any, any>();
     }
@@ -60,14 +59,6 @@ export function eq(a: any, b: any, visited?: Map<any, any>): boolean {
     }
 
     visited.set(a, b);
-
-    if (isPrimitive(a) || isPrimitive(b)) {
-        return a === b;
-    }
-
-    if (isBigInt(a) && isBigInt(b)) {
-        return a === b;
-    }
 
     if (a instanceof Array && b instanceof Array) {
         if (a.length !== b.length) {

--- a/test/integration/sol-ast-compile/source/snapshot.spec.ts
+++ b/test/integration/sol-ast-compile/source/snapshot.spec.ts
@@ -101,6 +101,16 @@ const cases: Array<[string, string, string]> = [
         "test/samples/solidity/dispatch_05.json",
         "test/samples/solidity/dispatch_05.sourced.sol",
         "0.5.17"
+    ],
+    [
+        "test/samples/solidity/spdx/sample00.sol",
+        "test/samples/solidity/spdx/sample00.sourced.sol",
+        "auto"
+    ],
+    [
+        "test/samples/solidity/spdx/sample01.sol",
+        "test/samples/solidity/spdx/sample01.sourced.sol",
+        "auto"
     ]
 ];
 
@@ -139,13 +149,14 @@ for (const [fileName, sample, compilerVersion] of cases) {
             });
 
             it("STDOUT is correct", () => {
-                const content = fse.readFileSync(sample, { encoding: "utf-8" });
                 const result = outData.replace(new RegExp(process.cwd(), "g"), "");
 
                 // Uncomment next line to update snapshots
                 // fse.writeFileSync(sample, result, { encoding: "utf-8" });
 
-                expect(result).toEqual(content);
+                const expected = fse.readFileSync(sample, { encoding: "utf-8" });
+
+                expect(result).toEqual(expected);
             });
         });
     }

--- a/test/samples/solidity/declarations/contract_050.nodes.native.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.native.txt
@@ -5,6 +5,7 @@ SourceUnit #146
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/declarations/contract_050.sol"
     exportedSymbols: Map(3) { "A" -> 90, "B" -> 100, "C" -> 145 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(0)
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/declarations/contract_050.nodes.wasm.txt
+++ b/test/samples/solidity/declarations/contract_050.nodes.wasm.txt
@@ -5,6 +5,7 @@ SourceUnit #146
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/declarations/contract_050.sol"
     exportedSymbols: Map(3) { "A" -> 90, "B" -> 100, "C" -> 145 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(0)
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.nodes.native.txt
+++ b/test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.nodes.native.txt
@@ -5,6 +5,7 @@ SourceUnit #21
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.sol"
     exportedSymbols: Map(2) { "A" -> 20, "B" -> 14 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #16 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #17 ]
@@ -148,6 +149,7 @@ SourceUnit #30
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/different_abi_encoders/v1_imports_v2/v2.sol"
     exportedSymbols: Map(1) { "B" -> 29 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #22 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.nodes.wasm.txt
+++ b/test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.nodes.wasm.txt
@@ -5,6 +5,7 @@ SourceUnit #21
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/different_abi_encoders/v1_imports_v2/v1.sol"
     exportedSymbols: Map(2) { "A" -> 20, "B" -> 14 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #16 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #17 ]
@@ -148,6 +149,7 @@ SourceUnit #30
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/different_abi_encoders/v1_imports_v2/v2.sol"
     exportedSymbols: Map(1) { "B" -> 29 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #22 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.nodes.native.txt
+++ b/test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.nodes.native.txt
@@ -5,6 +5,7 @@ SourceUnit #34
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/different_abi_encoders/v2_imports_v1/v1.sol"
     exportedSymbols: Map(1) { "B" -> 33 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #24 ]
     <getter> vImportDirectives: Array(0)
@@ -273,6 +274,7 @@ SourceUnit #46
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.sol"
     exportedSymbols: Map(2) { "A" -> 45, "B" -> 10 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #35 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #36 ]

--- a/test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.nodes.wasm.txt
+++ b/test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.nodes.wasm.txt
@@ -5,6 +5,7 @@ SourceUnit #34
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/different_abi_encoders/v2_imports_v1/v1.sol"
     exportedSymbols: Map(1) { "B" -> 33 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #24 ]
     <getter> vImportDirectives: Array(0)
@@ -273,6 +274,7 @@ SourceUnit #46
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/different_abi_encoders/v2_imports_v1/v2.sol"
     exportedSymbols: Map(2) { "A" -> 45, "B" -> 10 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #35 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #36 ]

--- a/test/samples/solidity/issue_132_fun_kind.nodes.native.txt
+++ b/test/samples/solidity/issue_132_fun_kind.nodes.native.txt
@@ -5,6 +5,7 @@ SourceUnit #56
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/issue_132_fun_kind.sol"
     exportedSymbols: Map(1) { "FBNoArgs" -> 55 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #29 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/issue_132_fun_kind.nodes.wasm.txt
+++ b/test/samples/solidity/issue_132_fun_kind.nodes.wasm.txt
@@ -5,6 +5,7 @@ SourceUnit #56
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/issue_132_fun_kind.sol"
     exportedSymbols: Map(1) { "FBNoArgs" -> 55 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(1) [ PragmaDirective #29 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/latest_08.nodes.native.txt
+++ b/test/samples/solidity/latest_08.nodes.native.txt
@@ -5,6 +5,7 @@ SourceUnit #1614
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/latest_08.sol"
     exportedSymbols: Map(28) { "A_0813" -> 1530, "Builtins_0811" -> 1356, "CatchPanic" -> 987, "EmitsIdentifierPath" -> 909, "EnumABC" -> 856, "EnumTypeMinMax_088" -> 1286, "ExternalFnSelectorAndAddress_0810" -> 1317, "Features082" -> 1072, "Features084" -> 1141, "Features087" -> 1158, "Features_0812" -> 1419, "Features_0813" -> 1537, "Features_0815" -> 1592, "Features_0819" -> 1613, "InterfaceWithUDTV_088" -> 1261, "LI" -> 847, "LibErrors084" -> 1083, "LibWithUDVT_088" -> 1250, "Price" -> 1160, "Quantity" -> 1162, "RestrictedNumber_0813" -> 1421, "Some" -> 851, "UncheckedMathExample" -> 873, "UnitLevelError084" -> 1077, "UsesNewAddressMembers" -> 930, "createRestrictedNumber_0813" -> 1501, "minusOne" -> 1473, "plusOne" -> 1452 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(2) [ PragmaDirective #845, PragmaDirective #846 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #847 ]
@@ -15665,6 +15666,7 @@ SourceUnit #1682
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/latest_imports_08.sol"
     exportedSymbols: Map(5) { "Int" -> 1631, "SomeContract" -> 1628, "SomeLib" -> 1629, "add" -> 1681, "neg" -> 1655 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(2) [ PragmaDirective #1615, PragmaDirective #1616 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/latest_08.nodes.wasm.txt
+++ b/test/samples/solidity/latest_08.nodes.wasm.txt
@@ -5,6 +5,7 @@ SourceUnit #1614
     sourceListIndex: 0
     absolutePath: "./test/samples/solidity/latest_08.sol"
     exportedSymbols: Map(28) { "A_0813" -> 1530, "Builtins_0811" -> 1356, "CatchPanic" -> 987, "EmitsIdentifierPath" -> 909, "EnumABC" -> 856, "EnumTypeMinMax_088" -> 1286, "ExternalFnSelectorAndAddress_0810" -> 1317, "Features082" -> 1072, "Features084" -> 1141, "Features087" -> 1158, "Features_0812" -> 1419, "Features_0813" -> 1537, "Features_0815" -> 1592, "Features_0819" -> 1613, "InterfaceWithUDTV_088" -> 1261, "LI" -> 847, "LibErrors084" -> 1083, "LibWithUDVT_088" -> 1250, "Price" -> 1160, "Quantity" -> 1162, "RestrictedNumber_0813" -> 1421, "Some" -> 851, "UncheckedMathExample" -> 873, "UnitLevelError084" -> 1077, "UsesNewAddressMembers" -> 930, "createRestrictedNumber_0813" -> 1501, "minusOne" -> 1473, "plusOne" -> 1452 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(2) [ PragmaDirective #845, PragmaDirective #846 ]
     <getter> vImportDirectives: Array(1) [ ImportDirective #847 ]
@@ -15665,6 +15666,7 @@ SourceUnit #1682
     sourceListIndex: 1
     absolutePath: "./test/samples/solidity/latest_imports_08.sol"
     exportedSymbols: Map(5) { "Int" -> 1631, "SomeContract" -> 1628, "SomeLib" -> 1629, "add" -> 1681, "neg" -> 1655 }
+    license: undefined
     context: ASTContext #1000
     <getter> vPragmaDirectives: Array(2) [ PragmaDirective #1615, PragmaDirective #1616 ]
     <getter> vImportDirectives: Array(0)

--- a/test/samples/solidity/spdx/sample00.sol
+++ b/test/samples/solidity/spdx/sample00.sol
@@ -1,0 +1,4 @@
+///SPDX-License-Identifier: UNLICENSED
+/// Other documentation on SourceUnit level.
+
+contract Test {}

--- a/test/samples/solidity/spdx/sample00.sourced.sol
+++ b/test/samples/solidity/spdx/sample00.sourced.sol
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// test/samples/solidity/spdx/sample00.sol
+// ------------------------------------------------------------
+/// SPDX-License-Identifier: UNLICENSED
+///  Other documentation on SourceUnit level.
+contract Test {}

--- a/test/samples/solidity/spdx/sample01.sol
+++ b/test/samples/solidity/spdx/sample01.sol
@@ -1,0 +1,5 @@
+/// SPDX-License-Identifier: UNLICENSED
+/// Other documentation on SourceUnit level.
+pragma solidity 0.8.18;
+
+contract Test {}

--- a/test/samples/solidity/spdx/sample01.sourced.sol
+++ b/test/samples/solidity/spdx/sample01.sourced.sol
@@ -1,0 +1,7 @@
+// ------------------------------------------------------------
+// test/samples/solidity/spdx/sample01.sol
+// ------------------------------------------------------------
+/// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+contract Test {}


### PR DESCRIPTION
## Preface
Closes #128. Current compiler AST do not have documentation nodes for `SourceUnit`. Units only have `license` field (if license is specified). This implementation introduces minimal functionality and nothing extensive (to not cause over-engineering).

## Changes
- [x] Introduce support of `license` field of `SourceUnit`.
- [x] Tweak related AST-to-source writing logic.
- [x] Introduce related test samples.

Regards.