### PR TITLE
Fix precedence of equality operators for custom operators

### DIFF
--- a/src/compile/inference/file_level_definitions.pegjs
+++ b/src/compile/inference/file_level_definitions.pegjs
@@ -194,10 +194,10 @@ CustomizableOperator =
     / '%'
     / '=='
     / '!='
-    / '<'
     / '<='
-    / '>'
-    / '>=';
+    / '>='
+    / '<'
+    / '>';
 
 UsingEntry =
     name: (IdentifierPath) operator: (__ AS __ CustomizableOperator)? {

--- a/test/unit/compile/inference/file_level_definitions_parser.spec.ts
+++ b/test/unit/compile/inference/file_level_definitions_parser.spec.ts
@@ -552,7 +552,7 @@ is /*3*/ int24/*;*/;`,
     ],
     [
         "using-for custamizable operators",
-        `using {op.RedLib.toScore, op.RedLib.exp, op.addRed as +, op.mulRed as *, op.unsubRed as -} for Red global;`,
+        `using {op.RedLib.toScore, op.RedLib.exp, op.addRed as +, op.mulRed as *, op.unsubRed as -, op.lteRed as <=, op.gteRed as >=} for Red global;`,
         [
             {
                 kind: "usingForDirective",
@@ -572,6 +572,14 @@ is /*3*/ int24/*;*/;`,
                     {
                         operator: "-",
                         name: "op.unsubRed"
+                    },
+                    {
+                        operator: "<=",
+                        name: "op.lteRed"
+                    },
+                    {
+                        operator: ">=",
+                        name: "op.gteRed"
                     }
                 ]
             }


### PR DESCRIPTION
## Preface
This PR fixes #238

## Changes
- [x] Tweak order of equality operators of `CustomizableOperator` in file-level definitions parser.
- [x] Tweak related unit test to check for mentioned edge-cases.

Credits for the fix goes to @brianlai98.

Regards.