### PR TITLE
Improve constant expression evaluator

### DIFF
--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -463,6 +463,12 @@ export function evalIndexAccess(node: IndexAccess, inference: InferType): Value 
 
         const indexInHex = plainIndex * 2;
 
+        if (indexInHex >= baseHex.length) {
+            throw new EvalError(
+                `Out-of-bounds index access ${indexInHex} (originally ${plainIndex}) to "${baseHex}"`
+            );
+        }
+
         return BigInt("0x" + baseHex.slice(indexInHex, indexInHex + 2));
     }
 
@@ -505,7 +511,7 @@ export function evalFunctionCall(node: FunctionCall, inference: InferType): Valu
         }
 
         if (castT instanceof FixedBytesType) {
-            return val;
+            return clampIntToType(val, new IntType(castT.size * 8, false));
         }
     }
 

--- a/src/types/eval_const.ts
+++ b/src/types/eval_const.ts
@@ -8,15 +8,17 @@ import {
     FunctionCall,
     FunctionCallKind,
     Identifier,
+    IndexAccess,
     Literal,
     LiteralKind,
+    MemberAccess,
     TimeUnit,
     TupleExpression,
     UnaryOperation,
     VariableDeclaration
 } from "../ast";
-import { assert, pp } from "../misc";
-import { IntType, NumericLiteralType } from "./ast";
+import { pp } from "../misc";
+import { BytesType, FixedBytesType, IntType, NumericLiteralType, StringType } from "./ast";
 import { InferType } from "./infer";
 import { BINARY_OPERATOR_GROUPS, SUBDENOMINATION_MULTIPLIERS, clampIntToType } from "./utils";
 /**
@@ -27,7 +29,7 @@ import { BINARY_OPERATOR_GROUPS, SUBDENOMINATION_MULTIPLIERS, clampIntToType } f
  */
 Decimal.set({ precision: 100 });
 
-export type Value = Decimal | boolean | string | bigint;
+export type Value = Decimal | boolean | string | bigint | Buffer;
 
 export class EvalError extends Error {
     expr?: Expression;
@@ -62,6 +64,10 @@ function promoteToDec(v: Value): Decimal {
         return new Decimal(v === "" ? 0 : "0x" + Buffer.from(v, "utf-8").toString("hex"));
     }
 
+    if (v instanceof Buffer) {
+        return new Decimal(v.length === 0 ? 0 : "0x" + v.toString("hex"));
+    }
+
     throw new Error(`Expected number not ${v}`);
 }
 
@@ -69,12 +75,21 @@ function demoteFromDec(d: Decimal): Decimal | bigint {
     return d.isInt() ? BigInt(d.toFixed()) : d;
 }
 
-export function isConstant(expr: Expression): boolean {
+export function isConstant(expr: Expression | VariableDeclaration): boolean {
     if (expr instanceof Literal) {
         return true;
     }
 
     if (expr instanceof UnaryOperation && isConstant(expr.vSubExpression)) {
+        return true;
+    }
+
+    if (
+        expr instanceof VariableDeclaration &&
+        expr.constant &&
+        expr.vValue &&
+        isConstant(expr.vValue)
+    ) {
         return true;
     }
 
@@ -108,17 +123,19 @@ export function isConstant(expr: Expression): boolean {
         return true;
     }
 
-    if (expr instanceof Identifier) {
-        const decl = expr.vReferencedDeclaration;
+    if (expr instanceof Identifier || expr instanceof MemberAccess) {
+        return (
+            expr.vReferencedDeclaration instanceof VariableDeclaration &&
+            isConstant(expr.vReferencedDeclaration)
+        );
+    }
 
-        if (
-            decl instanceof VariableDeclaration &&
-            decl.constant &&
-            decl.vValue &&
-            isConstant(decl.vValue)
-        ) {
-            return true;
-        }
+    if (expr instanceof IndexAccess) {
+        return (
+            isConstant(expr.vBaseExpression) &&
+            expr.vIndexExpression !== undefined &&
+            isConstant(expr.vIndexExpression)
+        );
     }
 
     if (
@@ -142,7 +159,7 @@ export function evalLiteralImpl(
     }
 
     if (kind === LiteralKind.HexString) {
-        return value === "" ? 0n : BigInt("0x" + value);
+        return Buffer.from(value, "hex");
     }
 
     if (kind === LiteralKind.String || kind === LiteralKind.UnicodeString) {
@@ -408,22 +425,93 @@ export function evalBinary(node: BinaryOperation, inference: InferType): Value {
     }
 }
 
+export function evalIndexAccess(node: IndexAccess, inference: InferType): Value {
+    const base = evalConstantExpr(node.vBaseExpression, inference);
+    const index = evalConstantExpr(node.vIndexExpression as Expression, inference);
+
+    if (!(typeof index === "bigint" || index instanceof Decimal)) {
+        throw new EvalError(
+            `Unexpected non-numeric index into base in expression ${pp(node)}`,
+            node
+        );
+    }
+
+    const plainIndex = index instanceof Decimal ? index.toNumber() : Number(index);
+
+    if (typeof base === "bigint" || base instanceof Decimal) {
+        let baseHex = base instanceof Decimal ? base.toHex().slice(2) : base.toString(16);
+
+        if (baseHex.length % 2 !== 0) {
+            baseHex = "0" + baseHex;
+        }
+
+        const indexInHex = plainIndex * 2;
+
+        return BigInt("0x" + baseHex.slice(indexInHex, indexInHex + 2));
+    }
+
+    if (base instanceof Buffer) {
+        const res = base.at(plainIndex);
+
+        if (res === undefined) {
+            throw new EvalError(
+                `Out-of-bounds index access ${plainIndex} to ${base.toString("hex")}`
+            );
+        }
+
+        return BigInt(res);
+    }
+
+    throw new EvalError(`Unable to process ${pp(node)}`, node);
+}
+
 export function evalFunctionCall(node: FunctionCall, inference: InferType): Value {
-    assert(
-        node.kind === FunctionCallKind.TypeConversion,
-        'Expected constant call to be a "{0}", but got "{1}" instead',
-        FunctionCallKind.TypeConversion,
-        node.kind
-    );
+    if (node.kind !== FunctionCallKind.TypeConversion) {
+        throw new EvalError(
+            `Expected function call to have kind "${FunctionCallKind.TypeConversion}", but got "${node.kind}" instead`,
+            node
+        );
+    }
+
+    if (!(node.vExpression instanceof ElementaryTypeNameExpression)) {
+        throw new EvalError(
+            `Expected function call expression to be an ${ElementaryTypeNameExpression.name}, but got "${node.type}" instead`,
+            node
+        );
+    }
 
     const val = evalConstantExpr(node.vArguments[0], inference);
+    const castT = inference.typeOfElementaryTypeNameExpression(node.vExpression).type;
 
-    if (typeof val === "bigint" && node.vExpression instanceof ElementaryTypeNameExpression) {
-        const castT = inference.typeOfElementaryTypeNameExpression(node.vExpression);
-        const toT = castT.type;
+    if (typeof val === "bigint") {
+        if (castT instanceof IntType) {
+            return clampIntToType(val, castT);
+        }
 
-        if (toT instanceof IntType) {
-            return clampIntToType(val, toT);
+        if (castT instanceof FixedBytesType) {
+            return val;
+        }
+    }
+
+    if (typeof val === "string") {
+        if (castT instanceof BytesType) {
+            return Buffer.from(val, "utf-8");
+        }
+
+        if (castT instanceof FixedBytesType) {
+            const buf = Buffer.from(val, "utf-8");
+
+            return BigInt("0x" + buf.slice(0, castT.size).toString("hex"));
+        }
+    }
+
+    if (val instanceof Buffer) {
+        if (castT instanceof StringType) {
+            return val.toString("utf-8");
+        }
+
+        if (castT instanceof FixedBytesType) {
+            return BigInt("0x" + val.slice(0, castT.size).toString("hex"));
         }
     }
 
@@ -437,7 +525,10 @@ export function evalFunctionCall(node: FunctionCall, inference: InferType): Valu
  * @todo The order of some operations changed in some version.
  * Current implementation does not yet take it into an account.
  */
-export function evalConstantExpr(node: Expression, inference: InferType): Value {
+export function evalConstantExpr(
+    node: Expression | VariableDeclaration,
+    inference: InferType
+): Value {
     if (!isConstant(node)) {
         throw new NonConstantExpressionError(node);
     }
@@ -464,12 +555,19 @@ export function evalConstantExpr(node: Expression, inference: InferType): Value 
             : evalConstantExpr(node.vFalseExpression, inference);
     }
 
-    if (node instanceof Identifier) {
-        const decl = node.vReferencedDeclaration;
+    if (node instanceof VariableDeclaration) {
+        return evalConstantExpr(node.vValue as Expression, inference);
+    }
 
-        if (decl instanceof VariableDeclaration) {
-            return evalConstantExpr(decl.vValue as Expression, inference);
-        }
+    if (node instanceof Identifier || node instanceof MemberAccess) {
+        return evalConstantExpr(
+            node.vReferencedDeclaration as Expression | VariableDeclaration,
+            inference
+        );
+    }
+
+    if (node instanceof IndexAccess) {
+        return evalIndexAccess(node, inference);
     }
 
     if (node instanceof FunctionCall) {

--- a/test/integration/eval_const.spec.ts
+++ b/test/integration/eval_const.spec.ts
@@ -38,7 +38,8 @@ const cases: Array<[string, Array<[string, Value]>]> = [
 
             ["//VariableDeclaration[@name='U16S']", 30841n],
             ["//VariableDeclaration[@name='U16B']", 30841n],
-            ["//VariableDeclaration[@name='B2U']", 258n]
+            ["//VariableDeclaration[@name='B2U']", 258n],
+            ["//VariableDeclaration[@name='NON_UTF8_SEQ']", Buffer.from("7532eaac", "hex")]
         ]
     ]
 ];

--- a/test/integration/eval_const.spec.ts
+++ b/test/integration/eval_const.spec.ts
@@ -18,21 +18,27 @@ const cases: Array<[string, Array<[string, Value]>]> = [
     [
         "test/samples/solidity/consts/consts.sol",
         [
-            ["//VariableDeclaration[@id=5]", 100n],
-            ["//VariableDeclaration[@id=8]", 15n],
-            ["//VariableDeclaration[@id=13]", 115n],
-            ["//VariableDeclaration[@id=18]", 158n],
-            ["//VariableDeclaration[@id=24]", 158n],
-            ["//VariableDeclaration[@id=31]", false],
-            ["//VariableDeclaration[@id=37]", 158n],
-            ["//VariableDeclaration[@id=44]", 85n],
-            ["//VariableDeclaration[@id=47]", "abcd"],
-            ["//VariableDeclaration[@id=53]", Buffer.from("abcd", "utf-8")],
-            ["//VariableDeclaration[@id=58]", 97n],
-            ["//VariableDeclaration[@id=64]", "abcd"],
-            ["//VariableDeclaration[@id=73]", 30841n],
-            ["//VariableDeclaration[@id=82]", 30841n],
-            ["//VariableDeclaration[@id=88]", 258n]
+            ["//VariableDeclaration[@name='SOME_CONST']", 100n],
+            ["//VariableDeclaration[@name='SOME_OTHER']", 15n],
+            ["//VariableDeclaration[@name='SOME_ELSE']", 115n],
+            ["//VariableDeclaration[@name='C2']", 158n],
+            ["//VariableDeclaration[@name='C3']", 158n],
+            [
+                "//VariableDeclaration[@name='C4']",
+                115792089237316195423570985008687907853269984665640564039457584007913129639836n
+            ],
+            ["//VariableDeclaration[@name='C5']", false],
+            ["//VariableDeclaration[@name='C6']", 158n],
+            ["//VariableDeclaration[@name='C7']", 85n],
+
+            ["//VariableDeclaration[@name='FOO']", "abcd"],
+            ["//VariableDeclaration[@name='BOO']", Buffer.from("abcd", "utf-8")],
+            ["//VariableDeclaration[@name='MOO']", 97n],
+            ["//VariableDeclaration[@name='WOO']", "abcd"],
+
+            ["//VariableDeclaration[@name='U16S']", 30841n],
+            ["//VariableDeclaration[@name='U16B']", 30841n],
+            ["//VariableDeclaration[@name='B2U']", 258n]
         ]
     ]
 ];

--- a/test/integration/eval_const.spec.ts
+++ b/test/integration/eval_const.spec.ts
@@ -1,0 +1,101 @@
+import expect from "expect";
+import {
+    assert,
+    ASTReader,
+    compileSol,
+    detectCompileErrors,
+    evalConstantExpr,
+    Expression,
+    InferType,
+    LatestCompilerVersion,
+    SourceUnit,
+    Value,
+    VariableDeclaration,
+    XPath
+} from "../../src";
+
+const cases: Array<[string, Array<[string, Value]>]> = [
+    [
+        "test/samples/solidity/consts/consts.sol",
+        [
+            ["//VariableDeclaration[@id=5]", 100n],
+            ["//VariableDeclaration[@id=8]", 15n],
+            ["//VariableDeclaration[@id=13]", 115n],
+            ["//VariableDeclaration[@id=18]", 158n],
+            ["//VariableDeclaration[@id=24]", 158n],
+            ["//VariableDeclaration[@id=31]", false],
+            ["//VariableDeclaration[@id=37]", 158n],
+            ["//VariableDeclaration[@id=44]", 85n],
+            ["//VariableDeclaration[@id=47]", "abcd"],
+            ["//VariableDeclaration[@id=53]", Buffer.from("abcd", "utf-8")],
+            ["//VariableDeclaration[@id=58]", 97n],
+            ["//VariableDeclaration[@id=64]", "abcd"],
+            ["//VariableDeclaration[@id=73]", 30841n],
+            ["//VariableDeclaration[@id=82]", 30841n],
+            ["//VariableDeclaration[@id=88]", 258n]
+        ]
+    ]
+];
+
+describe("Constant expression evaluator integration test", () => {
+    for (const [sample, mapping] of cases) {
+        describe(sample, () => {
+            let units: SourceUnit[];
+            let inference: InferType;
+
+            before(async () => {
+                const result = await compileSol(sample, "auto");
+
+                const data = result.data;
+                const compilerVersion = result.compilerVersion || LatestCompilerVersion;
+
+                const errors = detectCompileErrors(data);
+
+                expect(errors).toHaveLength(0);
+
+                const reader = new ASTReader();
+
+                units = reader.read(data);
+
+                expect(units.length).toBeGreaterThanOrEqual(1);
+
+                inference = new InferType(compilerVersion);
+            });
+
+            for (const [selector, expectation] of mapping) {
+                let found = false;
+
+                it(`${selector} -> ${expectation}`, () => {
+                    for (const unit of units) {
+                        const results = new XPath(unit).query(selector);
+
+                        if (results.length > 0) {
+                            const [expr] = results;
+
+                            assert(
+                                expr instanceof Expression || expr instanceof VariableDeclaration,
+                                `Expected selector result to be an {0} or {1} descendant, got {2} instead`,
+                                Expression.name,
+                                VariableDeclaration.name,
+                                expr
+                            );
+
+                            found = true;
+
+                            expect(evalConstantExpr(expr, inference)).toEqual(expectation);
+
+                            break;
+                        }
+                    }
+
+                    assert(
+                        found,
+                        `Selector "{0}" not found in source units of sample "{1}"`,
+                        selector,
+                        sample
+                    );
+                });
+            }
+        });
+    }
+});

--- a/test/samples/solidity/consts/consts.sol
+++ b/test/samples/solidity/consts/consts.sol
@@ -1,0 +1,22 @@
+import "./lib_a.sol";
+import "./lib_a.sol" as LibA;
+
+uint constant SOME_CONST = 100;
+uint constant SOME_OTHER = 15;
+uint constant SOME_ELSE = SOME_CONST + SOME_OTHER;
+uint constant C2 = SOME_ELSE + ANOTHER_CONST;
+uint constant C3 = SOME_ELSE + LibA.ANOTHER_CONST;
+uint constant C4 = -SOME_CONST;
+bool constant C5 = false;
+uint constant C6 = C5 ? SOME_ELSE : C3;
+uint constant C7 = LibA.ANOTHER_CONST + LibB.AND_ANOTHER_CONST;
+// uint constant C8 = LibA.ANOTHER_CONST + LibA.LibB.AND_ANOTHER_CONST;
+
+string constant FOO = "abcd";
+bytes constant BOO = bytes("abcd");
+bytes1 constant MOO = BOO[0];
+string constant WOO = string(BOO);
+
+uint16 constant U16S = uint16(bytes2("xy"));
+uint16 constant U16B = uint16(bytes2(hex"7879"));
+bytes2 constant B2U = bytes2(0x0102);

--- a/test/samples/solidity/consts/consts.sol
+++ b/test/samples/solidity/consts/consts.sol
@@ -20,3 +20,5 @@ string constant WOO = string(BOO);
 uint16 constant U16S = uint16(bytes2("xy"));
 uint16 constant U16B = uint16(bytes2(hex"7879"));
 bytes2 constant B2U = bytes2(0x0102);
+
+bytes4 constant NON_UTF8_SEQ = "\x75\x32\xea\xac";

--- a/test/samples/solidity/consts/lib_a.sol
+++ b/test/samples/solidity/consts/lib_a.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.7.5;
+
+import "./lib_b.sol" as LibB;
+
+uint constant ANOTHER_CONST = LibB.AND_ANOTHER_CONST + 1;

--- a/test/samples/solidity/consts/lib_b.sol
+++ b/test/samples/solidity/consts/lib_b.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.7.5;
+
+uint constant AND_ANOTHER_CONST = 42;

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -1309,6 +1309,18 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             0n
         ],
         [
+            "Edge-case <0.5.0: bytes1(1000)",
+            (factory: ASTNodeFactory) =>
+                factory.makeFunctionCall(
+                    "bytes1",
+                    FunctionCallKind.TypeConversion,
+                    factory.makeElementaryTypeNameExpression("type(bytes1)", "bytes1"),
+                    [factory.makeLiteral("int_const 1000", LiteralKind.Number, "", "1000")]
+                ),
+            true,
+            BigInt("0xe8")
+        ],
+        [
             'Identifier & IndexAccess (const A = "abcdef" (string), a[2])',
             (factory: ASTNodeFactory) => {
                 const v = factory.makeVariableDeclaration(
@@ -1363,6 +1375,34 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             },
             true,
             BigInt("0xcd")
+        ],
+        [
+            "Identifier & IndexAccess (const A = 0xab_cd_ef (bytes3), a[3])",
+            (factory: ASTNodeFactory) => {
+                const v = factory.makeVariableDeclaration(
+                    true,
+                    false,
+                    "A",
+                    0,
+                    true,
+                    DataLocation.Default,
+                    StateVariableVisibility.Public,
+                    Mutability.Constant,
+                    "bytes3",
+                    undefined,
+                    factory.makeElementaryTypeName("bytes3", "bytes3"),
+                    undefined,
+                    factory.makeLiteral("<missing>", LiteralKind.Number, "", "0xab_cd_ef")
+                );
+
+                return factory.makeIndexAccess(
+                    "string",
+                    factory.makeIdentifierFor(v),
+                    factory.makeLiteral("<missing>", LiteralKind.Number, "", "3")
+                );
+            },
+            true,
+            undefined
         ]
     ];
 

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -25,7 +25,7 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
             undefined
         ],
         [
-            "Literal (unknown)",
+            "Literal (invalid kind)",
             (factory: ASTNodeFactory) =>
                 factory.makeLiteral("<missing>", "unknown" as LiteralKind, "", "???"),
             true,
@@ -65,6 +65,13 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                 factory.makeLiteral("<missing>", LiteralKind.HexString, "888990", "xyz"),
             true,
             Buffer.from("888990", "hex")
+        ],
+        [
+            "Literal (invalid UTF-8 sequence edge case)",
+            (factory: ASTNodeFactory) =>
+                factory.makeLiteral("<missing>", LiteralKind.String, "7532eaac", null as any),
+            true,
+            Buffer.from("7532eaac", "hex")
         ],
         [
             "Literal (uint8)",

--- a/test/unit/types/eval_const.spec.ts
+++ b/test/unit/types/eval_const.spec.ts
@@ -62,9 +62,9 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
         [
             "Literal (hex string)",
             (factory: ASTNodeFactory) =>
-                factory.makeLiteral("<missing>", LiteralKind.HexString, "ffcc33", "abcdef"),
+                factory.makeLiteral("<missing>", LiteralKind.HexString, "888990", "xyz"),
             true,
-            BigInt("0xffcc33")
+            Buffer.from("888990", "hex")
         ],
         [
             "Literal (uint8)",
@@ -1300,6 +1300,62 @@ const cases: Array<[string, (factory: ASTNodeFactory) => Expression, boolean, Va
                 ),
             true,
             0n
+        ],
+        [
+            'Identifier & IndexAccess (const A = "abcdef" (string), a[2])',
+            (factory: ASTNodeFactory) => {
+                const v = factory.makeVariableDeclaration(
+                    true,
+                    false,
+                    "A",
+                    0,
+                    true,
+                    DataLocation.Default,
+                    StateVariableVisibility.Public,
+                    Mutability.Constant,
+                    "string",
+                    undefined,
+                    factory.makeElementaryTypeName("string", "string"),
+                    undefined,
+                    factory.makeLiteral("<missing>", LiteralKind.String, "", "abcdef")
+                );
+
+                return factory.makeIndexAccess(
+                    "string",
+                    factory.makeIdentifierFor(v),
+                    factory.makeLiteral("<missing>", LiteralKind.Number, "", "2")
+                );
+            },
+            true,
+            undefined
+        ],
+        [
+            "Identifier & IndexAccess (const A = 0xab_cd_ef (bytes3), a[1])",
+            (factory: ASTNodeFactory) => {
+                const v = factory.makeVariableDeclaration(
+                    true,
+                    false,
+                    "A",
+                    0,
+                    true,
+                    DataLocation.Default,
+                    StateVariableVisibility.Public,
+                    Mutability.Constant,
+                    "bytes3",
+                    undefined,
+                    factory.makeElementaryTypeName("bytes3", "bytes3"),
+                    undefined,
+                    factory.makeLiteral("<missing>", LiteralKind.Number, "", "0xab_cd_ef")
+                );
+
+                return factory.makeIndexAccess(
+                    "string",
+                    factory.makeIdentifierFor(v),
+                    factory.makeLiteral("<missing>", LiteralKind.Number, "", "1")
+                );
+            },
+            true,
+            BigInt("0xcd")
         ]
     ];
 


### PR DESCRIPTION
## Tasks
This PR resolves #224 and fixes #227.

## Changes
- [x] Tweak logic for better constant expression evaluation (`isConstant()`, `evalConstantExpr()`):
  - respect file-level constants;
  - support more node types (`MemberAccess`, `IndexAccess` `VariableDeclaration`);
  - support more cast operations (`string <-> bytes`, `string / bytes -> fixed bytes`, `uint <-> fixed bytes`);
- [x] Tweaked existing unit test to respect changes.
- [x] Introduced integration test to have an ability to check against real-world Solidity examples.

## Notes
- API changes:
  - `isConstant()` and `evalConstantExpr()` are now also accepting `VariableDeclaration` as an input node.
  - `Value` type now also includes `Buffer` (a **breaking** change).
- Due to breaking changes we would have to bump **major** version of the package.

Regards.