### PR TITLE
Added suport structured doc comments on enum values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
             "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.13",
@@ -1627,6 +1628,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
             "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -1698,6 +1700,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
             "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.3.1",
                 "@typescript-eslint/types": "7.3.1",
@@ -1897,6 +1900,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2217,6 +2221,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -2640,6 +2645,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2695,6 +2701,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -3699,6 +3706,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -4905,6 +4913,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
             "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -5561,6 +5570,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -5708,6 +5718,7 @@
             "version": "5.4.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
             "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6135,6 +6146,7 @@
             "version": "3.22.4",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
             "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -6236,6 +6248,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
             "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.13",
@@ -7378,6 +7391,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
             "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "undici-types": "~5.26.4"
             }
@@ -7433,6 +7447,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
             "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "7.3.1",
                 "@typescript-eslint/types": "7.3.1",
@@ -7546,7 +7561,8 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -7779,6 +7795,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
             "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -8076,6 +8093,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8122,6 +8140,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
+            "peer": true,
             "requires": {}
         },
         "eslint-plugin-prettier": {
@@ -8819,6 +8838,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -9731,7 +9751,8 @@
             "version": "3.2.5",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
             "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "prettier-linter-helpers": {
             "version": "1.0.0",
@@ -10174,6 +10195,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -10267,7 +10289,8 @@
         "typescript": {
             "version": "5.4.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg=="
+            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+            "peer": true
         },
         "undici-types": {
             "version": "5.26.5",
@@ -10569,7 +10592,8 @@
         "zod": {
             "version": "3.22.4",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
+            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "peer": true
         }
     }
 }

--- a/src/ast/implementation/declaration/enum_value.ts
+++ b/src/ast/implementation/declaration/enum_value.ts
@@ -1,6 +1,17 @@
-import { ASTNode } from "../../ast_node";
+import { ASTNodeWithChildren } from "../../ast_node";
+import { getDocumentation, setDocumentation, WithPrecedingDocs } from "../../documentation";
+import { StructuredDocumentation } from "../meta";
 
-export class EnumValue extends ASTNode {
+export class EnumValue
+    extends ASTNodeWithChildren<StructuredDocumentation>
+    implements WithPrecedingDocs
+{
+    /**
+     * Storage field for string documentation.
+     * This field is used when documentation is set as a string.
+     */
+    docString?: string;
+
     /**
      * Member value
      */
@@ -11,10 +22,32 @@ export class EnumValue extends ASTNode {
      */
     nameLocation?: string;
 
-    constructor(id: number, src: string, name: string, nameLocation?: string, raw?: any) {
+    constructor(
+        id: number,
+        src: string,
+        name: string,
+        documentation?: string | StructuredDocumentation,
+        nameLocation?: string,
+        raw?: any
+    ) {
         super(id, src, raw);
 
         this.name = name;
+        this.documentation = documentation;
         this.nameLocation = nameLocation;
+    }
+
+    /**
+     * Optional documentation appearing above the enum value:
+     * - Is `undefined` when not specified.
+     * - Is type of `string` when specified and compiler version is older than `0.8.30`.
+     * - Is instance of `StructuredDocumentation` when specified and compiler version is `0.8.30` or newer.
+     */
+    get documentation(): string | StructuredDocumentation | undefined {
+        return getDocumentation(this);
+    }
+
+    set documentation(value: string | StructuredDocumentation | undefined) {
+        setDocumentation(this, value);
     }
 }

--- a/src/ast/legacy/enum_value_processor.ts
+++ b/src/ast/legacy/enum_value_processor.ts
@@ -13,6 +13,6 @@ export class LegacyEnumValueProcessor extends LegacyNodeProcessor<EnumValue> {
 
         const name: string = attributes.name;
 
-        return [id, src, name, undefined, raw];
+        return [id, src, name, undefined,  undefined, raw];
     }
 }

--- a/src/ast/modern/enum_value_processor.ts
+++ b/src/ast/modern/enum_value_processor.ts
@@ -1,6 +1,7 @@
 import { ASTReader, ASTReaderConfiguration } from "../ast_reader";
 import { EnumValue } from "../implementation/declaration/enum_value";
 import { ModernNodeProcessor } from "./node_processor";
+import { StructuredDocumentation } from "../implementation/meta";
 
 export class ModernEnumValueProcessor extends ModernNodeProcessor<EnumValue> {
     process(
@@ -12,7 +13,14 @@ export class ModernEnumValueProcessor extends ModernNodeProcessor<EnumValue> {
 
         const name: string = raw.name;
         const nameLocation: string | undefined = raw.nameLocation;
+        let documentation: string | StructuredDocumentation | undefined;
 
-        return [id, src, name, nameLocation, raw];
+        if (raw.documentation) {
+            documentation =
+                typeof raw.documentation === "string"
+                    ? raw.documentation
+                    : reader.convert(raw.documentation, config);
+        }
+        return [id, src, name, documentation, nameLocation, raw];
     }
 }

--- a/src/ast/postprocessing/structured_documentation_reconstruction.ts
+++ b/src/ast/postprocessing/structured_documentation_reconstruction.ts
@@ -5,7 +5,7 @@ import { RawComment, parseComments } from "../comments";
 import { RawCommentKind } from "../constants";
 import {
     ContractDefinition,
-    EnumDefinition,
+    EnumDefinition, EnumValue,
     ErrorDefinition,
     EventDefinition,
     FunctionDefinition,
@@ -133,6 +133,7 @@ type SupportedNode =
     | ErrorDefinition
     | EventDefinition
     | EnumDefinition
+    | EnumValue
     | StructDefinition
     | ModifierDefinition
     | Statement
@@ -205,6 +206,7 @@ export class StructuredDocumentationReconstructingPostprocessor
             node instanceof FunctionDefinition ||
             node instanceof ContractDefinition ||
             node instanceof EnumDefinition ||
+            node instanceof EnumValue ||
             node instanceof StructDefinition ||
             node instanceof ErrorDefinition ||
             node instanceof EventDefinition ||

--- a/src/compile/constants.ts
+++ b/src/compile/constants.ts
@@ -84,7 +84,8 @@ export const CompilerVersions08 = [
     "0.8.26",
     "0.8.27",
     "0.8.28",
-    "0.8.29"
+    "0.8.29",
+    "0.8.30"
 ];
 
 export const CompilerSeries = [

--- a/test/integration/compile/latest_08.spec.ts
+++ b/test/integration/compile/latest_08.spec.ts
@@ -30,7 +30,7 @@ const encounters = new Map<string, number>([
     ["PragmaDirective", 2],
     ["ImportDirective", 1],
     ["StructDefinition", 1],
-    ["StructuredDocumentation", 6],
+    ["StructuredDocumentation", 12],
     ["VariableDeclaration", 86],
     ["ElementaryTypeName", 70],
     ["EnumDefinition", 2],
@@ -116,15 +116,11 @@ for (const compilerKind of PossibleCompilerKinds) {
 
             const sourceUnit = sourceUnits[0];
 
-            // Uncomment following lines to get the current state of unit:
-            // console.log(sourceUnit.print());
-            // console.log(sourceUnit.getChildren().length);
-
-            expect(sourceUnit.id).toEqual(888);
-            expect(sourceUnit.src).toEqual("0:10283:0");
+            expect(sourceUnit.id).toEqual(894);
+            expect(sourceUnit.src).toEqual("0:10563:0");
             expect(sourceUnit.absolutePath).toEqual(mainSample);
             expect(sourceUnit.children.length).toEqual(41);
-            expect(sourceUnit.getChildren().length).toEqual(877);
+            expect(sourceUnit.getChildren().length).toEqual(883);
         });
 
         it(`Validate parsed output (${astKind})`, () => {
@@ -132,13 +128,6 @@ for (const compilerKind of PossibleCompilerKinds) {
             const sourceUnitImprint = createImprint(sourceUnit);
 
             expect(sourceUnitImprint.ASTNode).toBeUndefined();
-
-            // Uncomment following lines to get the current unit snapshot data:
-            // let s = "";
-            // for (const [type, nodes] of Object.entries(sourceUnitImprint)) {
-            //    s += `["${type}", ${nodes.length}],\n`;
-            // }
-            // console.log(s);
 
             for (const [type, count] of encounters.entries()) {
                 expect(sourceUnitImprint[type]).toBeDefined();

--- a/test/integration/sol-ast-compile/xpath/enum_value_doc_recovery.spec.ts
+++ b/test/integration/sol-ast-compile/xpath/enum_value_doc_recovery.spec.ts
@@ -1,0 +1,53 @@
+import expect from "expect";
+import { PossibleCompilerKinds } from "../../../../src";
+import { SolAstCompileCommand, SolAstCompileExec } from "../common";
+
+const sample = "test/samples/solidity/enum_value_docs.sol";
+
+for (const kind of PossibleCompilerKinds) {
+    const selector = '//EnumValue/StructuredDocumentation/@*[name()="src" or name()="text"]';
+    const args = [
+        sample,
+        "--compiler-kind",
+        kind,
+        "--compiler-version",
+        "0.8.30",
+        "--xpath",
+        selector
+    ];
+
+    const command = SolAstCompileCommand(...args);
+
+    describe(command, () => {
+        let exitCode: number | null;
+        let outData: string;
+        let errData: string;
+
+        beforeAll(() => {
+            const result = SolAstCompileExec(...args);
+
+            outData = result.stdout;
+            errData = result.stderr;
+            exitCode = result.status;
+        });
+
+        it("Exit code is valid", () => {
+            expect(exitCode).toEqual(0);
+        });
+
+        it("STDERR is empty", () => {
+            expect(errData).toEqual("");
+        });
+
+        it("STDOUT contains enum value documentation", () => {
+            // Check for documentation text
+            expect(outData).toContain("@notice A");
+            expect(outData).toContain("@dev B");
+            expect(outData).toContain("@notice Active");
+            expect(outData).toContain("@notice Inactive");
+            expect(outData).toContain("Read permission");
+            expect(outData).toContain("Write permission");
+            expect(outData).toContain("Admin permission");
+        });
+    });
+}

--- a/test/samples/solidity/enum_value_docs.sol
+++ b/test/samples/solidity/enum_value_docs.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.8.30;
+
+/**
+ * Enum
+ * Doc
+ */
+enum EnumABC {
+    /**
+     * @notice A
+     */
+    A,
+    /**
+     * @dev B
+     */
+    B,
+    C
+
+    /**
+     * Enum
+     *  Dangling
+     *   Doc
+     */
+}
+
+contract Test {
+    enum Status {
+        /// @notice Active
+        Active,
+        /// @notice Inactive
+        Inactive
+    }
+
+    /// @notice Permission levels
+    enum Permission {
+        /// Read permission
+        Read,
+        /// Write permission
+        Write,
+        /// Admin permission
+        Admin
+    }
+}

--- a/test/samples/solidity/latest_08.sol
+++ b/test/samples/solidity/latest_08.sol
@@ -22,7 +22,18 @@ struct Some {
  * Doc
  */
 enum EnumABC {
-    A, B, C
+    /**
+     * @notice First value
+     */
+    A,
+    /**
+     * @dev Second value
+     */
+    B,
+    /**
+     * @notice Third value
+     */
+    C
 
     /**
      * Enum
@@ -88,7 +99,18 @@ contract Features082 {
     event Ev(uint a);
 
     enum EnumXYZ {
-        X, Y, Z
+        /**
+         * X value
+         */
+        X,
+        /**
+         * Y value
+         */
+        Y,
+        /**
+         * Z value
+         */
+        Z
     }
 
     modifier modStructDocs() {


### PR DESCRIPTION
The only change in solc 0.8.30 affecting the AST is the support of structureed doc comments on enum values. This PR adds support for this, so it should also enable support for solc 0.8.30.

N.B. I am not very familiar with Typescript at all, so this PR was heavily aided by AI. I am mostly concerned that I didn't generate enough test coverage