### PR TITLE
Resolve issue with AxiosResponse type on compiler downloading

### DIFF
--- a/src/compile/kinds/compiler.ts
+++ b/src/compile/kinds/compiler.ts
@@ -132,13 +132,18 @@ export async function getCompilerForVersion<T extends CompilerMapping>(
             `Unable to find build metadata for ${prefix} compiler ${version} in "list.json"`
         );
 
-        const response = await axios.get<Buffer>(`${BINARIES_URL}/${prefix}/${compilerFileName}`, {
-            responseType: "arraybuffer"
-        });
+        const response = await axios.get<ArrayBuffer>(
+            `${BINARIES_URL}/${prefix}/${compilerFileName}`,
+            {
+                responseType: "arraybuffer"
+            }
+        );
+
+        const buf = Buffer.from(response.data);
 
         const hash = crypto.createHash("sha256");
 
-        hash.update(response.data);
+        hash.update(buf);
 
         const digest = "0x" + hash.digest("hex");
 
@@ -153,7 +158,7 @@ export async function getCompilerForVersion<T extends CompilerMapping>(
          */
         const permissions = kind === CompilerKind.Native ? 0o555 : 0o444;
 
-        await fse.writeFile(compilerLocalPath, response.data, { mode: permissions });
+        await fse.writeFile(compilerLocalPath, buf, { mode: permissions });
     }
 
     if (kind === CompilerKind.Native) {


### PR DESCRIPTION
## Preface
This PR resolves #211

## Changes
- [x] Convert `AxiosResponse` to `Buffer` due to issues in newer NodeJS releases.

Regards.