### PR TITLE
fix error when typeDescriptions missing

### DIFF
--- a/src/ast/modern/expression_processor.ts
+++ b/src/ast/modern/expression_processor.ts
@@ -10,7 +10,7 @@ export class ModernExpressionProcessor<T extends Expression> extends ModernNodeP
     ): ConstructorParameters<ExpressionConstructor<T>> {
         const [id, src] = super.process(reader, config, raw);
 
-        const typeString: string = raw.typeDescriptions.typeString;
+        const typeString: string = raw.typeDescriptions?.typeString;
 
         return [id, src, typeString, undefined, raw];
     }

--- a/src/ast/modern/type_name_processor.ts
+++ b/src/ast/modern/type_name_processor.ts
@@ -10,7 +10,7 @@ export class ModernTypeNameProcessor<T extends TypeName> extends ModernNodeProce
     ): ConstructorParameters<TypeNameConstructor<T>> {
         const [id, src] = super.process(reader, config, raw);
 
-        const typeString: string = raw.typeDescriptions.typeString;
+        const typeString: string = raw.typeDescriptions?.typeString;
 
         return [id, src, typeString, undefined, raw];
     }

--- a/src/ast/modern/variable_declaration_processor.ts
+++ b/src/ast/modern/variable_declaration_processor.ts
@@ -21,7 +21,7 @@ export class ModernVariableDeclarationProcessor extends ModernNodeProcessor<Vari
         const scope: number = raw.scope;
         const stateVariable: boolean = raw.stateVariable;
         const visibility: StateVariableVisibility = raw.visibility;
-        const typeString: string = raw.typeDescriptions.typeString;
+        const typeString: string = raw.typeDescriptions?.typeString;
         const nameLocation: string | undefined = raw.nameLocation;
 
         const storageLocation: DataLocation =


### PR DESCRIPTION
I'm working on an AST tool and it just happens to be convenient to omit unnecessary fields.
the `typeDescriptions` field isn't really necessary for the AST compilation using `sol-ast-compile` yet when it throws an error when it is missing.

