### PR TITLE
Fix ABI encoding type for inline arrays

### DIFF
--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -2418,16 +2418,6 @@ export class InferType {
         if (type instanceof ArrayType) {
             const elT = this.toABIEncodedType(type.elementT, encoderVersion);
 
-            if (type.size !== undefined) {
-                const elements = [];
-
-                for (let i = 0; i < type.size; i++) {
-                    elements.push(elT);
-                }
-
-                return new TupleType(elements);
-            }
-
             return new ArrayType(elT, type.size);
         }
 


### PR DESCRIPTION
## Preface
This PR tweaks `InferType.toABIEncodedType()` to produce ABI typestring, that is consumable by `web3`s ABI encoder.

## Changes
- [x] Remove branch, causing inline arrays to have tuple type as ABI encoding type.

Regards.