### PR TITLE
Support for Solidity 0.8.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
             "version": "18.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "axios": "^1.6.7",
+                "axios": "^1.6.8",
                 "commander": "^12.0.0",
                 "decimal.js": "^10.4.3",
                 "findup-sync": "^5.0.0",
                 "fs-extra": "^11.2.0",
                 "jsel": "^1.1.6",
                 "semver": "^7.6.0",
-                "solc": "0.8.24",
+                "solc": "0.8.25",
                 "src-location": "^1.1.0",
                 "web3-eth-abi": "^4.2.0"
             },
@@ -26,11 +26,11 @@
             "devDependencies": {
                 "@types/fs-extra": "^11.0.4",
                 "@types/jest": "^29.5.12",
-                "@types/node": "^20.11.16",
-                "@types/semver": "^7.5.6",
-                "@typescript-eslint/eslint-plugin": "^6.21.0",
-                "@typescript-eslint/parser": "^6.21.0",
-                "eslint": "^8.56.0",
+                "@types/node": "^20.11.30",
+                "@types/semver": "^7.5.8",
+                "@typescript-eslint/eslint-plugin": "^7.3.1",
+                "@typescript-eslint/parser": "^7.3.1",
+                "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.1.3",
                 "expect": "^29.7.0",
@@ -40,8 +40,8 @@
                 "ts-jest": "^29.1.2",
                 "ts-node": "^10.9.2",
                 "ts-pegjs": "^3.1.0",
-                "typedoc": "^0.25.7",
-                "typescript": "^5.3.3"
+                "typedoc": "^0.25.12",
+                "typescript": "^5.4.3"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -806,22 +806,22 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -842,9 +842,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1576,18 +1576,18 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.11.16",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-            "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+            "version": "20.11.30",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+            "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
         },
         "node_modules/@types/semver": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -1612,16 +1612,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-            "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
+            "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/type-utils": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/type-utils": "7.3.1",
+                "@typescript-eslint/utils": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -1630,15 +1630,15 @@
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-                "eslint": "^7.0.0 || ^8.0.0"
+                "@typescript-eslint/parser": "^7.0.0",
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -1647,26 +1647,26 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
+            "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/typescript-estree": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -1675,16 +1675,16 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
+            "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1692,25 +1692,25 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
+            "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
+                "@typescript-eslint/typescript-estree": "7.3.1",
+                "@typescript-eslint/utils": "7.3.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -1719,12 +1719,12 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
+            "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
             "dev": true,
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1732,13 +1732,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
+            "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1747,7 +1747,7 @@
                 "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1784,41 +1784,41 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
+            "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/typescript-estree": "7.3.1",
                 "semver": "^7.5.4"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
+            "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/types": "7.3.1",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || >=20.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1999,11 +1999,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dependencies": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -2589,16 +2589,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.56.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -2998,9 +2998,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -5178,9 +5178,9 @@
             }
         },
         "node_modules/solc": {
-            "version": "0.8.24",
-            "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.24.tgz",
-            "integrity": "sha512-G5yUqjTUPc8Np74sCFwfsevhBPlUifUOfhYrgyu6CmYlC6feSw0YS6eZW47XDT23k3JYdKx5nJ+Q7whCEmNcoA==",
+            "version": "0.8.25",
+            "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.25.tgz",
+            "integrity": "sha512-7P0TF8gPeudl1Ko3RGkyY6XVCxe2SdD/qQhtns1vl3yAbK/PDifKDLHGtx1t7mX3LgR7ojV7Fg/Kc6Q9D2T8UQ==",
             "dependencies": {
                 "command-exists": "^1.2.8",
                 "commander": "^8.1.0",
@@ -5440,12 +5440,12 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-            "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
             "dev": true,
             "engines": {
-                "node": ">=16.13.0"
+                "node": ">=16"
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
@@ -5607,9 +5607,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.25.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-            "integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+            "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
@@ -5624,7 +5624,7 @@
                 "node": ">= 16"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
@@ -5652,9 +5652,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6528,19 +6528,19 @@
             }
         },
         "@eslint/js": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             }
         },
@@ -6551,9 +6551,9 @@
             "dev": true
         },
         "@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -7158,18 +7158,18 @@
             }
         },
         "@types/node": {
-            "version": "20.11.16",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-            "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+            "version": "20.11.30",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+            "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
             "requires": {
                 "undici-types": "~5.26.4"
             }
         },
         "@types/semver": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -7194,16 +7194,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-            "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
+            "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/type-utils": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/type-utils": "7.3.1",
+                "@typescript-eslint/utils": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -7213,54 +7213,54 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
+            "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/typescript-estree": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
+            "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
+            "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
+                "@typescript-eslint/typescript-estree": "7.3.1",
+                "@typescript-eslint/utils": "7.3.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
+            "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
+            "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/visitor-keys": "7.3.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -7290,27 +7290,27 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
+            "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.3.1",
+                "@typescript-eslint/types": "7.3.1",
+                "@typescript-eslint/typescript-estree": "7.3.1",
                 "semver": "^7.5.4"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
+            "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/types": "7.3.1",
                 "eslint-visitor-keys": "^3.4.1"
             }
         },
@@ -7434,11 +7434,11 @@
             "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
         },
         "axios": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "requires": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -7856,16 +7856,16 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.56.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -8157,9 +8157,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "for-each": {
             "version": "0.3.3",
@@ -9728,9 +9728,9 @@
             "dev": true
         },
         "solc": {
-            "version": "0.8.24",
-            "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.24.tgz",
-            "integrity": "sha512-G5yUqjTUPc8Np74sCFwfsevhBPlUifUOfhYrgyu6CmYlC6feSw0YS6eZW47XDT23k3JYdKx5nJ+Q7whCEmNcoA==",
+            "version": "0.8.25",
+            "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.25.tgz",
+            "integrity": "sha512-7P0TF8gPeudl1Ko3RGkyY6XVCxe2SdD/qQhtns1vl3yAbK/PDifKDLHGtx1t7mX3LgR7ojV7Fg/Kc6Q9D2T8UQ==",
             "requires": {
                 "command-exists": "^1.2.8",
                 "commander": "^8.1.0",
@@ -9922,9 +9922,9 @@
             }
         },
         "ts-api-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-            "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
             "dev": true,
             "requires": {}
         },
@@ -10016,9 +10016,9 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.25.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-            "integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+            "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
             "dev": true,
             "requires": {
                 "lunr": "^2.3.9",
@@ -10048,9 +10048,9 @@
             }
         },
         "typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg=="
         },
         "undici-types": {
             "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -27,25 +27,25 @@
         "prepare": "npm run build"
     },
     "dependencies": {
-        "axios": "^1.6.7",
+        "axios": "^1.6.8",
         "commander": "^12.0.0",
         "decimal.js": "^10.4.3",
         "findup-sync": "^5.0.0",
         "fs-extra": "^11.2.0",
         "jsel": "^1.1.6",
         "semver": "^7.6.0",
-        "solc": "0.8.24",
+        "solc": "0.8.25",
         "src-location": "^1.1.0",
         "web3-eth-abi": "^4.2.0"
     },
     "devDependencies": {
         "@types/fs-extra": "^11.0.4",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.16",
-        "@types/semver": "^7.5.6",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "eslint": "^8.56.0",
+        "@types/node": "^20.11.30",
+        "@types/semver": "^7.5.8",
+        "@typescript-eslint/eslint-plugin": "^7.3.1",
+        "@typescript-eslint/parser": "^7.3.1",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "expect": "^29.7.0",
@@ -55,8 +55,8 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "ts-pegjs": "^3.1.0",
-        "typedoc": "^0.25.7",
-        "typescript": "^5.3.3"
+        "typedoc": "^0.25.12",
+        "typescript": "^5.4.3"
     },
     "homepage": "https://consensys.github.io/solc-typed-ast",
     "bugs": "https://github.com/ConsenSys/solc-typed-ast/issues",

--- a/src/compile/constants.ts
+++ b/src/compile/constants.ts
@@ -79,7 +79,8 @@ export const CompilerVersions08 = [
     "0.8.21",
     "0.8.22",
     "0.8.23",
-    "0.8.24"
+    "0.8.24",
+    "0.8.25"
 ];
 
 export const CompilerSeries = [

--- a/test/samples/solidity/latest_08.nodes.native.txt
+++ b/test/samples/solidity/latest_08.nodes.native.txt
@@ -4481,7 +4481,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "3432:2:0", nodeType: "YulBlock", src: "3432:2:0", statements: Array(0) }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1123
                     <getter> children: Array(0)
@@ -4936,7 +4936,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "3858:249:0", nodeType: "YulBlock", src: "3858:249:0", statements: Array(7) [ Object { nativeSrc: "3872:15:0", nodeType: "YulVariableDeclaration", src: "3872:15:0", value: Object { hexValue: "74657374", kind: "string", nativeSrc: "3881:6:0", nodeType: "YulLiteral", src: "3881:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nativeSrc: "3876:1:0", nodeType: "YulTypedName", src: "3876:1:0", type: "" } ] }, Object { nativeSrc: "3900:54:0", nodeType: "YulVariableDeclaration", src: "3900:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nativeSrc: "3909:45:0", nodeType: "YulLiteral", src: "3909:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nativeSrc: "3904:1:0", nodeType: "YulTypedName", src: "3904:1:0", type: "" } ] }, Object { nativeSrc: "3967:23:0", nodeType: "YulVariableDeclaration", src: "3967:23:0", value: Object { hexValue: "1234abcd", kind: "string", nativeSrc: "3976:14:0", nodeType: "YulLiteral", src: "3976:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nativeSrc: "3971:1:0", nodeType: "YulTypedName", src: "3971:1:0", type: "" } ] }, Object { nativeSrc: "4003:15:0", nodeType: "YulVariableDeclaration", src: "4003:15:0", value: Object { hexValue: "c3", kind: "string", nativeSrc: "4012:6:0", nodeType: "YulLiteral", src: "4012:6:0", type: "" }, variables: Array(1) [ Object { name: "z", nativeSrc: "4007:1:0", nodeType: "YulTypedName", src: "4007:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nativeSrc: "4039:1:0", nodeType: "YulLiteral", src: "4039:1:0", type: "", value: "0" }, Object { name: "x", nativeSrc: "4042:1:0", nodeType: "YulIdentifier", src: "4042:1:0" } ], functionName: Object { name: "sstore", nativeSrc: "4032:6:0", nodeType: "YulIdentifier", src: "4032:6:0" }, nativeSrc: "4032:12:0", nodeType: "YulFunctionCall", src: "4032:12:0" }, nativeSrc: "4032:12:0", nodeType: "YulExpressionStatement", src: "4032:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nativeSrc: "4064:1:0", nodeType: "YulLiteral", src: "4064:1:0", type: "", value: "1" }, Object { name: "y", nativeSrc: "4067:1:0", nodeType: "YulIdentifier", src: "4067:1:0" } ], functionName: Object { name: "sstore", nativeSrc: "4057:6:0", nodeType: "YulIdentifier", src: "4057:6:0" }, nativeSrc: "4057:12:0", nodeType: "YulFunctionCall", src: "4057:12:0" }, nativeSrc: "4057:12:0", nodeType: "YulExpressionStatement", src: "4057:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nativeSrc: "4087:9:0", nodeType: "YulLiteral", src: "4087:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nativeSrc: "4083:3:0", nodeType: "YulIdentifier", src: "4083:3:0" }, nativeSrc: "4083:14:0", nodeType: "YulFunctionCall", src: "4083:14:0" }, nativeSrc: "4083:14:0", nodeType: "YulExpressionStatement", src: "4083:14:0" } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1143
                     <getter> children: Array(0)
@@ -6282,7 +6282,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "4909:40:0", nodeType: "YulBlock", src: "4909:40:0", statements: Array(1) [ Object { nativeSrc: "4923:16:0", nodeType: "YulAssignment", src: "4923:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nativeSrc: "4930:7:0", nodeType: "YulIdentifier", src: "4930:7:0" }, nativeSrc: "4930:9:0", nodeType: "YulFunctionCall", src: "4930:9:0" }, variableNames: Array(1) [ Object { name: "ret", nativeSrc: "4923:3:0", nodeType: "YulIdentifier", src: "4923:3:0" } ] } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1209
                     <getter> children: Array(0)
@@ -9487,7 +9487,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "6259:153:0", nodeType: "YulBlock", src: "6259:153:0", statements: Array(4) [ Object { nativeSrc: "6273:19:0", nodeType: "YulVariableDeclaration", src: "6273:19:0", value: Object { name: "fp.address", nativeSrc: "6282:10:0", nodeType: "YulIdentifier", src: "6282:10:0" }, variables: Array(1) [ Object { name: "o", nativeSrc: "6277:1:0", nodeType: "YulTypedName", src: "6277:1:0", type: "" } ] }, Object { nativeSrc: "6305:20:0", nodeType: "YulVariableDeclaration", src: "6305:20:0", value: Object { name: "fp.selector", nativeSrc: "6314:11:0", nodeType: "YulIdentifier", src: "6314:11:0" }, variables: Array(1) [ Object { name: "s", nativeSrc: "6309:1:0", nodeType: "YulTypedName", src: "6309:1:0", type: "" } ] }, Object { nativeSrc: "6339:24:0", nodeType: "YulAssignment", src: "6339:24:0", value: Object { name: "newAddress", nativeSrc: "6353:10:0", nodeType: "YulIdentifier", src: "6353:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nativeSrc: "6339:10:0", nodeType: "YulIdentifier", src: "6339:10:0" } ] }, Object { nativeSrc: "6376:26:0", nodeType: "YulAssignment", src: "6376:26:0", value: Object { name: "newSelector", nativeSrc: "6391:11:0", nodeType: "YulIdentifier", src: "6391:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nativeSrc: "6376:11:0", nodeType: "YulIdentifier", src: "6376:11:0" } ] } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1368
                     <getter> children: Array(0)
@@ -14052,7 +14052,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "8340:2:0", nodeType: "YulBlock", src: "8340:2:0", statements: Array(0) }
                     flags: Array(1) [ "memory-safe" ]
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1588
                     <getter> children: Array(0)
@@ -14072,7 +14072,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "8403:2:0", nodeType: "YulBlock", src: "8403:2:0", statements: Array(0) }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1588
                     <getter> children: Array(0)

--- a/test/samples/solidity/latest_08.nodes.wasm.txt
+++ b/test/samples/solidity/latest_08.nodes.wasm.txt
@@ -4481,7 +4481,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "3432:2:0", nodeType: "YulBlock", src: "3432:2:0", statements: Array(0) }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1123
                     <getter> children: Array(0)
@@ -4936,7 +4936,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "3858:249:0", nodeType: "YulBlock", src: "3858:249:0", statements: Array(7) [ Object { nativeSrc: "3872:15:0", nodeType: "YulVariableDeclaration", src: "3872:15:0", value: Object { hexValue: "74657374", kind: "string", nativeSrc: "3881:6:0", nodeType: "YulLiteral", src: "3881:6:0", type: "", value: "test" }, variables: Array(1) [ Object { name: "a", nativeSrc: "3876:1:0", nodeType: "YulTypedName", src: "3876:1:0", type: "" } ] }, Object { nativeSrc: "3900:54:0", nodeType: "YulVariableDeclaration", src: "3900:54:0", value: Object { hexValue: "112233445566778899aabbccddeeff6677889900", kind: "string", nativeSrc: "3909:45:0", nodeType: "YulLiteral", src: "3909:45:0", type: "" }, variables: Array(1) [ Object { name: "x", nativeSrc: "3904:1:0", nodeType: "YulTypedName", src: "3904:1:0", type: "" } ] }, Object { nativeSrc: "3967:23:0", nodeType: "YulVariableDeclaration", src: "3967:23:0", value: Object { hexValue: "1234abcd", kind: "string", nativeSrc: "3976:14:0", nodeType: "YulLiteral", src: "3976:14:0", type: "" }, variables: Array(1) [ Object { name: "y", nativeSrc: "3971:1:0", nodeType: "YulTypedName", src: "3971:1:0", type: "" } ] }, Object { nativeSrc: "4003:15:0", nodeType: "YulVariableDeclaration", src: "4003:15:0", value: Object { hexValue: "c3", kind: "string", nativeSrc: "4012:6:0", nodeType: "YulLiteral", src: "4012:6:0", type: "" }, variables: Array(1) [ Object { name: "z", nativeSrc: "4007:1:0", nodeType: "YulTypedName", src: "4007:1:0", type: "" } ] }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nativeSrc: "4039:1:0", nodeType: "YulLiteral", src: "4039:1:0", type: "", value: "0" }, Object { name: "x", nativeSrc: "4042:1:0", nodeType: "YulIdentifier", src: "4042:1:0" } ], functionName: Object { name: "sstore", nativeSrc: "4032:6:0", nodeType: "YulIdentifier", src: "4032:6:0" }, nativeSrc: "4032:12:0", nodeType: "YulFunctionCall", src: "4032:12:0" }, nativeSrc: "4032:12:0", nodeType: "YulExpressionStatement", src: "4032:12:0" }, Object { expression: Object { arguments: Array(2) [ Object { kind: "number", nativeSrc: "4064:1:0", nodeType: "YulLiteral", src: "4064:1:0", type: "", value: "1" }, Object { name: "y", nativeSrc: "4067:1:0", nodeType: "YulIdentifier", src: "4067:1:0" } ], functionName: Object { name: "sstore", nativeSrc: "4057:6:0", nodeType: "YulIdentifier", src: "4057:6:0" }, nativeSrc: "4057:12:0", nodeType: "YulFunctionCall", src: "4057:12:0" }, nativeSrc: "4057:12:0", nodeType: "YulExpressionStatement", src: "4057:12:0" }, Object { expression: Object { arguments: Array(1) [ Object { hexValue: "2233", kind: "string", nativeSrc: "4087:9:0", nodeType: "YulLiteral", src: "4087:9:0", type: "", value: "\"3" } ], functionName: Object { name: "pop", nativeSrc: "4083:3:0", nodeType: "YulIdentifier", src: "4083:3:0" }, nativeSrc: "4083:14:0", nodeType: "YulFunctionCall", src: "4083:14:0" }, nativeSrc: "4083:14:0", nodeType: "YulExpressionStatement", src: "4083:14:0" } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1143
                     <getter> children: Array(0)
@@ -6282,7 +6282,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "4909:40:0", nodeType: "YulBlock", src: "4909:40:0", statements: Array(1) [ Object { nativeSrc: "4923:16:0", nodeType: "YulAssignment", src: "4923:16:0", value: Object { arguments: Array(0), functionName: Object { name: "basefee", nativeSrc: "4930:7:0", nodeType: "YulIdentifier", src: "4930:7:0" }, nativeSrc: "4930:9:0", nodeType: "YulFunctionCall", src: "4930:9:0" }, variableNames: Array(1) [ Object { name: "ret", nativeSrc: "4923:3:0", nodeType: "YulIdentifier", src: "4923:3:0" } ] } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1209
                     <getter> children: Array(0)
@@ -9487,7 +9487,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "6259:153:0", nodeType: "YulBlock", src: "6259:153:0", statements: Array(4) [ Object { nativeSrc: "6273:19:0", nodeType: "YulVariableDeclaration", src: "6273:19:0", value: Object { name: "fp.address", nativeSrc: "6282:10:0", nodeType: "YulIdentifier", src: "6282:10:0" }, variables: Array(1) [ Object { name: "o", nativeSrc: "6277:1:0", nodeType: "YulTypedName", src: "6277:1:0", type: "" } ] }, Object { nativeSrc: "6305:20:0", nodeType: "YulVariableDeclaration", src: "6305:20:0", value: Object { name: "fp.selector", nativeSrc: "6314:11:0", nodeType: "YulIdentifier", src: "6314:11:0" }, variables: Array(1) [ Object { name: "s", nativeSrc: "6309:1:0", nodeType: "YulTypedName", src: "6309:1:0", type: "" } ] }, Object { nativeSrc: "6339:24:0", nodeType: "YulAssignment", src: "6339:24:0", value: Object { name: "newAddress", nativeSrc: "6353:10:0", nodeType: "YulIdentifier", src: "6353:10:0" }, variableNames: Array(1) [ Object { name: "fp.address", nativeSrc: "6339:10:0", nodeType: "YulIdentifier", src: "6339:10:0" } ] }, Object { nativeSrc: "6376:26:0", nodeType: "YulAssignment", src: "6376:26:0", value: Object { name: "newSelector", nativeSrc: "6391:11:0", nodeType: "YulIdentifier", src: "6391:11:0" }, variableNames: Array(1) [ Object { name: "fp.selector", nativeSrc: "6376:11:0", nodeType: "YulIdentifier", src: "6376:11:0" } ] } ] }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1368
                     <getter> children: Array(0)
@@ -14052,7 +14052,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "8340:2:0", nodeType: "YulBlock", src: "8340:2:0", statements: Array(0) }
                     flags: Array(1) [ "memory-safe" ]
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1588
                     <getter> children: Array(0)
@@ -14072,7 +14072,7 @@ SourceUnit #1717
                     operations: undefined
                     yul: Object { nativeSrc: "8403:2:0", nodeType: "YulBlock", src: "8403:2:0", statements: Array(0) }
                     flags: undefined
-                    evmVersion: "shanghai"
+                    evmVersion: "cancun"
                     context: ASTContext #1000
                     parent: Block #1588
                     <getter> children: Array(0)


### PR DESCRIPTION
## Changes
- [x] Update dependencies.
- [x] Add support for Solidity 0.8.25 on compiler-level (there are no related changes in AST).
- [x] Update test snapshots (as EVM version `cancun` is default now).

## Related links
- [Solidity 0.8.25 release notes](https://github.com/ethereum/solidity/releases/tag/v0.8.25)
- [Solidity 0.8.25 release blog post](https://soliditylang.org/blog/2024/03/14/solidity-0.8.25-release-announcement)
- [Diff of Solidity 0.8.24 and Solidity 0.8.25](https://github.com/ethereum/solidity/compare/v0.8.24...v0.8.25)

Regards.