### PR TITLE
Add support for custom compilers in solc-typed-ast versions

### DIFF
--- a/src/bin/compile.ts
+++ b/src/bin/compile.ts
@@ -26,6 +26,7 @@ import {
     FunctionDefinition,
     FunctionVisibility,
     InferType,
+    isCustom,
     isExact,
     LatestCompilerVersion,
     PathOptions,
@@ -193,7 +194,7 @@ function error(message: string): never {
 
     const compilerVersion: string = options.compilerVersion;
 
-    if (!(compilerVersion === "auto" || isExact(compilerVersion))) {
+    if (!(compilerVersion === "auto" || isExact(compilerVersion) || isCustom(compilerVersion))) {
         const message = [
             `Invalid compiler version "${compilerVersion}".`,
             'Possible values: "auto" or exact version string.'

--- a/src/compile/version.ts
+++ b/src/compile/version.ts
@@ -1,4 +1,5 @@
 import semver from "semver";
+import { assert } from "../misc";
 
 const rx = {
     comments: /\/\*[\s\S]*?\*\/|\/\/.*$/gm,
@@ -9,7 +10,8 @@ const rx = {
     spaceDash: /( -)/g,
 
     fixed: /^=?\d+\.\d+\.\d+$/,
-    exact: /^\d+.\d+.\d+$/
+    exact: /^\d+.\d+.\d+$/,
+    custom: /^custom:(.*)/
 };
 
 export function isFixed(version: string): boolean {
@@ -22,6 +24,17 @@ export function isFloating(version: string): boolean {
 
 export function isExact(version: string): boolean {
     return rx.exact.test(version);
+}
+
+export function isCustom(version: string): boolean {
+    return rx.custom.test(version);
+}
+
+export function getCustomPath(version: string): string {
+    const m = version.match(rx.custom);
+    assert(m !== null, `Bad custom version {0}`, version);
+
+    return m[1];
 }
 
 export function getCompilerVersionsBySpecifiers(

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -2284,7 +2284,9 @@ export class InferType {
                 return new UserDefinedType(getFQDefName(def), def);
             }
 
-            throw new Error(`NYI converting user-defined AST type ${def.print()} to TypeNode`);
+            throw new Error(
+                `NYI converting user-defined AST type ${def != undefined ? def.print() : undefined} to TypeNode`
+            );
         }
 
         if (node instanceof FunctionTypeName) {


### PR DESCRIPTION
This pr adds support for custom compiler paths in solc-typed-ast. To use a custom compiler you can specify a verison such as "custom:/<path-to-compiler>":

`sol-ast-compile --compiler-kind native --compiler-version 'custom:/path/to/solc' file.sol`