### PR TITLE
Handle `address payable` in imports preprocessing parser

### DIFF
--- a/src/compile/inference/file_level_definitions.pegjs
+++ b/src/compile/inference/file_level_definitions.pegjs
@@ -68,9 +68,10 @@ ImportDirective =
 
 // ==== Global Constants
 
-// global constants don't support reference types I think?
+// Global constants don't support reference types.
+// Only other multi-word case is "address payable".
 ConstantType =
-    Identifier (__ LBRACKET Number? RBRACKET)*  { return text(); }
+    (ADDRESS (__ PAYABLE)?) / (Identifier (__ LBRACKET Number? RBRACKET)*) { return text(); }
 
 Constant = ConstantType __ CONSTANT  __ name: Identifier __ EQUAL __ value: NonSemicolonSoup __  SEMICOLON {
     return { kind: FileLevelNodeKind.Constant, location: location(), name, value } as FLConstant;
@@ -324,6 +325,8 @@ LBRACKET = "["
 RBRACKET = "]"
 COMMA = ","
 EQUAL = "="
+ADDRESS = "address"
+PAYABLE = "payable"
 ABSTRACT = "abstract"
 CONTRACT = "contract"
 LIBRARY = "library"

--- a/test/unit/compile/inference/file_level_definitions_parser.spec.ts
+++ b/test/unit/compile/inference/file_level_definitions_parser.spec.ts
@@ -608,6 +608,29 @@ is /*3*/ int24/*;*/;`,
                 anonymous: true
             }
         ]
+    ],
+    [
+        "address payable",
+        `address payable constant MY_CONST = payable(0x0);
+        event MyEvent(address payable indexed addr);
+        error MyError(address payable addr);`,
+        [
+            {
+                kind: "constant",
+                name: "MY_CONST",
+                value: "payable(0x0)"
+            },
+            {
+                kind: "event",
+                name: "MyEvent",
+                args: "(address payable indexed addr)"
+            },
+            {
+                kind: "error",
+                name: "MyError",
+                args: "(address payable addr)"
+            }
+        ]
     ]
 ];
 


### PR DESCRIPTION
## Preface
This PR fixes #255.

## Changes
- [x] Handle `address payable` in file-level definition parser.
- [x] Introduce related test case.

## Notes
- Credits to @gas1cent and related team for finding and properly reporting the bug.

Regards.